### PR TITLE
Add GitHub Actions CI for iOS and macOS Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,24 +43,11 @@ jobs:
 
     - name: Setup iOS Simulator
       run: |
-        # Get runtime identifier
-        RUNTIME_ID=$(xcrun simctl list runtimes iOS -j | jq -r '.runtimes[0].identifier')
-        echo "Using runtime: $RUNTIME_ID"
-        
-        # Create and boot simulator
-        DEVICE_ID=$(xcrun simctl create "iPhone 16 Pro" com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro $RUNTIME_ID)
-        xcrun simctl boot $DEVICE_ID
-        
-        # Wait for simulator to be ready
-        xcrun simctl list devices | grep "iPhone 16 Pro"
-        
-        echo "SIMULATOR_DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
-
     - name: Build and Test iOS
       run: |
         xcodebuild test \
           -scheme ColorKit \
-          -destination "id=$SIMULATOR_DEVICE_ID" \
+          -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
           -parallel-testing-enabled YES \
           -parallel-testing-worker-count 4 \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         xcodebuild test \
           -scheme ColorKit \
-          -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=18.2' \
+          -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
           -enableCodeCoverage YES \
           | xcpretty && exit ${PIPESTATUS[0]}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,32 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
+    # Set up caching of Swift package dependencies
+    - name: Cache SPM dependencies
+      uses: actions/cache@v4
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    # Set up build cache
+    - name: Cache Build
+      uses: actions/cache@v4
+      with:
+        path: ~/Library/Developer/Xcode/DerivedData
+        key: ${{ runner.os }}-derived-data-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-derived-data-
+
     - name: Build and Test iOS
       run: |
         xcodebuild test \
           -scheme ColorKit \
           -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+          -parallel-testing-enabled YES \
+          -parallel-testing-worker-count 4 \
+          -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           -enableCodeCoverage YES \
           | xcpretty && exit ${PIPESTATUS[0]}
 
@@ -36,6 +57,9 @@ jobs:
         xcodebuild test \
           -scheme ColorKit \
           -destination 'platform=macOS,arch=arm64' \
+          -parallel-testing-enabled YES \
+          -parallel-testing-worker-count 4 \
+          -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           -enableCodeCoverage YES \
           | xcpretty && exit ${PIPESTATUS[0]}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [ main ]
+
+# Ensure we don't run on draft PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and Test
+    runs-on: macos-15 # Latest macOS runner with Xcode 16.2
+    if: github.event.pull_request.draft == false
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Select Xcode
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+    - name: Build and Test iOS
+      run: |
+        xcodebuild test \
+          -scheme ColorKit \
+          -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=18.2' \
+          -enableCodeCoverage YES \
+          | xcpretty && exit ${PIPESTATUS[0]}
+
+    - name: Build and Test macOS
+      run: |
+        xcodebuild test \
+          -scheme ColorKit \
+          -destination 'platform=macOS,arch=arm64,variant=Mac Catalyst' \
+          -enableCodeCoverage YES \
+          | xcpretty && exit ${PIPESTATUS[0]}
+
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
+      if: success() || failure() # Upload even if tests fail
+      with:
+        name: test-results
+        path: |
+          ~/Library/Developer/Xcode/DerivedData/**/Logs/Test/*.xcresult
+        retention-days: 5 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-derived-data-
 
-    - name: Setup iOS Simulator
-      run: |
     - name: Build and Test iOS
       run: |
         xcodebuild test \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,26 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-derived-data-
 
+    - name: Setup iOS Simulator
+      run: |
+        # Get runtime identifier
+        RUNTIME_ID=$(xcrun simctl list runtimes iOS -j | jq -r '.runtimes[0].identifier')
+        echo "Using runtime: $RUNTIME_ID"
+        
+        # Create and boot simulator
+        DEVICE_ID=$(xcrun simctl create "iPhone 16 Pro" com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro $RUNTIME_ID)
+        xcrun simctl boot $DEVICE_ID
+        
+        # Wait for simulator to be ready
+        xcrun simctl list devices | grep "iPhone 16 Pro"
+        
+        echo "SIMULATOR_DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
+
     - name: Build and Test iOS
       run: |
         xcodebuild test \
           -scheme ColorKit \
-          -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.2' \
+          -destination "id=$SIMULATOR_DEVICE_ID" \
           -parallel-testing-enabled YES \
           -parallel-testing-worker-count 4 \
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         xcodebuild test \
           -scheme ColorKit \
-          -destination 'platform=macOS,arch=arm64,variant=Mac Catalyst' \
+          -destination 'platform=macOS,arch=arm64' \
           -enableCodeCoverage YES \
           | xcpretty && exit ${PIPESTATUS[0]}
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,7 +29,7 @@ run_tests() {
 
 # Run iOS tests
 ios_result=0
-run_tests "iOS" "platform=iOS Simulator,name=iPhone 15 Pro" || ios_result=$?
+run_tests "iOS" "platform=iOS Simulator,name=iPhone 16 Pro" || ios_result=$?
 
 # Run macOS tests
 macos_result=0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo "🚀 Running ColorKit Tests..."
+
+# Function to run tests
+run_tests() {
+    platform=$1
+    destination=$2
+    
+    echo -e "\n${GREEN}Running tests for $platform...${NC}"
+    
+    if xcodebuild test \
+        -scheme ColorKit \
+        -destination "$destination" \
+        -enableCodeCoverage YES \
+        | xcpretty; then
+        echo -e "${GREEN}✅ $platform tests passed${NC}"
+        return 0
+    else
+        echo -e "${RED}❌ $platform tests failed${NC}"
+        return 1
+    fi
+}
+
+# Run iOS tests
+ios_result=0
+run_tests "iOS" "platform=iOS Simulator,name=iPhone 15 Pro" || ios_result=$?
+
+# Run macOS tests
+macos_result=0
+run_tests "macOS" "platform=macOS,arch=arm64" || macos_result=$?
+
+# Check if any tests failed
+if [ $ios_result -eq 0 ] && [ $macos_result -eq 0 ]; then
+    echo -e "\n${GREEN}✅ All tests passed successfully!${NC}"
+    exit 0
+else
+    echo -e "\n${RED}❌ Some tests failed${NC}"
+    exit 1
+fi 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -17,6 +17,9 @@ run_tests() {
     if xcodebuild test \
         -scheme ColorKit \
         -destination "$destination" \
+        -parallel-testing-enabled YES \
+        -parallel-testing-worker-count 4 \
+        -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
         -enableCodeCoverage YES \
         | xcpretty; then
         echo -e "${GREEN}✅ $platform tests passed${NC}"


### PR DESCRIPTION
This PR adds automated CI testing using GitHub Actions for both iOS and macOS platforms.

## Changes
- Added GitHub Actions workflow that runs on PR events
- Added local test runner script for development

## Features
- Automatically runs tests on:
  - iOS 18.2 (iPhone 16 Pro simulator)
  - macOS (arm64)
- Triggers on:
  - Opening PRs (excluding drafts)
  - New commits to PRs
  - Converting draft PRs to ready
- Uploads test results as artifacts
- Blocks PR merging if tests fail

## Local Testing
Added a convenient script to run tests locally:
```bash
./scripts/run_tests.sh
```

## Notes
- Uses latest stable Xcode 16.2
- Runs on latest macOS GitHub Actions runner