### PR TITLE
fix(color-spaces): Unify RGB to XYZ and LAB conversion

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,3 +24,19 @@ A contrast adjustment attempt that ends without finding a color that meets the r
 **Contrast fallback**:
 The black or white color selected when contrast adjustment is unsuccessful. It is not guaranteed to meet every requested minimum.
 _Avoid_: Guaranteed compliant color
+
+**LAB**:
+CIE L*a*b* coordinates relative to a reference white: L* describes lightness, a* the green–red axis, and b* the blue–yellow axis. ColorKit uses D65 as the reference white.
+_Avoid_: RGB brightness when referring to L*.
+
+**XYZ**:
+CIE XYZ tristimulus coordinates. ColorKit's public XYZ values use a relative scale on which the reference white has Y = 100; this is not an upper bound on every coordinate.
+_Avoid_: XYZ percentages, XYZ in the range 0–1 without specifying a different scale.
+
+**Normalized XYZ**:
+CIE XYZ coordinates on a relative scale where the reference white has Y = 1. Multiplying each coordinate by 100 expresses the same color on ColorKit's public XYZ scale.
+_Avoid_: XYZ percentages.
+
+**D65 reference white**:
+The reference white used for ColorKit's LAB coordinates, with XYZ values (95.047, 100, 108.883) on the Y = 100 scale.
+_Avoid_: White RGB color when referring to the reference white itself.

--- a/Sources/ColorKit/ColorSpaces/Color+LAB.swift
+++ b/Sources/ColorKit/ColorSpaces/Color+LAB.swift
@@ -89,46 +89,14 @@ public extension Color {
         }
 
         guard let components = cgColor?.components, components.count >= 3 else { return nil }
-        let r = components[0]
-        let g = components[1]
-        let b = components[2]
-
-        // Convert RGB to XYZ
-        func linearize(_ v: CGFloat) -> CGFloat {
-            v > 0.04045 ? pow((v + 0.055) / 1.055, 2.4) : v / 12.92
-        }
-
-        let rl = linearize(r)
-        let gl = linearize(g)
-        let bl = linearize(b)
-
-        // Using D65 illuminant
-        let x = rl * 0.4124564 + gl * 0.3575761 + bl * 0.1804375
-        let y = rl * 0.2126729 + gl * 0.7151522 + bl * 0.0721750
-        let z = rl * 0.0193339 + gl * 0.1191920 + bl * 0.9503041
-
-        // Convert XYZ to LAB
-        func f(_ t: CGFloat) -> CGFloat {
-            t > 0.008856 ? pow(t, 1.0 / 3.0) : (7.787 * t) + (16.0 / 116.0)
-        }
-
-        // Reference values for D65 illuminant
-        let xn: CGFloat = 0.95047
-        let yn: CGFloat = 1.0
-        let zn: CGFloat = 1.08883
-
-        let fx = f(x / xn)
-        let fy = f(y / yn)
-        let fz = f(z / zn)
-
-        let L = (116.0 * fy) - 16
-        let a = 500 * (fx - fy)
-        let bValue = 200 * (fy - fz)
+        let xyz = SRGBColorConversion.xyz(from: (Double(components[0]), Double(components[1]), Double(components[2])))
+        let lab = SRGBColorConversion.lab(from: xyz)
+        let result = (L: CGFloat(lab.l), a: CGFloat(lab.a), b: CGFloat(lab.b))
 
         // Cache the result
-        ColorCache.shared.cacheLABComponents(for: self, L: L, a: a, b: bValue)
+        ColorCache.shared.cacheLABComponents(for: self, L: result.L, a: result.a, b: result.b)
 
-        return (L, a, bValue)
+        return result
     }
 
     /// Creates a `Color` from LAB (L*, a*, b*) values.

--- a/Sources/ColorKit/Utilities/ColorSpaceConverter.swift
+++ b/Sources/ColorKit/Utilities/ColorSpaceConverter.swift
@@ -54,6 +54,8 @@ public struct ColorSpaceConverter {
     /// This method converts the color to all supported color spaces and returns their components
     /// in a single structure. This is useful when you need to analyze or compare a color across
     /// different color spaces.
+    /// LAB and XYZ share the D65 conversion used by `Color.labComponents()`.
+    /// XYZ uses a relative scale where the reference white has Y = 100.
     ///
     /// Example:
     /// ```swift
@@ -101,11 +103,8 @@ public struct ColorSpaceConverter {
             key: Double(cmykComponents.key)
         )
 
-        // Get LAB
-        let lab = calculateLAB(from: rgb)
-
-        // Get XYZ
-        let xyz = calculateXYZ(from: rgb)
+        let xyz = SRGBColorConversion.xyz(from: (rgb.red, rgb.green, rgb.blue))
+        let lab = SRGBColorConversion.lab(from: xyz)
 
         return ColorComponents(
             rgb: rgb,
@@ -113,63 +112,39 @@ public struct ColorSpaceConverter {
             hsb: hsb,
             cmyk: cmyk,
             lab: lab,
-            xyz: xyz
+            xyz: (x: xyz.x * 100, y: xyz.y * 100, z: xyz.z * 100)
+        )
+    }
+}
+
+/// Pure sRGB/D65 conversions. Internal XYZ uses reference-white Y = 1.
+enum SRGBColorConversion {
+    static func xyz(from rgb: (red: Double, green: Double, blue: Double)) -> (x: Double, y: Double, z: Double) {
+        func linearize(_ value: Double) -> Double {
+            value > 0.04045 ? pow((value + 0.055) / 1.055, 2.4) : value / 12.92
+        }
+
+        let r = linearize(rgb.red)
+        let g = linearize(rgb.green)
+        let b = linearize(rgb.blue)
+
+        return (
+            x: r * 0.4124564 + g * 0.3575761 + b * 0.1804375,
+            y: r * 0.2126729 + g * 0.7151522 + b * 0.0721750,
+            z: r * 0.0193339 + g * 0.1191920 + b * 0.9503041
         )
     }
 
-    /// Calculate LAB color components from RGB values.
-    ///
-    /// This method implements the conversion from RGB to LAB color space using the D65 white point.
-    /// The conversion happens in two steps:
-    /// 1. RGB to XYZ
-    /// 2. XYZ to LAB
-    ///
-    /// - Parameter rgb: A tuple containing the red, green, blue, and alpha components
-    /// - Returns: A tuple containing the LAB components (L, a, b)
-    private func calculateLAB(from rgb: (red: Double, green: Double, blue: Double, alpha: Double)) -> (l: Double, a: Double, b: Double) {
-        // First convert RGB to XYZ
-        let xyz = calculateXYZ(from: rgb)
+    static func lab(from xyz: (x: Double, y: Double, z: Double)) -> (l: Double, a: Double, b: Double) {
+        // Keep the existing LAB threshold and slope, also used by the inverse.
+        func transform(_ value: Double) -> Double {
+            value > 0.008856 ? pow(value, 1.0 / 3.0) : 7.787 * value + 16.0 / 116.0
+        }
 
-        // XYZ to LAB
-        // Using D65 reference white
-        let refX: Double = 95.047
-        let refY: Double = 100.0
-        let refZ: Double = 108.883
+        let fx = transform(xyz.x / 0.95047)
+        let fy = transform(xyz.y)
+        let fz = transform(xyz.z / 1.08883)
 
-        let x = xyz.x / refX
-        let y = xyz.y / refY
-        let z = xyz.z / refZ
-
-        let fx = x > 0.008856 ? pow(x, 1 / 3) : (7.787 * x) + (16 / 116)
-        let fy = y > 0.008856 ? pow(y, 1 / 3) : (7.787 * y) + (16 / 116)
-        let fz = z > 0.008856 ? pow(z, 1 / 3) : (7.787 * z) + (16 / 116)
-
-        let l = (116 * fy) - 16
-        let a = 500 * (fx - fy)
-        let b = 200 * (fy - fz)
-
-        return (l, a, b)
-    }
-
-    /// Calculate XYZ color components from RGB values.
-    ///
-    /// This method converts RGB values to CIE XYZ color space. The conversion process:
-    /// 1. Converts RGB to linear RGB
-    /// 2. Applies the RGB to XYZ transformation matrix
-    ///
-    /// - Parameter rgb: A tuple containing the red, green, blue, and alpha components
-    /// - Returns: A tuple containing the XYZ components (x, y, z)
-    private func calculateXYZ(from rgb: (red: Double, green: Double, blue: Double, alpha: Double)) -> (x: Double, y: Double, z: Double) {
-        // Convert RGB to linear RGB
-        let r = rgb.red <= 0.04045 ? rgb.red / 12.92 : pow((rgb.red + 0.055) / 1.055, 2.4)
-        let g = rgb.green <= 0.04045 ? rgb.green / 12.92 : pow((rgb.green + 0.055) / 1.055, 2.4)
-        let b = rgb.blue <= 0.04045 ? rgb.blue / 12.92 : pow((rgb.blue + 0.055) / 1.055, 2.4)
-
-        // Convert linear RGB to XYZ
-        let x = r * 0.4124 + g * 0.3576 + b * 0.1805
-        let y = r * 0.2126 + g * 0.7152 + b * 0.0722
-        let z = r * 0.0193 + g * 0.1192 + b * 0.9505
-
-        return (x * 100, y * 100, z * 100)
+        return (l: 116 * fy - 16, a: 500 * (fx - fy), b: 200 * (fy - fz))
     }
 }

--- a/Tests/ColorKitTests/ColorKitTests.swift
+++ b/Tests/ColorKitTests/ColorKitTests.swift
@@ -232,6 +232,52 @@ final class ColorKitTests: XCTestCase {
         XCTAssertEqual(Double(whiteLab.L), 100.0, accuracy: 0.1, "White L* value incorrect")
     }
 
+    func testLABConversionPopulatesCache() throws {
+        let color = Color(.sRGB, red: 0.23, green: 0.47, blue: 0.61)
+        ColorCache.shared.clearCache()
+        defer { ColorCache.shared.clearCache() }
+
+        XCTAssertNil(ColorCache.shared.getCachedLABComponents(for: color))
+        let lab = try XCTUnwrap(color.labComponents())
+        let cached = try XCTUnwrap(ColorCache.shared.getCachedLABComponents(for: color))
+
+        XCTAssertEqual(cached.L, lab.L)
+        XCTAssertEqual(cached.a, lab.a)
+        XCTAssertEqual(cached.b, lab.b)
+    }
+
+    func testLABRoundTripAroundLowLightnessThreshold() throws {
+        for lightness: CGFloat in [0, 0.1, 7.999, 8, 8.001, 50, 100] {
+            let color = Color(L: lightness, a: 0, b: 0)
+            let lab = try XCTUnwrap(color.labComponents())
+
+            XCTAssertEqual(lab.L, lightness, accuracy: 0.0001, "L*: \(lightness)")
+            XCTAssertEqual(lab.a, 0, accuracy: 0.0001, "L*: \(lightness)")
+            XCTAssertEqual(lab.b, 0, accuracy: 0.0001, "L*: \(lightness)")
+        }
+    }
+
+    func testLABInversePreservesInputClampingAndRGBClipping() {
+        let outsideBounds = Color(L: 120, a: 200, b: -200).rgbaComponents()
+        let atBounds = Color(L: 100, a: 127, b: -128).rgbaComponents()
+
+        XCTAssertEqual(outsideBounds.red, atBounds.red, accuracy: 1e-7)
+        XCTAssertEqual(outsideBounds.green, atBounds.green, accuracy: 1e-7)
+        XCTAssertEqual(outsideBounds.blue, atBounds.blue, accuracy: 1e-7)
+        XCTAssertEqual(atBounds.red, 1, accuracy: 1e-7)
+        XCTAssertEqual(atBounds.blue, 1, accuracy: 1e-7)
+        XCTAssertTrue((0...1).contains(atBounds.green))
+
+        let belowBounds = Color(L: -20, a: -200, b: 200).rgbaComponents()
+        let lowerBounds = Color(L: 0, a: -128, b: 127).rgbaComponents()
+        XCTAssertEqual(belowBounds.red, lowerBounds.red, accuracy: 1e-7)
+        XCTAssertEqual(belowBounds.green, lowerBounds.green, accuracy: 1e-7)
+        XCTAssertEqual(belowBounds.blue, lowerBounds.blue, accuracy: 1e-7)
+        XCTAssertEqual(lowerBounds.red, 0, accuracy: 1e-7)
+        XCTAssertEqual(lowerBounds.blue, 0, accuracy: 1e-7)
+        XCTAssertTrue((0...1).contains(lowerBounds.green))
+    }
+
     // MARK: - RGBA Components Test
     func testRGBAComponents() {
         let color = Color(red: 0.5, green: 0.6, blue: 0.7, opacity: 0.8)

--- a/Tests/ColorKitTests/Utilities/ColorSpaceConverterTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorSpaceConverterTests.swift
@@ -124,6 +124,106 @@ final class ColorSpaceConverterTests: XCTestCase {
         XCTAssertEqual(components.xyz.y, 100.0, accuracy: 5.0)
     }
 
+    func testLABMatchesStandaloneConversionForExplicitSRGBColors() throws {
+        for rgb in srgbSamples {
+            let color = Color(.sRGB, red: rgb.red, green: rgb.green, blue: rgb.blue)
+            let standalone = try XCTUnwrap(color.labComponents())
+            let aggregate = ColorSpaceConverter(color: color).getAllColorComponents().lab
+
+            XCTAssertEqual(aggregate.l, Double(standalone.L), accuracy: 0.0001, "RGB: \(rgb)")
+            XCTAssertEqual(aggregate.a, Double(standalone.a), accuracy: 0.0001, "RGB: \(rgb)")
+            XCTAssertEqual(aggregate.b, Double(standalone.b), accuracy: 0.0001, "RGB: \(rgb)")
+        }
+    }
+
+    func testAggregateLABRoundTripsToSRGB() {
+        for rgb in srgbSamples {
+            let color = Color(.sRGB, red: rgb.red, green: rgb.green, blue: rgb.blue)
+            let lab = color.colorSpaceComponents().lab
+            let restored = Color(L: CGFloat(lab.l), a: CGFloat(lab.a), b: CGFloat(lab.b)).rgbaComponents()
+
+            XCTAssertEqual(restored.red, rgb.red, accuracy: 0.00002, "RGB: \(rgb)")
+            XCTAssertEqual(restored.green, rgb.green, accuracy: 0.00002, "RGB: \(rgb)")
+            XCTAssertEqual(restored.blue, rgb.blue, accuracy: 0.00002, "RGB: \(rgb)")
+        }
+    }
+
+    func testPrimaryXYZValuesUseReferenceWhiteY100Scale() {
+        let samples: [(rgb: (Double, Double, Double), xyz: (Double, Double, Double))] = [
+            ((1, 0, 0), (41.24564, 21.26729, 1.93339)),
+            ((0, 1, 0), (35.75761, 71.51522, 11.9192)),
+            ((0, 0, 1), (18.04375, 7.2175, 95.03041)),
+            ((1, 1, 1), (95.047, 100.00001, 108.883)),
+            ((0.5, 0.5, 0.5), (20.34396828, 21.40411619, 23.30544150)),
+            ((0, 0, 0), (0, 0, 0))
+        ]
+
+        for (rgb, expected) in samples {
+            let color = Color(.sRGB, red: rgb.0, green: rgb.1, blue: rgb.2)
+            let xyz = color.colorSpaceComponents().xyz
+
+            XCTAssertEqual(xyz.x, expected.0, accuracy: 0.0001, "RGB: \(rgb)")
+            XCTAssertEqual(xyz.y, expected.1, accuracy: 0.0001, "RGB: \(rgb)")
+            XCTAssertEqual(xyz.z, expected.2, accuracy: 0.0001, "RGB: \(rgb)")
+        }
+    }
+
+    func testSRGBLinearizationThreshold() {
+        // Fixed reference values below, at, and above the encoded-sRGB breakpoint.
+        let samples: [(value: Double, xyz: (Double, Double, Double))] = [
+            (0.040449, (0.002975662618421053, 0.003130727867252322, 0.003408830082817338)),
+            (0.040450, (0.002975736184210526, 0.003130805266640867, 0.003408914357585139)),
+            (0.040451, (0.002975813221014465, 0.003130886317922488, 0.003409002608643282))
+        ]
+
+        for (value, expected) in samples {
+            let xyz = SRGBColorConversion.xyz(from: (value, value, value))
+
+            XCTAssertEqual(xyz.x, expected.0, accuracy: 1e-15, "sRGB: \(value)")
+            XCTAssertEqual(xyz.y, expected.1, accuracy: 1e-15, "sRGB: \(value)")
+            XCTAssertEqual(xyz.z, expected.2, accuracy: 1e-15, "sRGB: \(value)")
+        }
+    }
+
+    func testLABThresholdAndD65Normalization() {
+        let samples: [(y: Double, lab: (Double, Double, Double))] = [
+            (0.008855, (7.998650660, 396.557540258621, -158.623016103448)),
+            (0.008856, (7.999553952, 396.553646758621, -158.621458703448)),
+            (0.008857, (8.000495286075, 396.549589284159, -158.619835713664))
+        ]
+
+        for (y, expected) in samples {
+            // X and Z are the D65 reference white; only Y crosses the LAB breakpoint.
+            let lab = SRGBColorConversion.lab(from: (0.95047, y, 1.08883))
+
+            XCTAssertEqual(lab.l, expected.0, accuracy: 1e-9, "Y: \(y)")
+            XCTAssertEqual(lab.a, expected.1, accuracy: 1e-9, "Y: \(y)")
+            XCTAssertEqual(lab.b, expected.2, accuracy: 1e-9, "Y: \(y)")
+        }
+
+        let white = SRGBColorConversion.lab(from: (0.95047, 1, 1.08883))
+        XCTAssertEqual(white.l, 100, accuracy: 1e-12)
+        XCTAssertEqual(white.a, 0, accuracy: 1e-12)
+        XCTAssertEqual(white.b, 0, accuracy: 1e-12)
+    }
+
+    func testAggregateLABDoesNotUseOrReplaceStandaloneCache() throws {
+        let color = Color(.sRGB, red: 1, green: 0, blue: 0)
+        ColorCache.shared.clearCache()
+        defer { ColorCache.shared.clearCache() }
+        ColorCache.shared.cacheLABComponents(for: color, L: 12, a: 34, b: 56)
+
+        let aggregate = color.colorSpaceComponents().lab
+        let cached = try XCTUnwrap(color.labComponents())
+
+        XCTAssertEqual(aggregate.l, 53.24079414, accuracy: 0.0001)
+        XCTAssertEqual(aggregate.a, 80.09245960, accuracy: 0.0001)
+        XCTAssertEqual(aggregate.b, 67.20319652, accuracy: 0.0001)
+        XCTAssertEqual(cached.L, 12)
+        XCTAssertEqual(cached.a, 34)
+        XCTAssertEqual(cached.b, 56)
+    }
+
     func testCMYKConversion() {
         // Create primary colors with known RGB values
         let red = Color(red: 1.0, green: 0.0, blue: 0.0, opacity: 1.0)
@@ -156,5 +256,14 @@ final class ColorSpaceConverterTests: XCTestCase {
 
         // Black should have high key/black value
         XCTAssertEqual(blackComponents.cmyk.key, 1.0, accuracy: 0.05)
+    }
+
+    private var srgbSamples: [(red: Double, green: Double, blue: Double)] {
+        [
+            (1, 0, 0), (0, 1, 0), (0, 0, 1),
+            (0, 0, 0), (1, 1, 1), (0.5, 0.5, 0.5), (0.01, 0.01, 0.01),
+            (0.2, 0.4, 0.6), (0.73, 0.21, 0.49), (0.9, 0.7, 0.2),
+            (0.040449, 0.04045, 0.040451)
+        ]
     }
 }


### PR DESCRIPTION
## Summary

F01 · S02 identified two RGB → XYZ → LAB implementations with different matrix coefficients, plus a second XYZ calculation in aggregate conversion. Share the existing higher-precision `Color+LAB` calculation so both entry points agree for explicit sRGB inputs and aggregate conversion computes XYZ once.

## Changes

- Add two internal pure numerical helpers in `ColorSpaceConverter.swift` and use them from both entry points.
- Keep internal XYZ on the reference-white Y = 1 scale; scale the public aggregate XYZ result to Y = 100.
- Preserve public tuple labels and types, optionality, input extraction, cache behavior, and the LAB inverse's thresholds and clipping.
- Add nine regression tests covering cross-entry parity, XYZ reference values and units, both forward thresholds, round trips, inverse clipping, and cache behavior.
- Document the shared conversion and add the LAB/XYZ glossary from the design discussion.

## Alternatives considered

Keeping the aggregate converter's rounded matrix would change standalone LAB results and diverge from the existing inverse. Calling `labComponents()` from aggregate conversion would change cache and extraction behavior while still needing a separate XYZ calculation. Changing thresholds, inverse clipping, or color extraction is outside this focused fix.

## Notes

Aggregate LAB and XYZ values change slightly with the approved coefficients. For explicit sRGB red, the LAB change is approximately (+0.0079, −0.0168, −0.0169). Standalone LAB retains its existing calculation, and public XYZ units remain unchanged.

Standards review: 0 findings. Spec review: 0 findings. The simplification review found no unnecessary scaffolding or prose. Changes are split into a conversion-and-tests commit and a glossary commit.

## Screenshots

Not applicable; no UI changes.

## Testing

Validated with Xcode 26.5:

- `swiftlint lint --strict`: 0 violations.
- `xcodebuild test -scheme ColorKit -destination 'platform=macOS' -skipPackagePluginValidation -skipMacroValidation`: 103 tests passed.
- `xcodebuild test -scheme ColorKit -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -skipPackagePluginValidation -skipMacroValidation`: 106 tests passed.
- `git diff --check`: passed; no new TODO/FIXME markers.

Parity and round-trip fixtures include explicit sRGB primaries, black, white, gray, dark neutrals, interior colors, and values around the sRGB transfer breakpoint. Numerical fixtures also check the LAB breakpoint and D65 normalization independently of the public scale conversion.
