### PR TITLE
fix(accessibility): Preserve already-compliant input colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to ColorKit will be documented in this file.
 
 ### Fixed
 - Round RGB and alpha channels to the nearest byte when generating hexadecimal colors, preserving round trips such as `#232323FF`.
+- Preserve already-compliant colors, including opacity, in `adjustedForAccessibility` and `highContrastColor` instead of replacing them with black or white.
 
 ## [1.6.0] - 2025-04-01
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # ColorKit
 
-ColorKit describes, compares, blends, and interpolates colors across color spaces.
+ColorKit describes, compares, blends, and interpolates colors across color spaces, and provides contrast adjustments for SwiftUI interfaces.
 
 ## Language
 
@@ -14,3 +14,13 @@ A fixed color whose original color space is an explicitly recognized RGB or gray
 **Interpolation amount**:
 The position between an ordered pair of colors, with zero representing the starting color and one representing the destination. Nearby amounts such as 0.5001 and 0.5004 are distinct positions.
 _Avoid_: Rounded amount
+
+**Already-compliant input**:
+A foreground color whose existing contrast against the specified background meets or exceeds the requested minimum under ColorKit's legacy contrast calculation. It needs no adjustment; this term does not independently certify WCAG compliance.
+
+**Exhausted adjustment**:
+A contrast adjustment attempt that ends without finding a color that meets the requested minimum. It does not establish that no suitable color exists.
+
+**Contrast fallback**:
+The black or white color selected when contrast adjustment is unsuccessful. It is not guaranteed to meet every requested minimum.
+_Avoid_: Guaranteed compliant color

--- a/Sources/ColorKit/AdaptiveColorModifier.swift
+++ b/Sources/ColorKit/AdaptiveColorModifier.swift
@@ -9,7 +9,7 @@
 //
 //  Features:
 //  - `adaptiveColor`: Applies a light or dark color based on system appearance.
-//  - `highContrastColor`: Ensures text meets a minimum contrast ratio.
+//  - `highContrastColor`: Attempts to meet a minimum contrast ratio.
 //  - `onAdaptiveColorChange`: Executes an action when the system color scheme changes.
 //
 //  License:
@@ -85,23 +85,22 @@ public extension View {
         self.modifier(AdaptiveColorModifier(light: light, dark: dark, brightnessAdjustment: brightnessAdjustment))
     }
 
-    /// Ensures a color meets a minimum contrast ratio against the background.
+    /// Applies the result of `Color.adjustedForAccessibility(with:minimumRatio:)` to the foreground.
     ///
-    /// This modifier automatically adjusts the color to meet WCAG contrast
-    /// requirements, ensuring text and UI elements remain readable. It will
-    /// attempt to preserve the original color while meeting the contrast
-    /// requirements.
+    /// Preserves an already-compliant base color and delegates adjustment to the legacy
+    /// contrast calculation. Conversion failure returns the base color; unsuccessful
+    /// adjustment uses the existing black/white fallback, which may not meet the minimum.
     ///
     /// Example:
     /// ```swift
-    /// // Ensure text meets WCAG AA standard (4.5:1)
+    /// // Request a contrast ratio of 4.5:1
     /// Text("Readable Text")
     ///     .highContrastColor(
     ///         base: .blue,
     ///         background: .white
     ///     )
     ///
-    /// // Meet stricter WCAG AAA standard (7:1)
+    /// // Request a stricter contrast ratio of 7:1
     /// Text("High Contrast Text")
     ///     .highContrastColor(
     ///         base: .purple,
@@ -182,10 +181,7 @@ private struct AdaptiveColorModifier: ViewModifier {
     }
 }
 
-/// A ViewModifier that ensures a text or foreground element meets a minimum contrast ratio.
-///
-/// This modifier automatically adjusts colors to meet WCAG accessibility guidelines
-/// while attempting to preserve the original color's characteristics.
+/// A ViewModifier that applies the result of the legacy accessibility color adjustment.
 ///
 /// Example:
 /// ```swift

--- a/Sources/ColorKit/Color+Adaptive.swift
+++ b/Sources/ColorKit/Color+Adaptive.swift
@@ -129,11 +129,15 @@ public extension Color {
         return max(l1, l2) / min(l1, l2)
     }
 
-    /// Returns an improved color that meets a minimum contrast ratio requirement.
+    /// Preserves a color that already meets the requested contrast, or attempts to adjust it.
     ///
-    /// This method iteratively adjusts the color's brightness until it meets the specified
-    /// contrast ratio with the background color. If no suitable adjustment is found,
-    /// it falls back to black or white depending on the background.
+    /// Uses the legacy `contrastRatio(with:)` calculation. If the initial ratio meets or
+    /// exceeds the minimum, the original color is returned unchanged, including its opacity.
+    /// Otherwise, the existing greedy search adjusts HSL lightness in steps of 0.05.
+    /// If adjustment is unsuccessful, the fallback is white for a background classified
+    /// as dark by `isDarkColor()`, or black otherwise. The fallback may not meet the minimum.
+    /// If the foreground cannot be converted to HSL, the original color is returned.
+    /// A NaN minimum retains the fallback behavior when foreground conversion succeeds.
     ///
     /// Example:
     /// ```swift
@@ -145,7 +149,7 @@ public extension Color {
     ///         Text("Accessible Text")
     ///             .foregroundColor(textColor.adjustedForAccessibility(
     ///                 with: backgroundColor,
-    ///                 minimumRatio: 4.5 // WCAG AA standard
+    ///                 minimumRatio: 4.5
     ///             ))
     ///             .background(backgroundColor)
     ///     }
@@ -154,13 +158,18 @@ public extension Color {
     ///
     /// - Parameters:
     ///   - background: The background color against which contrast should be checked.
-    ///   - minimumRatio: The minimum contrast ratio required (4.5 for WCAG AA, 7 for AAA).
-    /// - Returns: A `Color` adjusted to meet the contrast ratio requirement.
+    ///   - minimumRatio: The requested minimum under the legacy contrast calculation.
+    /// - Returns: The original color on initial success or HSL conversion failure,
+    ///   the first successful adjustment, or the existing black/white fallback.
     func adjustedForAccessibility(with background: Color, minimumRatio: CGFloat) -> Color {
         guard let foregroundHSL = self.hslComponents() else { return self }
 
         var adjustedLightness = foregroundHSL.lightness
         var contrastRatio = self.contrastRatio(with: background)
+
+        if contrastRatio >= minimumRatio {
+            return self
+        }
 
         while contrastRatio < minimumRatio {
             // Try adjusting in both directions and pick the better one
@@ -194,7 +203,7 @@ public extension Color {
             }
         }
 
-        // if contrast is still too low, return a guaranteed high-contrast color
+        // Preserve the legacy fallback when adjustment does not produce a successful result.
         return background.isDarkColor() ? .white : .black
     }
 }

--- a/Sources/ColorKit/Documentation.docc/Accessibility-article.md
+++ b/Sources/ColorKit/Documentation.docc/Accessibility-article.md
@@ -72,6 +72,13 @@ Text("Dynamic Text")
     }
 ```
 
+`adjustedForAccessibility(with:minimumRatio:)` preserves the original color, including
+opacity, when its legacy contrast ratio already meets or exceeds the requested minimum.
+Otherwise, it attempts to adjust lightness. Failed foreground conversion returns the
+original color; unsuccessful adjustment retains the existing black/white fallback,
+which may not meet the requested ratio. `highContrastColor` delegates to this behavior.
+These legacy adjustments do not independently certify WCAG compliance.
+
 ## WCAG Guidelines
 
 ColorKit supports both WCAG 2.1 AA and AAA levels:

--- a/Tests/ColorKitTests/AccessibilityAdjustmentTests.swift
+++ b/Tests/ColorKitTests/AccessibilityAdjustmentTests.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class AccessibilityAdjustmentTests: XCTestCase {
+    func testAlreadyCompliantColorIsUnchangedIncludingOpacity() throws {
+        let pairs: [(foreground: Color, background: Color)] = [
+            (Color(.sRGB, red: 0.02, green: 0.08, blue: 0.12, opacity: 0.35), .white),
+            (Color(.sRGB, red: 0.7, green: 0.8, blue: 0.6, opacity: 0.65), .black)
+        ]
+
+        for (foreground, background) in pairs {
+            _ = try XCTUnwrap(foreground.hslComponents())
+            XCTAssertGreaterThan(foreground.contrastRatio(with: background), 4.5)
+
+            let adjusted = foreground.adjustedForAccessibility(with: background, minimumRatio: 4.5)
+
+            XCTAssertEqual(adjusted, foreground)
+            XCTAssertEqual(adjusted.cgColor?.alpha, foreground.cgColor?.alpha)
+        }
+    }
+
+    func testColorExactlyAtMinimumRatioIsUnchanged() throws {
+        let foreground = Color(.sRGB, red: 0.1, green: 0.2, blue: 0.3)
+        let background = Color.white
+        _ = try XCTUnwrap(foreground.hslComponents())
+        let minimumRatio = foreground.contrastRatio(with: background)
+
+        let adjusted = foreground.adjustedForAccessibility(with: background, minimumRatio: minimumRatio)
+
+        XCTAssertEqual(adjusted, foreground)
+    }
+
+    func testUnattainableRatioUsesLegacyFallbackForBothBackgrounds() throws {
+        let foreground = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5)
+        _ = try XCTUnwrap(foreground.hslComponents())
+        let pairs: [(background: Color, fallback: Color)] = [
+            (Color(.sRGB, red: 0.25, green: 0.25, blue: 0.25), .white),
+            (Color(.sRGB, red: 0.75, green: 0.75, blue: 0.75), .black)
+        ]
+
+        for (background, fallback) in pairs {
+            for minimumRatio: CGFloat in [22, .infinity] {
+                let adjusted = foreground.adjustedForAccessibility(with: background, minimumRatio: minimumRatio)
+
+                XCTAssertEqual(adjusted, fallback)
+                XCTAssertLessThan(adjusted.contrastRatio(with: background), minimumRatio)
+            }
+        }
+    }
+
+    func testExhaustedSearchKeepsLegacyFallbackEvenWhenBlackWouldPass() {
+        let foreground = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+        let background = Color(.sRGB, red: 0.4, green: 0.4, blue: 0.4)
+        XCTAssertLessThan(foreground.contrastRatio(with: background), 7)
+        XCTAssertGreaterThan(Color.black.contrastRatio(with: background), 7)
+
+        let adjusted = foreground.adjustedForAccessibility(with: background, minimumRatio: 7)
+
+        XCTAssertEqual(adjusted, .white)
+        XCTAssertLessThan(adjusted.contrastRatio(with: background), 7)
+    }
+
+    func testFailedForegroundConversionReturnsOriginalColor() {
+        let foregrounds = [Color.primary, Color(CGColor(gray: 0.4, alpha: 0.3))]
+
+        for foreground in foregrounds {
+            XCTAssertNil(foreground.hslComponents())
+
+            let adjusted = foreground.adjustedForAccessibility(with: .white, minimumRatio: 22)
+
+            XCTAssertEqual(adjusted, foreground)
+        }
+    }
+
+    func testNaNMinimumRatioKeepsLegacyFallback() {
+        let foreground = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5)
+
+        XCTAssertEqual(foreground.adjustedForAccessibility(with: .white, minimumRatio: .nan), .black)
+        XCTAssertEqual(foreground.adjustedForAccessibility(with: .black, minimumRatio: .nan), .white)
+    }
+
+    @MainActor
+    func testHighContrastModifierDelegatesCustomRatio() throws {
+        guard #available(iOS 16.0, macOS 13.0, *) else {
+            throw XCTSkip("ImageRenderer requires iOS 16 or macOS 13")
+        }
+        let cases: [(base: Color, background: Color, minimumRatio: CGFloat)] = [
+            (Color(.sRGB, red: 0.02, green: 0.08, blue: 0.12, opacity: 0.35), .white, 4.5),
+            (Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5), .white, 7),
+            (Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5), .black, 22),
+            (.primary, .white, 22)
+        ]
+
+        for (base, background, minimumRatio) in cases {
+            let adjusted = base.adjustedForAccessibility(with: background, minimumRatio: minimumRatio)
+            let actual = Rectangle().highContrastColor(base: base, background: background, minimumRatio: minimumRatio)
+            let expected = Rectangle().foregroundColor(adjusted)
+
+            XCTAssertEqual(try renderedPixel(of: actual), try renderedPixel(of: expected))
+        }
+    }
+
+    @MainActor
+    func testHighContrastModifierDefaultsToRatioOfFourPointFive() throws {
+        guard #available(iOS 16.0, macOS 13.0, *) else {
+            throw XCTSkip("ImageRenderer requires iOS 16 or macOS 13")
+        }
+        let base = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5)
+        let adjusted = base.adjustedForAccessibility(with: .white, minimumRatio: 4.5)
+        let actual = Rectangle().highContrastColor(base: base, background: .white)
+        let expected = Rectangle().foregroundColor(adjusted)
+
+        XCTAssertEqual(try renderedPixel(of: actual), try renderedPixel(of: expected))
+    }
+
+    @available(iOS 16.0, macOS 13.0, *)
+    @MainActor
+    private func renderedPixel(of view: some View) throws -> [UInt8] {
+        let renderer = ImageRenderer(content: view.frame(width: 1, height: 1).environment(\.colorScheme, .light))
+        let image = try XCTUnwrap(renderer.cgImage)
+        var pixel = [UInt8](repeating: 0, count: 4)
+        try pixel.withUnsafeMutableBytes { bytes in
+            let context = try XCTUnwrap(CGContext(
+                data: bytes.baseAddress,
+                width: 1,
+                height: 1,
+                bitsPerComponent: 8,
+                bytesPerRow: 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ))
+            context.draw(image, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        return pixel
+    }
+}


### PR DESCRIPTION
## Summary

Already-compliant colors skipped the adjustment loop and reached the black/white fallback. Return the original color when its initial legacy contrast meets or exceeds the requested minimum, preserving its opacity and representation.

## Changes

- Add an initial-success return after the existing HSL conversion guard.
- Keep the greedy search, contrast calculation, conversion-failure handling, fallback selection, and public modifier interfaces unchanged.
- Add eight regression tests covering identity on light and dark backgrounds, threshold equality, unattainable and exhausted adjustment, conversion failures, NaN, and rendered modifier delegation with custom and default ratios.
- Update the API contracts, accessibility guide, changelog, and glossary to explain that the fallback may not meet the requested minimum.

## Alternatives considered

Leaving the loop unchanged without an early return retains the bug. Negating the loop condition would also treat NaN as success, changing its existing fallback behavior. A new search or WCAG formula would exceed this repair's scope.

## Notes

Addresses F04 / S05 from the supplied review brief. This is not a WCAG-formula migration: the legacy fallback can still miss a requested ratio, even where another color could satisfy it.

Independent Standards and Spec reviews reported zero findings. Cleanup passes completed before committing.

## Screenshots

Not applicable; no UI changes. The modifier implementation and view layout are unchanged; its rendered foreground behavior is covered by tests.

## Testing

- Confirmed the new identity and exact-threshold tests fail before the fix (five failed assertions across two tests).
- macOS, Xcode 26.5: all 102 tests passed.
- iPhone 17 simulator, iOS 26.5: all 105 tests passed.
- `swiftlint lint --strict`: zero violations.
- `git diff --check`: passed.

Platform commands:

```sh
xcodebuild test -scheme ColorKit \
  -destination 'platform=macOS,arch=arm64' \
  -skipPackagePluginValidation -skipMacroValidation
xcodebuild test -scheme ColorKit \
  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
  -skipPackagePluginValidation -skipMacroValidation
```
