### PR TITLE
fix(cache): Make color cache identities optional and exact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           mkdir -p TestResults
           scripts/run_tests.sh --log-file TestResults/iOS.log \
             iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+            -skip-testing:ColorKitTests/ColorCacheIntegrationTests \
             -resultBundlePath TestResults/iOS.xcresult \
             -skipPackagePluginValidation \
             -skipMacroValidation
@@ -81,7 +82,33 @@ jobs:
           mkdir -p TestResults
           scripts/run_tests.sh --log-file TestResults/macOS.log \
             macOS 'platform=macOS' \
+            -skip-testing:ColorKitTests/ColorCacheIntegrationTests \
             -resultBundlePath TestResults/macOS.xcresult \
+            -skipPackagePluginValidation \
+            -skipMacroValidation
+
+      # Shared-cache tests clear global state and run outside the parallel suite.
+      - name: Test Shared Cache iOS
+        if: ${{ !cancelled() && (steps.ios_tests.outcome == 'success' || steps.ios_tests.outcome == 'failure') }}
+        run: |
+          mkdir -p TestResults
+          scripts/run_tests.sh --log-file TestResults/SharedCacheiOS.log \
+            iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+            -parallel-testing-enabled NO \
+            -only-testing:ColorKitTests/ColorCacheIntegrationTests \
+            -resultBundlePath TestResults/SharedCacheiOS.xcresult \
+            -skipPackagePluginValidation \
+            -skipMacroValidation
+
+      - name: Test Shared Cache macOS
+        if: ${{ !cancelled() && (steps.ios_tests.outcome == 'success' || steps.ios_tests.outcome == 'failure') }}
+        run: |
+          mkdir -p TestResults
+          scripts/run_tests.sh --log-file TestResults/SharedCachemacOS.log \
+            macOS 'platform=macOS' \
+            -parallel-testing-enabled NO \
+            -only-testing:ColorKitTests/ColorCacheIntegrationTests \
+            -resultBundlePath TestResults/SharedCachemacOS.xcresult \
             -skipPackagePluginValidation \
             -skipMacroValidation
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,16 @@
+# ColorKit
+
+ColorKit describes, compares, blends, and interpolates colors across color spaces.
+
+## Language
+
+**Color identity**:
+The original color space and complete component values, including opacity, that distinguish a color input. Equal component values in different color spaces do not establish the same color identity.
+_Avoid_: Visual equivalence
+
+**Identifiable color**:
+A fixed color whose original color space is an explicitly recognized RGB or grayscale space and whose complete, finite component values are available. Unresolved or dynamic colors, patterns, and colors in custom or unknown spaces fall outside this category.
+
+**Interpolation amount**:
+The position between an ordered pair of colors, with zero representing the starting color and one representing the destination. Nearby amounts such as 0.5001 and 0.5004 are distinct positions.
+_Avoid_: Rounded amount

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,13 +136,24 @@ To run the same platform checks locally with Xcode 26.5 selected:
 
 ```sh
 swiftlint lint --strict
-xcodebuild test -scheme ColorKit \
-  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+  -skip-testing:ColorKitTests/ColorCacheIntegrationTests \
   -skipPackagePluginValidation -skipMacroValidation
-xcodebuild test -scheme ColorKit \
-  -destination 'platform=macOS' \
+scripts/run_tests.sh macOS 'platform=macOS' \
+  -skip-testing:ColorKitTests/ColorCacheIntegrationTests \
+  -skipPackagePluginValidation -skipMacroValidation
+scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+  -parallel-testing-enabled NO \
+  -only-testing:ColorKitTests/ColorCacheIntegrationTests \
+  -skipPackagePluginValidation -skipMacroValidation
+scripts/run_tests.sh macOS 'platform=macOS' \
+  -parallel-testing-enabled NO \
+  -only-testing:ColorKitTests/ColorCacheIntegrationTests \
   -skipPackagePluginValidation -skipMacroValidation
 ```
+
+`ColorCacheIntegrationTests` clears `ColorCache.shared` before and after each test.
+Run it separately without parallel testing; direct cache tests use independent instances.
 
 The `test-results` workflow artifact retains raw build logs and `.xcresult`
 bundles for 14 days, including logs from failed test commands. Check the

--- a/PERFORMANCE_IMPROVEMENTS.md
+++ b/PERFORMANCE_IMPROVEMENTS.md
@@ -45,6 +45,14 @@ The caching system is implemented through the `ColorCache` class, which:
 - Maintains thread safety through proper synchronization
 - Automatically manages memory based on system pressure
 
+### Cache identity
+
+Caching is optional. Colors without a fixed identity in one of the supported RGB or grayscale spaces miss the cache and are not inserted. Keys retain the original color space, every component including alpha, and exact finite interpolation amounts; they do not convert colors or round values. Unsupported spaces and nonfinite key inputs bypass caching.
+
+Contrast keys are symmetric. Blend and interpolation keys preserve operand order and operation parameters. All six stores use the same count limit. Fewer hits or eviction must not change numerical results.
+
+See [the cache identity design](docs/design/cache-identity.md) for the supported spaces and regression coverage. This change does not extend the color formats accepted by the underlying computations.
+
 ## Using the Cache in Memory-Sensitive Applications
 
 While the cache is automatically managed, you can manually control it if needed:

--- a/Sources/ColorKit/Utilities/ColorCache.swift
+++ b/Sources/ColorKit/Utilities/ColorCache.swift
@@ -19,7 +19,10 @@
 import Foundation
 import SwiftUI
 
-/// A thread-safe cache for expensive color operations
+/// A thread-safe cache for expensive color operations.
+///
+/// Colors without an exact identity in a supported color space bypass caching.
+/// Cache keys preserve component values and operation parameters without rounding.
 public final class ColorCache: @unchecked Sendable {
     /// The shared instance for app-wide caching
     public static let shared = ColorCache()
@@ -48,41 +51,22 @@ public final class ColorCache: @unchecked Sendable {
     private let interpolatedColorCache = NSCache<NSString, UIColor>()
 #endif
 
-    /// Private initializer to enforce singleton pattern
-    private init() {
+    /// Creates an independent cache for internal use and tests.
+    init() {
         // Set cache limits
         labCache.countLimit = maxCacheSize
         hslCache.countLimit = maxCacheSize
         luminanceCache.countLimit = maxCacheSize
         contrastRatioCache.countLimit = maxCacheSize
-    }
-
-    /// Generates a cache key for a color
-    private func cacheKey(for color: Color) -> NSString {
-        guard let components = color.cgColor?.components, components.count >= 3 else {
-            return "invalid_color" as NSString
-        }
-
-        let r = components[0]
-        let g = components[1]
-        let b = components[2]
-        let a = components.count >= 4 ? components[3] : 1.0
-
-        return "\(r),\(g),\(b),\(a)" as NSString
-    }
-
-    /// Generates a cache key for a pair of colors
-    private func cacheKey(for color1: Color, and color2: Color) -> NSString {
-        let key1 = cacheKey(for: color1)
-        let key2 = cacheKey(for: color2)
-        return "\(key1)_\(key2)" as NSString
+        blendedColorCache.countLimit = maxCacheSize
+        interpolatedColorCache.countLimit = maxCacheSize
     }
 
     // MARK: - LAB Caching
 
     /// Gets cached LAB components for a color, or nil if not cached
     func getCachedLABComponents(for color: Color) -> (L: CGFloat, a: CGFloat, b: CGFloat)? {
-        let key = cacheKey(for: color)
+        guard let key = cacheKey(for: color) else { return nil }
         guard let array = labCache.object(forKey: key) else { return nil }
 
         guard array.count == 3,
@@ -97,7 +81,7 @@ public final class ColorCache: @unchecked Sendable {
 
     /// Caches LAB components for a color
     func cacheLABComponents(for color: Color, L: CGFloat, a: CGFloat, b: CGFloat) {
-        let key = cacheKey(for: color)
+        guard let key = cacheKey(for: color) else { return }
         let array = [L, a, b] as NSArray
         labCache.setObject(array, forKey: key)
     }
@@ -106,7 +90,7 @@ public final class ColorCache: @unchecked Sendable {
 
     /// Gets cached HSL components for a color, or nil if not cached
     func getCachedHSLComponents(for color: Color) -> (hue: CGFloat, saturation: CGFloat, lightness: CGFloat)? {
-        let key = cacheKey(for: color)
+        guard let key = cacheKey(for: color) else { return nil }
         guard let array = hslCache.object(forKey: key) else { return nil }
 
         guard array.count == 3,
@@ -121,7 +105,7 @@ public final class ColorCache: @unchecked Sendable {
 
     /// Caches HSL components for a color
     func cacheHSLComponents(for color: Color, hue: CGFloat, saturation: CGFloat, lightness: CGFloat) {
-        let key = cacheKey(for: color)
+        guard let key = cacheKey(for: color) else { return }
         let array = [hue, saturation, lightness] as NSArray
         hslCache.setObject(array, forKey: key)
     }
@@ -132,7 +116,7 @@ public final class ColorCache: @unchecked Sendable {
     /// - Parameter color: The color to get cached luminance for
     /// - Returns: The cached luminance value if available, nil otherwise
     public func getCachedLuminance(for color: Color) -> Double? {
-        let key = cacheKey(for: color)
+        guard let key = cacheKey(for: color) else { return nil }
         if let cachedValue = luminanceCache.object(forKey: key) {
             return cachedValue.doubleValue
         }
@@ -144,7 +128,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - color: The color to cache luminance for
     ///   - luminance: The luminance value to cache
     public func cacheLuminance(for color: Color, luminance: Double) {
-        let key = cacheKey(for: color)
+        guard let key = cacheKey(for: color) else { return }
         luminanceCache.setObject(NSNumber(value: luminance), forKey: key)
     }
 
@@ -154,7 +138,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - color2: The second color
     /// - Returns: The cached contrast ratio if available, nil otherwise
     public func getCachedContrastRatio(for color1: Color, with color2: Color) -> Double? {
-        let key = contrastCacheKey(for: color1, with: color2)
+        guard let key = contrastCacheKey(for: color1, with: color2) else { return nil }
         if let cachedValue = contrastRatioCache.object(forKey: key) {
             return cachedValue.doubleValue
         }
@@ -167,7 +151,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - color2: The second color
     ///   - ratio: The contrast ratio to cache
     public func cacheContrastRatio(for color1: Color, with color2: Color, ratio: Double) {
-        let key = contrastCacheKey(for: color1, with: color2)
+        guard let key = contrastCacheKey(for: color1, with: color2) else { return }
         contrastRatioCache.setObject(NSNumber(value: ratio), forKey: key)
     }
 
@@ -201,15 +185,6 @@ public final class ColorCache: @unchecked Sendable {
         contrastRatioCache.removeAllObjects()
     }
 
-    /// Generates a contrast cache key for two colors
-    private func contrastCacheKey(for color1: Color, with color2: Color) -> NSString {
-        let key1 = cacheKey(for: color1)
-        let key2 = cacheKey(for: color2)
-        // Create a consistent key regardless of color order
-        let keys = [key1 as String, key2 as String].sorted()
-        return (keys[0] + ":" + keys[1]) as NSString
-    }
-
     // MARK: - Color Blending Caching
 
     /// Get cached blended color
@@ -219,7 +194,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - blendMode: The blend mode used
     /// - Returns: The cached blended color if available, nil otherwise
     public func getCachedBlendedColor(color1: Color, with color2: Color, blendMode: String) -> Color? {
-        let key = blendCacheKey(for: color1, with: color2, blendMode: blendMode)
+        guard let key = blendCacheKey(for: color1, with: color2, blendMode: blendMode) else { return nil }
 
         #if canImport(AppKit)
         return blendedColorCache.object(forKey: key).map { Color($0) }
@@ -237,7 +212,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - blendMode: The blend mode used
     ///   - result: The resulting blended color
     public func cacheBlendedColor(color1: Color, with color2: Color, blendMode: String, result: Color) {
-        let key = blendCacheKey(for: color1, with: color2, blendMode: blendMode)
+        guard let key = blendCacheKey(for: color1, with: color2, blendMode: blendMode) else { return }
         cacheColor(result, forKey: key)
     }
 
@@ -268,7 +243,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - colorSpace: The color space used for interpolation
     /// - Returns: The cached interpolated color if available, nil otherwise
     public func getCachedInterpolatedColor(color1: Color, with color2: Color, amount: CGFloat, colorSpace: String) -> Color? {
-        let key = interpolationCacheKey(for: color1, with: color2, amount: amount, colorSpace: colorSpace)
+        guard let key = interpolationCacheKey(for: color1, with: color2, amount: amount, colorSpace: colorSpace) else { return nil }
 
         #if canImport(AppKit)
         return interpolatedColorCache.object(forKey: key).map { Color($0) }
@@ -287,7 +262,7 @@ public final class ColorCache: @unchecked Sendable {
     ///   - colorSpace: The color space used for interpolation
     ///   - result: The resulting interpolated color
     public func cacheInterpolatedColor(color1: Color, with color2: Color, amount: CGFloat, colorSpace: String, result: Color) {
-        let key = interpolationCacheKey(for: color1, with: color2, amount: amount, colorSpace: colorSpace)
+        guard let key = interpolationCacheKey(for: color1, with: color2, amount: amount, colorSpace: colorSpace) else { return }
         guard let cgColor = result.cgColor else { return }
 
         #if canImport(AppKit)
@@ -307,30 +282,51 @@ public final class ColorCache: @unchecked Sendable {
 
     // MARK: - Helper Methods
 
-    private func blendCacheKey(for color1: Color, with color2: Color, blendMode: String) -> NSString {
-        let key1 = cacheKey(for: color1)
-        let key2 = cacheKey(for: color2)
-        return "\(key1):\(key2):\(blendMode)" as NSString
+    private static let SUPPORTED_SPACE_NAMES: Set<String> = [
+        CGColorSpace.sRGB as String,
+        CGColorSpace.linearSRGB as String,
+        CGColorSpace.extendedSRGB as String,
+        CGColorSpace.extendedLinearSRGB as String,
+        CGColorSpace.displayP3 as String,
+        CGColorSpace.genericGrayGamma2_2 as String,
+        CGColorSpace.linearGray as String,
+        CGColorSpace.extendedGray as String,
+        CGColorSpace.extendedLinearGray as String
+    ]
+
+    private func cacheKey(for color: Color) -> NSString? {
+        guard let cgColor = color.cgColor,
+              let space = cgColor.colorSpace,
+              let name = space.name,
+              Self.SUPPORTED_SPACE_NAMES.contains(name as String),
+              let supportedSpace = CGColorSpace(name: name),
+              CFEqual(space, supportedSpace),
+              let components = cgColor.components,
+              components.count == supportedSpace.numberOfComponents + 1,
+              components.allSatisfy({ $0.isFinite }) else { return nil }
+
+        let componentBits = components.map { String(Double($0).bitPattern, radix: 16) }
+        return "\(name):\(componentBits.joined(separator: ","))" as NSString
     }
 
-    private func interpolationCacheKey(for color1: Color, with color2: Color, amount: CGFloat, colorSpace: String) -> NSString {
-        let key1 = cacheKey(for: color1)
-        let key2 = cacheKey(for: color2)
-        // Round amount to 3 decimal places to avoid too many cache entries
-        let roundedAmount = round(amount * 1_000) / 1_000
-        return "\(key1):\(key2):\(roundedAmount):\(colorSpace)" as NSString
-    }
-}
-
-// Extension to add z component to CGPoint for 3D color space caching
-private extension CGPoint {
-    init(x: CGFloat, y: CGFloat, z: CGFloat) {
-        self.init(x: x, y: y)
-        // Store z in a way that can be retrieved later
-        objc_setAssociatedObject(self, "z", z, .OBJC_ASSOCIATION_RETAIN)
+    private func contrastCacheKey(for color1: Color, with color2: Color) -> NSString? {
+        guard let key1 = cacheKey(for: color1),
+              let key2 = cacheKey(for: color2) else { return nil }
+        let keys = [key1 as String, key2 as String].sorted()
+        return keys.joined(separator: "|") as NSString
     }
 
-    var z: CGFloat {
-        return objc_getAssociatedObject(self, "z") as? CGFloat ?? 0
+    private func blendCacheKey(for color1: Color, with color2: Color, blendMode: String) -> NSString? {
+        guard let key1 = cacheKey(for: color1),
+              let key2 = cacheKey(for: color2) else { return nil }
+        return "\(key1)|\(key2)|\(blendMode)" as NSString
+    }
+
+    private func interpolationCacheKey(for color1: Color, with color2: Color, amount: CGFloat, colorSpace: String) -> NSString? {
+        guard amount.isFinite,
+              let key1 = cacheKey(for: color1),
+              let key2 = cacheKey(for: color2) else { return nil }
+        let amountBits = String(Double(amount).bitPattern, radix: 16)
+        return "\(key1)|\(key2)|\(amountBits)|\(colorSpace)" as NSString
     }
 }

--- a/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+// CI runs this suite separately without parallel testing because it clears the shared cache.
+final class ColorCacheIntegrationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ColorCache.shared.clearCache()
+    }
+
+    override func tearDown() {
+        ColorCache.shared.clearCache()
+        super.tearDown()
+    }
+
+    func testNearbyInterpolationAmountsMatchColdResultsInBothCallOrders() throws {
+        let first = try cacheTestColor(components: [0.8, 0.1, 0.2, 1])
+        let second = try cacheTestColor(components: [0.1, 0.6, 0.9, 1])
+        let amounts: [CGFloat] = [0.5001, 0.5004]
+        for space: GradientColorSpace in [.rgb, .hsl, .lab] {
+            let cold = amounts.map { amount in
+                ColorCache.shared.clearCache()
+                return first.interpolated(with: second, amount: amount, in: space)
+            }
+            XCTAssertNotEqual(try XCTUnwrap(cold[0].cgColor?.components), try XCTUnwrap(cold[1].cgColor?.components))
+            for order in [[0, 1], [1, 0]] {
+                ColorCache.shared.clearCache()
+                for index in order {
+                    try assertCacheColorEqual(first.interpolated(with: second, amount: amounts[index], in: space), cold[index])
+                }
+                for index in order {
+                    try assertCacheColorEqual(first.interpolated(with: second, amount: amounts[index], in: space), cold[index])
+                }
+            }
+        }
+    }
+
+    func testColorSpaceOrderDoesNotChangeColdOrWarmConversions() throws {
+        let colors = try [CGColorSpace.sRGB, CGColorSpace.linearSRGB, CGColorSpace.displayP3].map {
+            try cacheTestColor(space: $0)
+        }
+        let other = try cacheTestColor(components: [0.9, 0.8, 0.7, 1])
+        let cold = colors.map { color in
+            ColorCache.shared.clearCache()
+            return conversionValues(color, other: other)
+        }
+        for order in [[0, 1, 2], [2, 1, 0]] {
+            ColorCache.shared.clearCache()
+            for index in order {
+                XCTAssertEqual(conversionValues(colors[index], other: other), cold[index])
+            }
+            for index in order {
+                XCTAssertEqual(conversionValues(colors[index], other: other), cold[index])
+            }
+        }
+    }
+
+    func testBlendAndInterpolationPreserveOperandOrderWhenWarm() throws {
+        let first = try cacheTestColor(components: [0.8, 0.1, 0.2, 1])
+        let second = try cacheTestColor(components: [0.1, 0.6, 0.9, 0.5])
+        let pairs = [(first, second), (second, first)]
+        let coldBlends = pairs.map { base, blend in
+            ColorCache.shared.clearCache()
+            return base.blended(with: blend, mode: .normal)
+        }
+        let coldInterpolations = pairs.map { start, end in
+            ColorCache.shared.clearCache()
+            return start.interpolated(with: end, amount: 0.3)
+        }
+        XCTAssertNotEqual(coldBlends[0].cgColor?.components, coldBlends[1].cgColor?.components)
+        XCTAssertNotEqual(coldInterpolations[0].cgColor?.components, coldInterpolations[1].cgColor?.components)
+        for order in [[0, 1], [1, 0]] {
+            ColorCache.shared.clearCache()
+            for _ in 0..<2 {
+                for index in order {
+                    let (first, second) = pairs[index]
+                    try assertCacheColorEqual(first.blended(with: second, mode: .normal), coldBlends[index])
+                    try assertCacheColorEqual(first.interpolated(with: second, amount: 0.3), coldInterpolations[index])
+                }
+            }
+        }
+    }
+
+    func testGrayscaleFallbacksDoNotChangeWhenCacheIsWarm() throws {
+        let other = try cacheTestColor()
+        let grays = try [0.25, 0.75].map { value in
+            try cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [value, 1])
+        }
+        let cold = grays.map { color in
+            ColorCache.shared.clearCache()
+            return conversionValues(color, other: other)
+        }
+        for order in [[0, 1], [1, 0]] {
+            ColorCache.shared.clearCache()
+            for _ in 0..<2 {
+                for index in order {
+                    let gray = grays[index]
+                    XCTAssertNil(gray.labComponents())
+                    XCTAssertNil(gray.hslComponents())
+                    XCTAssertEqual(conversionValues(gray, other: other), cold[index])
+                    try assertCacheColorEqual(gray.blended(with: other, mode: .normal), gray)
+                    try assertCacheColorEqual(gray.interpolated(with: other, amount: 0.3), gray)
+                }
+            }
+        }
+    }
+
+    func testUnresolvedColorsKeepTheirFallbacksAfterOtherCalls() throws {
+        let other = try cacheTestColor()
+        let colors = [Color.primary, Color.secondary]
+        let cold = colors.map { color in
+            ColorCache.shared.clearCache()
+            return conversionValues(color, other: other)
+        }
+        for order in [[0, 1], [1, 0]] {
+            ColorCache.shared.clearCache()
+            for _ in 0..<2 {
+                for index in order {
+                    let color = colors[index]
+                    XCTAssertNil(color.cgColor)
+                    XCTAssertEqual(conversionValues(color, other: other), cold[index])
+                    XCTAssertEqual(color.blended(with: other, mode: .normal), color)
+                    XCTAssertEqual(color.interpolated(with: other, amount: 0.3), color)
+                    XCTAssertEqual(cachePresence(ColorCache.shared, color: color, other: other), Array(repeating: false, count: 6))
+                }
+            }
+        }
+    }
+
+    func testInterpolationKeepsExistingClampingBeforeCacheLookup() throws {
+        let first = try cacheTestColor()
+        let second = try cacheTestColor(components: [0.8, 0.7, 0.1, 1])
+        for (amount, clamped): (CGFloat, CGFloat) in [(-0.25, 0), (1.25, 1)] {
+            ColorCache.shared.clearCache()
+            let cold = first.interpolated(with: second, amount: clamped)
+            try assertCacheColorEqual(first.interpolated(with: second, amount: amount), cold)
+            XCTAssertNil(ColorCache.shared.getCachedInterpolatedColor(color1: first, with: second, amount: amount, colorSpace: "rgb"))
+            XCTAssertNotNil(ColorCache.shared.getCachedInterpolatedColor(color1: first, with: second, amount: clamped, colorSpace: "rgb"))
+        }
+    }
+
+    private func conversionValues(_ color: Color, other: Color) -> [Double?] {
+        let lab = color.labComponents()
+        let hsl = color.hslComponents()
+        return [
+            lab.map { Double($0.L) }, lab.map { Double($0.a) }, lab.map { Double($0.b) },
+            hsl.map { Double($0.hue) }, hsl.map { Double($0.saturation) }, hsl.map { Double($0.lightness) },
+            color.wcagRelativeLuminance(), color.wcagContrastRatio(with: other), other.wcagContrastRatio(with: color)
+        ]
+    }
+}

--- a/Tests/ColorKitTests/Utilities/ColorCacheTestSupport.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheTestSupport.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+func cacheTestColor(
+    space name: CFString = CGColorSpace.sRGB,
+    components: [CGFloat] = [0.2, 0.4, 0.6, 0.8]
+) throws -> Color {
+    let space = try XCTUnwrap(CGColorSpace(name: name))
+    return try cacheTestColor(space: space, components: components)
+}
+
+func cacheTestColor(space: CGColorSpace, components: [CGFloat]) throws -> Color {
+    let cgColor = try XCTUnwrap(CGColor(colorSpace: space, components: components))
+    let color = Color(cgColor)
+    let represented = try XCTUnwrap(color.cgColor)
+    XCTAssertTrue(CFEqual(try XCTUnwrap(represented.colorSpace), space))
+    let representedBits = try XCTUnwrap(represented.components).map { Double($0).bitPattern }
+    XCTAssertEqual(representedBits, components.map { Double($0).bitPattern })
+    return color
+}
+
+func assertCacheColorEqual(
+    _ actual: Color?, _ expected: Color,
+    file: StaticString = #filePath, line: UInt = #line
+) throws {
+    let actualCG = try XCTUnwrap(actual?.cgColor, file: file, line: line)
+    let expectedCG = try XCTUnwrap(expected.cgColor, file: file, line: line)
+    XCTAssertTrue(CFEqual(try XCTUnwrap(actualCG.colorSpace), try XCTUnwrap(expectedCG.colorSpace)), file: file, line: line)
+    XCTAssertEqual(actualCG.components, expectedCG.components, file: file, line: line)
+}
+
+func populateCache(_ cache: ColorCache, color: Color, other: Color, marker: CGFloat = 0.25) {
+    cache.cacheLABComponents(for: color, L: marker, a: marker + 1, b: marker + 2)
+    cache.cacheHSLComponents(for: color, hue: marker, saturation: marker + 1, lightness: marker + 2)
+    cache.cacheLuminance(for: color, luminance: Double(marker))
+    cache.cacheContrastRatio(for: color, with: other, ratio: Double(marker))
+    let result = Color(.sRGB, red: Double(marker), green: 0.25, blue: 0.75)
+    cache.cacheBlendedColor(color1: color, with: other, blendMode: "normal", result: result)
+    cache.cacheInterpolatedColor(color1: color, with: other, amount: 0.5, colorSpace: "rgb", result: result)
+}
+
+func cachePresence(_ cache: ColorCache, color: Color, other: Color) -> [Bool] {
+    [
+        cache.getCachedLABComponents(for: color) != nil,
+        cache.getCachedHSLComponents(for: color) != nil,
+        cache.getCachedLuminance(for: color) != nil,
+        cache.getCachedContrastRatio(for: color, with: other) != nil,
+        cache.getCachedBlendedColor(color1: color, with: other, blendMode: "normal") != nil,
+        cache.getCachedInterpolatedColor(color1: color, with: other, amount: 0.5, colorSpace: "rgb") != nil
+    ]
+}
+
+func assertCacheMarker(
+    _ cache: ColorCache, color: Color, other: Color, marker: CGFloat,
+    file: StaticString = #filePath, line: UInt = #line
+) throws {
+    let lab = try XCTUnwrap(cache.getCachedLABComponents(for: color), file: file, line: line)
+    XCTAssertEqual([lab.L, lab.a, lab.b], [marker, marker + 1, marker + 2], file: file, line: line)
+    let hsl = try XCTUnwrap(cache.getCachedHSLComponents(for: color), file: file, line: line)
+    XCTAssertEqual([hsl.hue, hsl.saturation, hsl.lightness], [marker, marker + 1, marker + 2], file: file, line: line)
+    XCTAssertEqual(cache.getCachedLuminance(for: color), Double(marker), file: file, line: line)
+    XCTAssertEqual(cache.getCachedContrastRatio(for: color, with: other), Double(marker), file: file, line: line)
+    let result = Color(.sRGB, red: Double(marker), green: 0.25, blue: 0.75)
+    try assertCacheColorEqual(cache.getCachedBlendedColor(color1: color, with: other, blendMode: "normal"), result, file: file, line: line)
+    try assertCacheColorEqual(cache.getCachedInterpolatedColor(color1: color, with: other, amount: 0.5, colorSpace: "rgb"), result, file: file, line: line)
+}

--- a/Tests/ColorKitTests/Utilities/ColorCacheTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheTests.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class ColorCacheTests: XCTestCase {
+    func testSupportedSpacesHaveSeparateEntriesInEveryStore() throws {
+        let cache = ColorCache()
+        let other = try cacheTestColor(components: [0.9, 0.1, 0.3, 1])
+        let names = [
+            CGColorSpace.sRGB, CGColorSpace.linearSRGB, CGColorSpace.extendedSRGB,
+            CGColorSpace.extendedLinearSRGB, CGColorSpace.displayP3,
+            CGColorSpace.genericGrayGamma2_2, CGColorSpace.linearGray,
+            CGColorSpace.extendedGray, CGColorSpace.extendedLinearGray
+        ]
+        let colors = try names.map { name in
+            let space = try XCTUnwrap(CGColorSpace(name: name))
+            return try cacheTestColor(space: space, components: space.model == .rgb ? [0.2, 0.4, 0.6, 0.8] : [0.2, 0.8])
+        }
+
+        for (index, color) in colors.enumerated() {
+            XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
+            populateCache(cache, color: color, other: other, marker: CGFloat(index) / 16)
+        }
+        for (index, color) in colors.enumerated() {
+            try assertCacheMarker(cache, color: color, other: other, marker: CGFloat(index) / 16)
+        }
+    }
+
+    func testGrayscaleComponentsAndAlphaAreNotAliasedToRGB() throws {
+        let cache = ColorCache()
+        let other = try cacheTestColor()
+        let colors = try [
+            cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.25, 1]),
+            cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.75, 1]),
+            cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.25, 0.5]),
+            cacheTestColor(components: [0.25, 0.25, 0.25, 1]),
+            cacheTestColor(components: [0.25, 0.25, 0.25, 0.5])
+        ]
+        for (index, color) in colors.enumerated() {
+            XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
+            populateCache(cache, color: color, other: other, marker: CGFloat(index) / 8)
+        }
+        for (index, color) in colors.enumerated() {
+            try assertCacheMarker(cache, color: color, other: other, marker: CGFloat(index) / 8)
+        }
+    }
+
+    func testUnsupportedColorsMissAndCannotInsertInAnyStore() throws {
+        let supported = try cacheTestColor()
+        #if canImport(AppKit)
+        let dynamic = Color(NSColor(name: nil) { _ in .red })
+        #else
+        let dynamic = Color(UIColor { _ in .red })
+        #endif
+        XCTAssertNil(dynamic.cgColor)
+        let customSpace = try XCTUnwrap(CGColorSpace(calibratedGrayWhitePoint: [0.9505, 1, 1.089], blackPoint: nil, gamma: 1.8))
+        let unsupported = try [
+            Color.primary, Color.secondary, dynamic,
+            cacheTestColor(space: CGColorSpace.adobeRGB1998),
+            cacheTestColor(space: CGColorSpaceCreateDeviceRGB(), components: [0.2, 0.4, 0.6, 0.8]),
+            cacheTestColor(space: CGColorSpaceCreateDeviceGray(), components: [0.2, 0.8]),
+            cacheTestColor(space: customSpace, components: [0.2, 0.8])
+        ]
+        XCTAssertNil(Color.primary.cgColor)
+        XCTAssertNil(Color.secondary.cgColor)
+        for color in unsupported {
+            let cache = ColorCache()
+            populateCache(cache, color: color, other: supported)
+            XCTAssertEqual(cachePresence(cache, color: color, other: supported), Array(repeating: false, count: 6))
+            for other in unsupported {
+                XCTAssertEqual(cachePresence(cache, color: other, other: supported), Array(repeating: false, count: 6))
+            }
+            populateCache(cache, color: supported, other: color)
+            XCTAssertEqual(cachePresence(cache, color: supported, other: color), [true, true, true, false, false, false])
+            XCTAssertEqual(cachePresence(cache, color: color, other: supported), Array(repeating: false, count: 6))
+            populateCache(cache, color: supported, other: supported, marker: 0.75)
+            try assertCacheMarker(cache, color: supported, other: supported, marker: 0.75)
+        }
+    }
+
+    func testPatternColorCannotUseAnOrdinaryColorEntry() throws {
+        var callbacks = CGPatternCallbacks(
+            version: 0,
+            drawPattern: { _, context in
+                context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+                context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+            },
+            releaseInfo: nil
+        )
+        let pattern = try XCTUnwrap(CGPattern(
+            info: nil,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            matrix: .identity,
+            xStep: 1,
+            yStep: 1,
+            tiling: .constantSpacing,
+            isColored: true,
+            callbacks: &callbacks
+        ))
+        let space = try XCTUnwrap(CGColorSpace(patternBaseSpace: nil))
+        let cgColor = try XCTUnwrap(CGColor(patternSpace: space, pattern: pattern, components: [1]))
+        let color = Color(cgColor)
+        XCTAssertEqual(color.cgColor?.colorSpace?.model, .pattern)
+        let cache = ColorCache()
+        let other = try cacheTestColor()
+        populateCache(cache, color: other, other: other)
+        populateCache(cache, color: color, other: other)
+        XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
+        populateCache(cache, color: other, other: color)
+        XCTAssertEqual(cachePresence(cache, color: other, other: color), [true, true, true, false, false, false])
+        try assertCacheMarker(cache, color: other, other: other, marker: 0.25)
+    }
+
+    func testFiniteComponentBitsRemainDistinct() throws {
+        let cache = ColorCache()
+        let other = try cacheTestColor()
+        let values: [CGFloat] = [-0.0, 0.0, 0.5001, 0.5004, -0.25, 1.25]
+        let colors = try values.map { value in
+            try cacheTestColor(space: CGColorSpace.extendedSRGB, components: [value, 0.2, 0.3, 1])
+        }
+        for (index, color) in colors.enumerated() {
+            XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
+            populateCache(cache, color: color, other: other, marker: CGFloat(index) / 8)
+        }
+        for (index, color) in colors.enumerated() {
+            try assertCacheMarker(cache, color: color, other: other, marker: CGFloat(index) / 8)
+        }
+    }
+
+    func testNonfiniteComponentsBypassEveryStore() throws {
+        let other = try cacheTestColor()
+        for value: CGFloat in [.nan, .infinity, -.infinity] {
+            let color = try cacheTestColor(space: CGColorSpace.extendedSRGB, components: [value, 0.2, 0.3, 1])
+            let cache = ColorCache()
+            populateCache(cache, color: color, other: other)
+            XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
+            populateCache(cache, color: other, other: color)
+            XCTAssertEqual(cachePresence(cache, color: other, other: color), [true, true, true, false, false, false])
+        }
+    }
+
+    func testContrastIsSymmetricButBlendAndInterpolationAreOrdered() throws {
+        let cache = ColorCache()
+        let first = try cacheTestColor(components: [0.8, 0.1, 0.2, 1])
+        let second = try cacheTestColor(components: [0.2, 0.6, 0.9, 0.5])
+        populateCache(cache, color: first, other: second)
+        XCTAssertEqual(cache.getCachedContrastRatio(for: second, with: first), 0.25)
+        XCTAssertNil(cache.getCachedBlendedColor(color1: second, with: first, blendMode: "normal"))
+        XCTAssertNil(cache.getCachedInterpolatedColor(color1: second, with: first, amount: 0.5, colorSpace: "rgb"))
+
+        cache.cacheBlendedColor(color1: second, with: first, blendMode: "normal", result: second)
+        cache.cacheInterpolatedColor(color1: second, with: first, amount: 0.5, colorSpace: "rgb", result: second)
+        try assertCacheMarker(cache, color: first, other: second, marker: 0.25)
+        try assertCacheColorEqual(cache.getCachedBlendedColor(color1: second, with: first, blendMode: "normal"), second)
+        try assertCacheColorEqual(cache.getCachedInterpolatedColor(color1: second, with: first, amount: 0.5, colorSpace: "rgb"), second)
+    }
+
+    func testOperationNamesAreKeptExact() throws {
+        let cache = ColorCache()
+        let first = try cacheTestColor()
+        let second = try cacheTestColor(components: [0.8, 0.7, 0.1, 1])
+        let names = ["rgb", "RGB", "rgb|hsl", "", "normal"]
+        for (index, name) in names.enumerated() {
+            let result = index.isMultiple(of: 2) ? first : second
+            XCTAssertNil(cache.getCachedBlendedColor(color1: first, with: second, blendMode: name))
+            XCTAssertNil(cache.getCachedInterpolatedColor(color1: first, with: second, amount: 0.5, colorSpace: name))
+            cache.cacheBlendedColor(color1: first, with: second, blendMode: name, result: result)
+            cache.cacheInterpolatedColor(color1: first, with: second, amount: 0.5, colorSpace: name, result: result)
+        }
+        for (index, name) in names.enumerated() {
+            let result = index.isMultiple(of: 2) ? first : second
+            try assertCacheColorEqual(cache.getCachedBlendedColor(color1: first, with: second, blendMode: name), result)
+            try assertCacheColorEqual(cache.getCachedInterpolatedColor(color1: first, with: second, amount: 0.5, colorSpace: name), result)
+        }
+    }
+
+    func testInterpolationAmountsAreExactInBothInsertionOrders() throws {
+        let first = try cacheTestColor()
+        let second = try cacheTestColor(components: [0.8, 0.7, 0.1, 1])
+        let amounts: [CGFloat] = [0.5001, 0.5004, -0.0, 0.0, -0.25, 1.25]
+        for order in [amounts, amounts.reversed().map { $0 }] {
+            let cache = ColorCache()
+            for (index, amount) in order.enumerated() {
+                XCTAssertNil(cache.getCachedInterpolatedColor(color1: first, with: second, amount: amount, colorSpace: "rgb"))
+                cache.cacheInterpolatedColor(color1: first, with: second, amount: amount, colorSpace: "rgb", result: index.isMultiple(of: 2) ? first : second)
+            }
+            for (index, amount) in order.enumerated() {
+                try assertCacheColorEqual(cache.getCachedInterpolatedColor(color1: first, with: second, amount: amount, colorSpace: "rgb"), index.isMultiple(of: 2) ? first : second)
+            }
+        }
+    }
+
+    func testNonfiniteInterpolationAmountsCannotInsert() throws {
+        let cache = ColorCache()
+        let color = try cacheTestColor()
+        for amount: CGFloat in [.nan, .infinity, -.infinity] {
+            cache.cacheInterpolatedColor(color1: color, with: color, amount: amount, colorSpace: "rgb", result: color)
+            XCTAssertNil(cache.getCachedInterpolatedColor(color1: color, with: color, amount: amount, colorSpace: "rgb"))
+        }
+        XCTAssertNil(cache.getCachedInterpolatedColor(color1: color, with: color, amount: 0, colorSpace: "rgb"))
+        XCTAssertNil(cache.getCachedInterpolatedColor(color1: color, with: color, amount: 1, colorSpace: "rgb"))
+    }
+
+    func testEachClearOnlyRemovesItsOwnStore() throws {
+        let color = try cacheTestColor()
+        let clearOperations: [(ColorCache) -> Void] = [
+            { $0.clearLABCache() }, { $0.clearHSLCache() }, { $0.clearLuminanceCache() },
+            { $0.clearContrastCache() }, { $0.clearBlendedColorCache() }, { $0.clearInterpolatedColorCache() }
+        ]
+        for (index, clear) in clearOperations.enumerated() {
+            let cache = ColorCache()
+            populateCache(cache, color: color, other: color)
+            XCTAssertEqual(cachePresence(cache, color: color, other: color), Array(repeating: true, count: 6))
+            clear(cache)
+            var expected = Array(repeating: true, count: 6)
+            expected[index] = false
+            XCTAssertEqual(cachePresence(cache, color: color, other: color), expected)
+        }
+    }
+
+    func testGlobalClearRemovesEveryStoreWithoutAffectingOtherInstances() throws {
+        let color = try cacheTestColor()
+        let first = ColorCache()
+        let second = ColorCache()
+        populateCache(first, color: color, other: color)
+        populateCache(second, color: color, other: color)
+        first.clearCache()
+        XCTAssertEqual(cachePresence(first, color: color, other: color), Array(repeating: false, count: 6))
+        try assertCacheMarker(second, color: color, other: color, marker: 0.25)
+    }
+}

--- a/docs/design/cache-identity.md
+++ b/docs/design/cache-identity.md
@@ -1,0 +1,47 @@
+# F03 · S04 — Optional, exact cache identity
+
+Status: accepted for implementation.
+
+## Agreed scope
+
+- Preserve NSCache and existing public methods.
+- Failure to establish a supported color identity means a cache miss on lookup and no insertion on write. No shared fallback identity is permitted.
+- Support identities only for explicitly recognized RGB and grayscale spaces. Unresolved or dynamic colors, patterns, and custom or unknown spaces bypass caching.
+- Preserve the original color space and every component, including alpha. Do not convert colors merely to construct keys.
+- Giving grayscale a distinct identity does not change algorithms that currently reject grayscale component layouts or return a fallback.
+- Preserve exact interpolation amounts: 0.5001 and 0.5004 must not share an entry.
+- Preserve exact finite floating-point bit patterns for color components and interpolation amounts, including distinct negative and positive zero. Do not round, clamp, or normalize values when constructing keys; extended-range finite components remain eligible.
+- If any component or interpolation amount supplied to the cache is NaN or infinite, lookup misses and insertion is skipped. This does not change the higher-level interpolation method's existing clamping behavior.
+- Contrast remains symmetric; blending and interpolation retain operand order.
+- Apply the existing per-store count limit to the blend and interpolation stores as well.
+
+## Recognized color spaces
+
+The initial list is explicit. Each listed space has a distinct identity:
+
+- RGB: `sRGB`, `linearSRGB`, `extendedSRGB`, `extendedLinearSRGB`, and `displayP3`.
+- Grayscale: `genericGrayGamma2_2`, `linearGray`, `extendedGray`, and `extendedLinearGray`.
+
+All other spaces, including device-dependent spaces, bypass caching. Recognition must establish the actual supported space rather than equating spaces solely because their component counts or color models match.
+
+## Existing behavior to preserve
+
+`Color.interpolated` clamps the amount before passing the same value to both the cache and computation. Removing rounding inside the cache must preserve this behavior without introducing additional normalization in the cache's public methods.
+
+## Required validation
+
+Cover all six stores directly: LAB, HSL, luminance, contrast, blending, and interpolation.
+
+- Verify that unsupported colors cannot insert entries or retrieve another color's entry, including either operand of pair operations.
+- Verify the recognized RGB and grayscale spaces with fixtures whose actual color space and component layout are checked. Equal components in different supported spaces must remain distinct; alpha must participate in identity.
+- Verify exact numeric identity, signed zero, finite extended-range components, and nonfinite-input bypass. Fixtures must establish which values survive platform color construction before asserting their cache behavior.
+- Verify contrast symmetry, ordered blending and interpolation, and separation by blend mode and interpolation space.
+- Verify each store-specific clear operation leaves other stores intact and that global clearing empties all stores.
+- Compare cold and warm scalar or color-component results across the cached operations. For interpolation, exercise 0.5001 and 0.5004 in both call orders in RGB, HSL, and LAB, comparing each result with its own cold baseline. Assertions must expose the original collision rather than hide it behind a broad numerical tolerance.
+- Retain the existing numerical suites and validate both platform storage paths on macOS and iOS Simulator where available.
+
+## Test isolation
+
+Keep `ColorCache.init()` internal so direct tests can construct a fresh instance per test through `@testable import`. The public API and shared production instance remain unchanged.
+
+Tests of high-level operations still use `ColorCache.shared`. Run those integration tests in a separate invocation with parallel testing disabled, exclude them from the parallel invocation, and clear the shared cache before and after each test. This preserves parallel execution for the remaining suite without relying on a lock that unrelated cache users do not observe.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,6 +10,8 @@ Usage: scripts/run_tests.sh [--log-file path] platform destination [xcodebuild-o
 With no arguments, run both iOS and macOS tests and report both results.
 With a platform label and destination, run only that destination. Additional
 arguments are passed unchanged to xcodebuild after the shared test options.
+An explicit -parallel-testing-enabled option replaces the default parallel
+settings; pass -parallel-testing-enabled NO for tests that share mutable state.
 Use --log-file to save raw output with tee instead of formatting with xcpretty;
 the log's parent directory must already exist. This requires a single platform.
 
@@ -31,16 +33,23 @@ run_tests() {
     local statuses
     shift 2
 
+    local argument
+    local test_options=(-parallel-testing-enabled YES -parallel-testing-worker-count 4 "$@")
+    for argument in "$@"; do
+        if [[ $argument == -parallel-testing-enabled ]]; then
+            test_options=("$@")
+            break
+        fi
+    done
+
     printf '\nRunning tests for %s...\n' "$platform"
 
     if xcodebuild test \
         -scheme ColorKit \
         -destination "$destination" \
-        -parallel-testing-enabled YES \
-        -parallel-testing-worker-count 4 \
         -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData" \
         -enableCodeCoverage YES \
-        "$@" \
+        "${test_options[@]}" \
         | "${output_command[@]}"; then
         printf '%s tests passed\n' "$platform"
         return 0


### PR DESCRIPTION
## Summary

Cache occupancy could change color results: unsupported colors shared one fallback key, color spaces were omitted, and interpolation amounts were rounded even though the calculations used their exact values. This change makes cache identity optional and preserves the inputs used by the computation.

## Changes

- Bypass lookup and insertion when a fixed, finite identity cannot be established in one of nine supported RGB or grayscale spaces.
- Include the original color space and every component bit, including alpha; retain exact finite interpolation amounts and distinguish signed zero.
- Preserve symmetric contrast keys and ordered blend/interpolation keys without changing public methods or color algorithms.
- Apply the existing count limit to all six stores and allow independent internal cache instances for direct tests.
- Add 12 direct cache tests and six integration tests. Run shared-cache integration tests separately from parallel CI suites, with their own logs and result bundles. The shared runner accepts an explicit parallel-testing option so serial runs do not receive duplicate Xcode flags.
- Document the contract, supported spaces, and local validation commands; remove unused cache helpers.

## Alternatives considered

Converting colors or rounding only cache keys would still disagree with the computations. Changing those computations would expand the scope. A narrow list of supported spaces deliberately trades hit rate for a reliable identity; other spaces continue through the existing uncached behavior.

Independent instances isolate direct tests without adding locks around unrelated cache users. The high-level integration suite still exercises the production shared instance in a separate serial run.

## Notes

Implements F03 / S04 from the agreed design in `docs/design/cache-identity.md`. Grayscale cache identity does not add grayscale support to algorithms that currently reject its component layout. Finite extended-range components remain eligible; nonfinite key inputs bypass caching. The higher-level interpolation method retains its existing clamping.

Independent Standards and Spec reviews of the cache change have no outstanding findings. A CI artifact-path regression caught during review was fixed and rechecked. Rebased onto main at `720774c`; the CI conflict was resolved by retaining the shared test runner, its failure reporting, and separate serial cache runs.

## Screenshots

Not applicable; no UI changes.

## Testing

- After rebasing, Xcode 26.5 full parallel suites passed through `scripts/run_tests.sh` on macOS and on iPhone 17 / iOS 26.5, excluding the shared-cache integration class.
- After rebasing, all six shared-cache integration tests passed through the shared runner in separate serial runs on both platforms. ShellCheck, workflow YAML/shell syntax, and strict SwiftLint also passed.
- The earlier full parallel and serial iOS 18.6 runs also passed before updating to the latest main.
- Strict SwiftLint, whitespace checks, YAML parsing, and shell syntax checks for every workflow run block passed.
- Direct coverage includes unsupported and dynamic colors, patterns, device/custom spaces, all nine supported spaces, grayscale, alpha, exact component bits, signed zero, nonfinite inputs, clearing every store, operation names, and operand order.
- RGB, HSL, and LAB interpolation at 0.5001 and 0.5004 matches each cold baseline exactly in both call orders.
- In a temporary copy of the original implementation, the three targeted regressions for unsupported identities, color-space collisions, and nearby interpolation amounts all failed as expected. The only baseline adjustment allowed tests to construct an independent cache.

