### PR TITLE
fix(tests): Centralize test execution and report pipeline failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,34 +66,24 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-xcode-26.5-derived-data-
 
       - name: Build and Test iOS
+        id: ios_tests
         run: |
           mkdir -p TestResults
-          xcodebuild test \
-            -scheme ColorKit \
-            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
-            -parallel-testing-enabled YES \
-            -parallel-testing-worker-count 4 \
-            -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
+          scripts/run_tests.sh --log-file TestResults/iOS.log \
+            iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
             -resultBundlePath TestResults/iOS.xcresult \
-            -enableCodeCoverage YES \
             -skipPackagePluginValidation \
-            -skipMacroValidation \
-            | tee TestResults/iOS.log
+            -skipMacroValidation
 
       - name: Build and Test macOS
+        if: ${{ !cancelled() && (steps.ios_tests.outcome == 'success' || steps.ios_tests.outcome == 'failure') }}
         run: |
           mkdir -p TestResults
-          xcodebuild test \
-            -scheme ColorKit \
-            -destination 'platform=macOS' \
-            -parallel-testing-enabled YES \
-            -parallel-testing-worker-count 4 \
-            -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
+          scripts/run_tests.sh --log-file TestResults/macOS.log \
+            macOS 'platform=macOS' \
             -resultBundlePath TestResults/macOS.xcresult \
-            -enableCodeCoverage YES \
             -skipPackagePluginValidation \
-            -skipMacroValidation \
-            | tee TestResults/macOS.log
+            -skipMacroValidation
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,48 +1,93 @@
 #!/bin/bash
 
-# Colors for output
-GREEN='\033[0;32m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+set -o pipefail
 
-echo "🚀 Running ColorKit Tests..."
+usage() {
+    cat <<'EOF'
+Usage: scripts/run_tests.sh [--log-file path] platform destination [xcodebuild-options...]
+       scripts/run_tests.sh
 
-# Function to run tests
+With no arguments, run both iOS and macOS tests and report both results.
+With a platform label and destination, run only that destination. Additional
+arguments are passed unchanged to xcodebuild after the shared test options.
+Use --log-file to save raw output with tee instead of formatting with xcpretty;
+the log's parent directory must already exist. This requires a single platform.
+
+Examples:
+  scripts/run_tests.sh
+  scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 16 Pro'
+  scripts/run_tests.sh macOS 'platform=macOS,arch=arm64' -skipMacroValidation
+  scripts/run_tests.sh --log-file macOS.log macOS 'platform=macOS'
+
+Requires xcodebuild and xcpretty (or tee with --log-file). Exit status is 0 only
+when every test command and output command succeeds, 1 on execution failure,
+and 2 on invalid arguments. Use --help to show this message.
+EOF
+}
+
 run_tests() {
-    platform=$1
-    destination=$2
-    
-    echo -e "\n${GREEN}Running tests for $platform...${NC}"
-    
+    local platform=$1
+    local destination=$2
+    local statuses
+    shift 2
+
+    printf '\nRunning tests for %s...\n' "$platform"
+
     if xcodebuild test \
         -scheme ColorKit \
         -destination "$destination" \
         -parallel-testing-enabled YES \
         -parallel-testing-worker-count 4 \
-        -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
+        -derivedDataPath "$HOME/Library/Developer/Xcode/DerivedData" \
         -enableCodeCoverage YES \
-        | xcpretty; then
-        echo -e "${GREEN}✅ $platform tests passed${NC}"
+        "$@" \
+        | "${output_command[@]}"; then
+        printf '%s tests passed\n' "$platform"
         return 0
     else
-        echo -e "${RED}❌ $platform tests failed${NC}"
+        # Capture both statuses before another command overwrites PIPESTATUS.
+        statuses=("${PIPESTATUS[@]}")
+        printf '%s test run failed (xcodebuild: %s, %s: %s)\n' \
+            "$platform" "${statuses[0]}" "${output_command[0]}" "${statuses[1]}" >&2
         return 1
     fi
 }
 
-# Run iOS tests
+if [[ $# -eq 1 && $1 == --help ]]; then
+    usage
+    exit 0
+fi
+
+output_command=(xcpretty)
+if [[ ${1:-} == --log-file ]]; then
+    if [[ $# -lt 4 || -z $2 || $2 == -* ]]; then
+        usage >&2
+        exit 2
+    fi
+    output_command=(tee "$2")
+    shift 2
+fi
+
+if [[ $# -gt 0 ]]; then
+    if [[ $# -lt 2 || -z $1 || -z $2 || $1 == -* || $2 == -* ]]; then
+        usage >&2
+        exit 2
+    fi
+    run_tests "$@"
+    exit $?
+fi
+
 ios_result=0
 run_tests "iOS" "platform=iOS Simulator,name=iPhone 16 Pro" || ios_result=$?
 
-# Run macOS tests
 macos_result=0
 run_tests "macOS" "platform=macOS,arch=arm64" || macos_result=$?
 
-# Check if any tests failed
-if [ $ios_result -eq 0 ] && [ $macos_result -eq 0 ]; then
-    echo -e "\n${GREEN}✅ All tests passed successfully!${NC}"
+if [[ $ios_result -eq 0 && $macos_result -eq 0 ]]; then
+    printf '\nAll tests passed successfully!\n'
     exit 0
 else
-    echo -e "\n${RED}❌ Some tests failed${NC}"
+    printf '\nSome test runs failed (iOS: %s, macOS: %s)\n' \
+        "$ios_result" "$macos_result" >&2
     exit 1
-fi 
+fi


### PR DESCRIPTION
## Summary

The local runner could report success when `xcodebuild` failed because it only
checked the formatter's exit status. CI also maintained a separate copy of the
test command and skipped macOS after an iOS failure.

This implements F02/S16 by making `scripts/run_tests.sh` the shared execution
owner, requiring both pipeline commands to succeed, and retaining both platform
results.

## Changes

- Centralize the scheme, parallel testing, DerivedData path, and coverage options
  in the existing runner. CI supplies its destinations, validation flags, and
  result bundle paths.
- Preserve no-argument local runs of both platforms. Add explicit single-platform
  invocation and `--log-file` for CI's existing raw logs through `tee`.
- Enable `pipefail` and capture both command statuses immediately on failure.
  Report producer and formatter/log-writer failures separately and return failure
  if either command fails.
- Keep separate CI platform steps; attempt macOS after iOS failure while skipping
  it after setup failure or cancellation. A failed iOS step still fails the job.
- Document usage and exit statuses in `--help`; simplify status output and remove
  redundant comments. Only the runner and workflow change.

## Alternatives considered

Adding only `pipefail` would leave duplicated commands and skipped platform
results. Requiring xcpretty in CI would restore a dependency removed by the
current workflow, so the runner supports its existing raw-log output. A matrix
or a larger test framework would exceed this change's scope.

## Notes

- Based on current `main`, including its Xcode 26.5/macOS 26 runner update.
- Local default destinations remain unchanged. CI retains the iPhone 17/iOS 26.5
  destination and its architecture-independent macOS destination.
- `TestResults/iOS.log`, `TestResults/macOS.log`, both explicit `.xcresult` paths,
  artifact upload conditions, and 14-day retention remain unchanged.
- Independent standards and spec reviews found no actionable issues.

## Screenshots

Not applicable; no UI changes.

## Testing

- 145 temporary stubbed executions passed: producer/output success and failure
  combinations, first-platform failure with second-platform execution, normal
  and strict Bash modes, single-platform selection, argument quoting, invalid
  arguments, early formatter exit, missing commands, real `tee` file failure,
  and both workflow shell bodies. The harness also reproduces the original
  false-success bug and compares CI Xcode arguments with the previous workflow.
- Real Xcode 26.5 tests through the shared runner passed locally: 97 iOS tests on
  iPhone 17/iOS 26.5 and 94 macOS tests. Both result bundles contain coverage
  reports. Local verification used temporary artifact paths.
- An additional real macOS run through xcpretty also passed.
- `swiftlint lint --strict`: zero violations in 64 files.
- `bash -n scripts/run_tests.sh`, `shellcheck scripts/run_tests.sh`, YAML parsing,
  and `git diff --check` passed.
- [Hosted CI passed](https://github.com/agisilaos/ColorKit/actions/runs/33306963749):
  iOS tests, macOS tests, strict SwiftLint, and test-result artifact upload all
  completed successfully.
