### PR TITLE
fix(wcag): Choose the strongest contrasting endpoint

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,6 +25,10 @@ A contrast adjustment attempt that ends without finding a color that meets the r
 The black or white color selected when contrast adjustment is unsuccessful. It is not guaranteed to meet every requested minimum.
 _Avoid_: Guaranteed compliant color
 
+**Best available contrasting endpoint**:
+Whichever of black or white has the greater WCAG contrast ratio against a given color. This choice may still fall short of the requested contrast level, including AAA.
+_Avoid_: Guaranteed compliant color
+
 **LAB**:
 CIE L*a*b* coordinates relative to a reference white: L* describes lightness, a* the green–red axis, and b* the blue–yellow axis. ColorKit uses D65 as the reference white.
 _Avoid_: RGB brightness when referring to L*.

--- a/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
+++ b/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
@@ -144,16 +144,14 @@ public extension Color {
         return generator.generateAccessibleTheme(from: self, name: name)
     }
 
-    /// Finds a color that contrasts well with this color and meets the specified WCAG level.
+    /// Returns the best available contrasting endpoint, either black or white.
     ///
-    /// This method generates a contrasting color that ensures readability when used
-    /// together with the base color. It's particularly useful for text colors
-    /// or UI elements that need to stand out against a background.
+    /// Compares both endpoints using `wcagContrastRatio(with:)` and returns the one
+    /// with the higher ratio. Exact ties return black.
     ///
-    /// The method follows these steps:
-    /// 1. Checks if black or white provides sufficient contrast
-    /// 2. If not, creates a new color by adjusting lightness
-    /// 3. Falls back to black or white if other attempts fail
+    /// The result is independent of the requested level: the stronger endpoint is
+    /// returned even when neither meets the target. In particular, AAA may be
+    /// unattainable. Color resolution follows the existing WCAG calculation.
     ///
     /// Example:
     /// ```swift
@@ -170,35 +168,12 @@ public extension Color {
     ///     .background(backgroundColor)
     /// ```
     ///
-    /// - Parameter level: The WCAG level to target
-    /// - Returns: A color that contrasts well with this color
+    /// - Parameter level: The desired WCAG level (default: .AA), retained for API
+    ///   compatibility. Meeting this level is not guaranteed.
+    /// - Returns: Black or white, whichever provides the greater WCAG contrast ratio.
     func accessibleContrastingColor(for level: WCAGContrastLevel = .AA) -> Color {
-        // Get the luminance of this color
-        let luminance = self.wcagRelativeLuminance()
-
-        // Start with black or white based on luminance
-        let contrastingColor: Color = luminance < 0.5 ? .white : .black
-
-        // Check if the contrast is sufficient
-        let ratio = self.wcagContrastRatio(with: contrastingColor)
-        if ratio >= level.minimumRatio {
-            return contrastingColor
-        }
-
-        // If not, try to find a color with sufficient contrast
-        // Extract HSL components
-        guard let hsl = self.hslComponents() else {
-            // Fallback to black or white if HSL conversion fails
-            return luminance < 0.5 ? .white : .black
-        }
-
-        // Adjust lightness to ensure sufficient contrast
-        let targetLightness = luminance < 0.5 ? 0.9 : 0.1
-
-        return Color(
-            hue: hsl.hue,
-            saturation: hsl.saturation,
-            lightness: targetLightness
-        )
+        let blackRatio = wcagContrastRatio(with: .black)
+        let whiteRatio = wcagContrastRatio(with: .white)
+        return blackRatio >= whiteRatio ? .black : .white
     }
 }

--- a/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
@@ -141,6 +141,65 @@ final class ColorCacheIntegrationTests: XCTestCase {
         }
     }
 
+    func testContrastingEndpointMatchesWithColdAndWarmCachesInBothOrders() throws {
+        let cases: [(color: Color, expected: Color)] = try [
+            (cacheTestColor(components: [0.46, 0.46, 0.46, 1]), .white),
+            (cacheTestColor(components: [0.461, 0.461, 0.461, 1]), .black),
+            (cacheTestColor(components: [0.5, 0.5, 0.5, 1]), .black),
+            (cacheTestColor(components: [1, 0, 0, 1]), .black),
+            (cacheTestColor(components: [0, 0, 1, 1]), .white)
+        ]
+
+        for (color, expected) in cases {
+            for level in WCAGContrastLevel.allCases {
+                ColorCache.shared.clearCache()
+                XCTAssertNil(ColorCache.shared.getCachedContrastRatio(for: color, with: .black))
+                XCTAssertNil(ColorCache.shared.getCachedContrastRatio(for: color, with: .white))
+
+                XCTAssertEqual(color.accessibleContrastingColor(for: level), expected)
+
+                XCTAssertNotNil(ColorCache.shared.getCachedContrastRatio(for: color, with: .black))
+                XCTAssertNotNil(ColorCache.shared.getCachedContrastRatio(for: color, with: .white))
+                XCTAssertEqual(color.accessibleContrastingColor(for: level), expected)
+            }
+        }
+
+        for order in [cases, Array(cases.reversed())] {
+            ColorCache.shared.clearCache()
+            for (color, _) in order {
+                // Populate the symmetric contrast keys through the reverse call direction.
+                _ = Color.white.wcagContrastRatio(with: color)
+                _ = Color.black.wcagContrastRatio(with: color)
+            }
+            for (color, expected) in order {
+                for level in WCAGContrastLevel.allCases {
+                    XCTAssertEqual(color.accessibleContrastingColor(for: level), expected)
+                }
+            }
+        }
+    }
+
+    func testContrastingEndpointBreaksExactRatioTiesWithoutRounding() throws {
+        let color = try cacheTestColor(components: [0.4603, 0.4603, 0.4603, 1])
+        let ratio = sqrt(21.0)
+        let cases: [(blackRatio: Double, expected: Color)] = [
+            (ratio.nextDown, .white), (ratio, .black), (ratio.nextUp, .black)
+        ]
+
+        // Seed ratios to exercise exact equality and adjacent Doubles independently
+        // of platform color conversion rounding at the luminance crossover.
+        for (blackRatio, expected) in cases {
+            ColorCache.shared.cacheContrastRatio(for: color, with: .black, ratio: blackRatio)
+            ColorCache.shared.cacheContrastRatio(for: color, with: .white, ratio: ratio)
+            XCTAssertEqual(color.wcagContrastRatio(with: .black), blackRatio)
+            XCTAssertEqual(color.wcagContrastRatio(with: .white), ratio)
+
+            for level in WCAGContrastLevel.allCases {
+                XCTAssertEqual(color.accessibleContrastingColor(for: level), expected)
+            }
+        }
+    }
+
     private func conversionValues(_ color: Color, other: Color) -> [Double?] {
         let lab = color.labComponents()
         let hsl = color.hslComponents()

--- a/Tests/ColorKitTests/WCAG/AccessibleContrastingColorTests.swift
+++ b/Tests/ColorKitTests/WCAG/AccessibleContrastingColorTests.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class AccessibleContrastingColorTests: XCTestCase {
+    func testMiddleGraysChooseStrongerEndpointForEveryLevel() {
+        let cases: [(gray: Double, expected: Color)] = [
+            (0.4, .white), (0.46, .white), (0.461, .black),
+            (0.5, .black), (0.6, .black), (0.7, .black)
+        ]
+
+        for (gray, expected) in cases {
+            let color = Color(.sRGB, red: gray, green: gray, blue: gray)
+            assertStrongestEndpoint(for: color, expected: expected)
+        }
+    }
+
+    func testSaturatedColorsChooseStrongerEndpointForEveryLevel() {
+        let cases: [(color: Color, expected: Color)] = [
+            (Color(.sRGB, red: 1, green: 0, blue: 0), .black),
+            (Color(.sRGB, red: 0, green: 1, blue: 0), .black),
+            (Color(.sRGB, red: 0, green: 0, blue: 1), .white),
+            (Color(.sRGB, red: 0, green: 1, blue: 1), .black),
+            (Color(.sRGB, red: 1, green: 0, blue: 1), .black),
+            (Color(.sRGB, red: 1, green: 1, blue: 0), .black)
+        ]
+
+        for (color, expected) in cases {
+            assertStrongestEndpoint(for: color, expected: expected)
+        }
+    }
+
+    func testExtremesChooseOppositeEndpointForEveryLevel() {
+        assertStrongestEndpoint(for: .black, expected: .white)
+        assertStrongestEndpoint(for: .white, expected: .black)
+        for (gray, expected): (Double, Color) in [(0.0001, .white), (0.9999, .black)] {
+            let color = Color(.sRGB, red: gray, green: gray, blue: gray)
+            assertStrongestEndpoint(for: color, expected: expected)
+        }
+    }
+
+    func testUnattainableAAAReturnsBestEndpointWithoutTinting() {
+        for (gray, expected): (Double, Color) in [(0.45, .white), (0.5, .black)] {
+            let color = Color(.sRGB, red: gray, green: gray, blue: gray)
+            XCTAssertLessThan(color.wcagContrastRatio(with: .black), WCAGContrastLevel.AAA.minimumRatio)
+            XCTAssertLessThan(color.wcagContrastRatio(with: .white), WCAGContrastLevel.AAA.minimumRatio)
+
+            let result = color.accessibleContrastingColor(for: .AAA)
+
+            XCTAssertEqual(result, expected)
+            XCTAssertFalse(color.wcagCompliance(with: result).passesAAA)
+            assertStrongestEndpoint(for: color, expected: expected)
+        }
+    }
+
+    func testSuggestedColorKeepsItsExistingHeuristic() {
+        let color = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5)
+
+        for level in WCAGContrastLevel.allCases {
+            XCTAssertEqual(color.suggestedColor(for: level), .white)
+            XCTAssertEqual(color.accessibleContrastingColor(for: level), .black)
+        }
+    }
+
+    private func assertStrongestEndpoint(
+        for color: Color, expected: Color,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        let blackRatio = color.wcagContrastRatio(with: .black)
+        let whiteRatio = color.wcagContrastRatio(with: .white)
+        XCTAssertEqual(color.accessibleContrastingColor(), expected, file: file, line: line)
+        for level in WCAGContrastLevel.allCases {
+            let result = color.accessibleContrastingColor(for: level)
+
+            XCTAssertEqual(result, expected, "Level: \(level)", file: file, line: line)
+            XCTAssertEqual(color.wcagContrastRatio(with: result), max(blackRatio, whiteRatio), file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix F10: `accessibleContrastingColor(for:)` now returns whichever of black and white has the greater WCAG contrast ratio. The previous luminance heuristic could choose the weaker endpoint and then fall back to an unchecked tint.

## Changes

- Compare both endpoints using the existing WCAG calculation; return black on exact ties, without a tolerance.
- Preserve the public signature and default level. Document best available contrast, including when AAA is unattainable.
- Add seven focused tests covering middle grays, saturated colors, extremes, unattainable targets, exact and near ties, all contrast levels, and cold/warm caches in both call orders.
- Keep `suggestedColor(for:)`, color resolution, and the cache implementation unchanged.

## Alternatives considered

Keeping the luminance heuristic or adjusting lightness would not reliably select the strongest endpoint. Changing color resolution or the separate suggestion API would broaden F10 beyond its requested scope. Exact-tie tests seed cached ratios because platform color conversion can round a computed gray away from an exact tie.

## Notes

The requested level remains in the API for compatibility; it does not change which endpoint is strongest and is not a compliance guarantee. Shared-cache tests stay in the existing serial integration suite. Independent Standards and Spec reviews found no actionable issues.

The commits separate the behavior fix, documentation, and core regression tests from the cache and tie boundary tests.

## Screenshots

Not applicable; no UI changes.

## Testing

- Full macOS suite: 136 tests passed.
- Full iOS 26.5 suite on iPhone 17: 139 tests passed.
- Both suites ran serially, including shared-cache integration tests.
- `swiftlint lint --strict`: passed with zero violations.
- `git diff --check`: passed.

Commands:

```sh
scripts/run_tests.sh --log-file /tmp/colorkit-f10-macos-full.log \
  macOS 'platform=macOS,arch=arm64' -parallel-testing-enabled NO \
  -skipPackagePluginValidation -skipMacroValidation
scripts/run_tests.sh --log-file /tmp/colorkit-f10-ios-full.log \
  iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
  -parallel-testing-enabled NO -skipPackagePluginValidation -skipMacroValidation
swiftlint lint --strict
```
