### PR TITLE
doc(agents): Configure engineering skill workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live in GitHub Issues for `agisilaos/ColorKit`; external PRs are also a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, and `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: root `CONTEXT.md` and `docs/adr/`, created as needed. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,26 @@
+# Domain docs
+
+ColorKit uses a single-context layout. This file tells engineering skills how to consume its domain documentation.
+
+## Before exploring
+
+- Read `CONTEXT.md` at the repository root for domain terminology.
+- Read relevant architectural decision records (ADRs) under root `docs/adr/` before working in the affected area.
+
+If either is missing, proceed silently. Do not flag the absence or suggest creating placeholder documents. The `domain-modeling` skill, also used by `grill-with-docs` and `improve-codebase-architecture`, creates them when terminology or architectural decisions are resolved.
+
+## File structure
+
+- `CONTEXT.md`: shared domain language for the repository.
+- `docs/adr/`: repository-wide architectural decisions, with numbered Markdown records.
+- `Sources/`: Swift package source code using this shared context.
+
+Do not create separate contexts for the library, examples, or demo app as part of this setup. If the repository later adopts multiple contexts, update these instructions to use a root `CONTEXT-MAP.md` pointing to the relevant context files and ADR directories.
+
+## Use the glossary's vocabulary
+
+Use the terms defined in `CONTEXT.md` in issue titles, refactor proposals, hypotheses, and test names. Avoid synonyms the glossary rejects. If a concept is missing, reconsider whether the project uses it or note the gap for `domain-modeling`.
+
+## Flag ADR conflicts
+
+Explicitly identify any existing ADR your proposal contradicts and explain why reopening the decision is warranted. Do not silently override recorded decisions.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,55 @@
+# Issue tracker: GitHub
+
+Issues and PRDs live in GitHub Issues for `agisilaos/ColorKit`. Use the `gh` CLI for all operations. Run it inside this clone so it infers the repository from the git remote, or pass `--repo agisilaos/ColorKit` explicitly. For `gh api`, use `repos/agisilaos/ColorKit/...` endpoints.
+
+## Conventions
+
+- Create an issue: `gh issue create --title "..." --body-file <path>`.
+- Read an issue: `gh issue view <number> --json number,title,body,labels,comments`.
+- List issues: `gh issue list --state open --limit 100 --json number,title,body,labels,comments`, with appropriate label and state filters. Increase the limit or paginate via `gh api` when the queue exceeds it.
+- Comment on an issue: `gh issue comment <number> --body-file <path>`.
+- Apply or remove labels: `gh issue edit <number> --add-label "..." --remove-label "..."`.
+- Close an issue: `gh issue close <number>`; post any resolution comment separately.
+
+Write multiline issue bodies and comments to a temporary UTF-8 file and pass it with `--body-file`. Preserve real newlines and literal text. Follow the current task's authorization before publishing issues or comments.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: yes.**
+
+External PRs use the same triage labels and states as issues. Exclude authors with `OWNER`, `MEMBER`, or `COLLABORATOR` association so collaborators' in-flight work stays out of this queue.
+
+List external PRs with:
+
+    gh api --paginate 'repos/agisilaos/ColorKit/pulls?state=open&per_page=100' \
+      --jq '.[] | select(.author_association == "CONTRIBUTOR" or .author_association == "FIRST_TIME_CONTRIBUTOR" or .author_association == "FIRST_TIMER" or .author_association == "NONE") | {number,title,author: .user.login,author_association,labels: [.labels[].name]}'
+
+Use the API for this filter: `gh pr list --json` does not expose author association in the installed CLI. Leave unknown association values for human review rather than guessing.
+
+- Read a PR and its discussion: `gh pr view <number> --comments`.
+- Read its labels and body: `gh pr view <number> --json number,title,body,labels,author`.
+- Inspect its code: `gh pr diff <number>`.
+- Comment: `gh pr comment <number> --body-file <path>`.
+- Apply or remove labels: `gh pr edit <number> --add-label "..." --remove-label "..."`.
+- Close: `gh pr close <number>`.
+
+Issues and PRs share a number space. For an ambiguous `#<number>`, read `gh api repos/agisilaos/ColorKit/issues/<number>`; the presence of `pull_request` identifies a PR. Surface authentication or network errors instead of interpreting them as an issue type.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Resolve whether the number is an issue or PR, then read its body, labels, and discussion using the commands above.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The map is one GitHub issue with child issues as tickets.
+
+- Map: label the map issue `wayfinder:map`; its body holds Notes, Decisions-so-far, and Fog.
+- Child ticket: link it to the map using GitHub sub-issues through `gh api`. If sub-issues are unavailable, add it to the map's task list and put `Part of #<map>` at the top of its body. Use `wayfinder:research`, `wayfinder:prototype`, `wayfinder:grilling`, or `wayfinder:task` as appropriate. Create these labels when needed; they are separate from the five triage labels.
+- Blocking: use native GitHub issue dependencies. Add a dependency with `gh api --method POST repos/agisilaos/ColorKit/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-database-id>`. Fetch the database ID using `gh api repos/agisilaos/ColorKit/issues/<blocker-number> --jq .id`; do not use the issue number or node ID. If dependencies are unavailable, use a `Blocked by: #<number>, #<number>` line in the child body. A ticket is unblocked when all blockers are closed.
+- Frontier: inspect the map's open children in map order. Skip assigned tickets and those with open blockers (`issue_dependencies_summary.blocked_by > 0`, or open issues named in the fallback line). The first remaining child is next.
+- Claim: `gh issue edit <number> --add-assignee @me` is the wayfinding session's first write.
+- Resolve: post the answer with `gh issue comment <number> --body-file <path>`, close the child issue, and append a concise finding and link to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage labels
+
+The engineering skills use five canonical triage roles. Apply the corresponding GitHub label from this table to issues and eligible external PRs.
+
+| Canonical role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate |
+| `needs-info` | `needs-info` | Waiting on the reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified; an agent can implement without additional human context |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill mentions a triage role, use its mapped label. Existing labels such as `bug`, `enhancement`, and `question` remain unchanged; they do not replace these roles.
+
+Edit the GitHub label column if the repository's vocabulary changes, and keep the actual GitHub labels in sync.


### PR DESCRIPTION
## Summary

Engineering skills need repository-specific instructions for tracking work, applying triage labels, and reading domain documentation. Add those conventions for ColorKit so skills use GitHub Issues and the existing shared domain context consistently.

## Changes

- Add `AGENTS.md` linking to the three engineering-skill configuration documents.
- Configure GitHub Issues and external PR triage while excluding owner, member, and collaborator PRs from the intake queue.
- Map the five default triage roles to GitHub labels.
- Document the single-context layout, glossary usage, and handling of missing domain documents or conflicting ADRs.

## Alternatives considered

Local Markdown tracking was rejected in favor of the repository's existing GitHub Issues. Separate domain contexts were unnecessary for this library, and `AGENTS.md` was selected as the root instructions file instead of `CLAUDE.md`.

## Notes

The four missing triage labels have already been created on GitHub; the existing `wontfix` and other labels were preserved. The existing `CONTEXT.md` is unchanged. No placeholder domain files, issues, or PR comments were created. The configuration can be maintained directly in `docs/agents/*.md`.

## Screenshots

Not applicable; no UI changes.

## Testing

- `swiftlint lint --strict`: passed with zero violations across 71 Swift files.
- `scripts/run_tests.sh --log-file <temporary-log> macOS 'platform=macOS' -parallel-testing-enabled NO -skipPackagePluginValidation -skipMacroValidation`: all 146 tests passed, including shared-cache tests run serially.
- `git diff --check origin/main...HEAD`: passed.
- Verified the approved draft, instruction links, all five GitHub labels, preserved domain context, and absence of new TODO/FIXME-style markers.
- iOS tests were not run locally for this documentation-only change.
