### PR TITLE
fix(conversion): resolve Hex and CMYK through fallible sRGBA

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,10 @@ ColorKit describes, compares, blends, and interpolates colors across color space
 
 ## Language
 
+**Resolved sRGBA snapshot**:
+A fixed representation of a color in nonlinear sRGB with separate, unpremultiplied alpha in 0–1. All components are finite; RGB values may extend outside 0–1 to preserve colors beyond the sRGB gamut, and an unavailable conversion has no snapshot.
+_Avoid_: Clamped RGB, color identity
+
 **Unavailable inspector conversion**:
 A color representation or contrast ratio that cannot be obtained from the current color inputs. It is neither a zero value nor a failed contrast threshold, and says nothing about earlier inputs.
 

--- a/Sources/ColorKit/ColorSpaces/Color+CMYK.swift
+++ b/Sources/ColorKit/ColorSpaces/Color+CMYK.swift
@@ -63,6 +63,11 @@ public extension Color {
     /// 2. Calculates CMY values accounting for the black component
     /// 3. Handles special cases like pure black
     ///
+    /// Fixed RGB and grayscale colors are converted to nonlinear sRGB first.
+    /// Unresolved colors, failed conversions, invalid alpha, and RGB outside 0–1
+    /// return `nil` without clipping. Alpha is ignored, with no background compositing.
+    /// This is an arithmetic CMYK approximation, not a printer-profile conversion.
+    ///
     /// Example:
     /// ```swift
     /// let color = Color.blue
@@ -91,10 +96,10 @@ public extension Color {
     ///           yellow (0.0-1.0), and key/black (0.0-1.0), or `nil` if
     ///           conversion fails.
     func cmykComponents() -> (cyan: CGFloat, magenta: CGFloat, yellow: CGFloat, key: CGFloat)? {
-        guard let components = cgColor?.components, components.count >= 3 else { return nil }
-        let r = components[0]
-        let g = components[1]
-        let b = components[2]
+        guard let rgba = ResolvedSRGBA.resolve(self), rgba.isInSRGBGamut else { return nil }
+        let r = rgba.red
+        let g = rgba.green
+        let b = rgba.blue
 
         let k = 1 - max(r, g, b)
 

--- a/Sources/ColorKit/ColorSpaces/Color+Hex.swift
+++ b/Sources/ColorKit/ColorSpaces/Color+Hex.swift
@@ -111,6 +111,9 @@ public extension Color {
     ///
     /// This method converts the color's RGB(A) components to a hexadecimal string
     /// in the format #RRGGBBAA. The alpha channel is always included for consistency.
+    /// Fixed RGB and grayscale colors are converted to nonlinear sRGB first.
+    /// Unresolved colors, failed conversions, invalid alpha, and RGB outside 0–1
+    /// return `nil`; values are not clipped or composited against a background.
     ///
     /// Example:
     /// ```swift
@@ -134,17 +137,8 @@ public extension Color {
     /// - Returns: A hexadecimal string in the format `#RRGGBBAA` representing
     ///           the color, or `nil` if conversion fails.
     func hexValue() -> String? {
-        guard let components = cgColor?.components, components.count >= 3 else { return nil }
-        let r = components[0]
-        let g = components[1]
-        let b = components[2]
-        let a = components.count >= 4 ? components[3] : 1.0
-
-        return String(format: "#%02X%02X%02X%02X",
-                      Int(round(r * 255)),
-                      Int(round(g * 255)),
-                      Int(round(b * 255)),
-                      Int(round(a * 255)))
+        guard let hex = hexComponents() else { return nil }
+        return "#\(hex.red)\(hex.green)\(hex.blue)\(hex.alpha)"
     }
 
     /// Returns the hexadecimal representation of the color.
@@ -171,6 +165,9 @@ public extension Color {
     }
 
     /// Returns the RGBA components of the color as hexadecimal values.
+    ///
+    /// Uses the same fixed-color resolution and failure policy as `hexValue()`.
+    /// Each channel is rounded to the nearest byte; alpha does not alter RGB.
     ///
     /// This method provides access to individual color components in hexadecimal
     /// format, useful for:
@@ -203,17 +200,13 @@ public extension Color {
     /// - Returns: A tuple containing the red, green, blue, and alpha components
     ///           as hexadecimal values, or `nil` if conversion fails.
     func hexComponents() -> (red: String, green: String, blue: String, alpha: String)? {
-        guard let components = cgColor?.components, components.count >= 3 else { return nil }
-        let r = components[0]
-        let g = components[1]
-        let b = components[2]
-        let a = components.count >= 4 ? components[3] : 1.0
+        guard let rgba = ResolvedSRGBA.resolve(self), rgba.isInSRGBGamut else { return nil }
 
         return (
-            red: String(format: "%02X", Int(round(r * 255))),
-            green: String(format: "%02X", Int(round(g * 255))),
-            blue: String(format: "%02X", Int(round(b * 255))),
-            alpha: String(format: "%02X", Int(round(a * 255)))
+            red: String(format: "%02X", Int(round(rgba.red * 255))),
+            green: String(format: "%02X", Int(round(rgba.green * 255))),
+            blue: String(format: "%02X", Int(round(rgba.blue * 255))),
+            alpha: String(format: "%02X", Int(round(rgba.alpha * 255)))
         )
     }
 }

--- a/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
+++ b/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
@@ -64,6 +64,18 @@ if let components = color.labComponents() {
 
 ## Color Space Conversion
 
+Hex and CMYK extraction resolve fixed RGB and grayscale colors to nonlinear sRGB.
+This includes linear RGB and Display P3 inputs; their raw components are not treated
+as sRGB. Hex includes unpremultiplied alpha, and CMYK ignores alpha without compositing
+against a background. CMYK uses an arithmetic approximation, not a printer profile.
+
+These optional methods return `nil` for unresolved appearance-dependent colors,
+patterns, other source color models, failed conversions, nonfinite components, invalid
+alpha, or resolved RGB outside 0–1. They do not clip or apply a range tolerance, even
+when platform conversion produces a tiny overshoot near white. Supply an already-resolved
+fixed color when appearance matters. Existing nonoptional conversion fallbacks and
+cached conversions retain their previous behavior.
+
 ColorKit handles color space conversions automatically. When you create a color in one color space and request components in another, the conversion is done for you:
 
 ```swift

--- a/Sources/ColorKit/Utilities/ResolvedSRGBA.swift
+++ b/Sources/ColorKit/Utilities/ResolvedSRGBA.swift
@@ -1,0 +1,51 @@
+import CoreGraphics
+import SwiftUI
+
+/// A finite, nonlinear sRGB snapshot with unpremultiplied alpha.
+/// RGB may extend beyond 0–1; consumers decide whether that range is representable.
+struct ResolvedSRGBA {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+
+    var isInSRGBGamut: Bool {
+        (0...1).contains(red) && (0...1).contains(green) && (0...1).contains(blue)
+    }
+
+    init?(sRGBComponents components: [CGFloat]) {
+        guard components.count == 4,
+              components.allSatisfy({ $0.isFinite }),
+              (0...1).contains(components[3]) else { return nil }
+        red = components[0]
+        green = components[1]
+        blue = components[2]
+        alpha = components[3]
+    }
+
+    /// Resolves fixed RGB or grayscale inputs without consulting appearance or caches.
+    static func resolve(_ color: Color) -> Self? {
+        guard let source = color.cgColor,
+              let space = source.colorSpace,
+              space.model == .rgb || space.model == .monochrome,
+              let components = source.components,
+              components.count == space.numberOfComponents + 1,
+              components.allSatisfy({ $0.isFinite }),
+              let alpha = components.last,
+              (0...1).contains(alpha),
+              let sRGB = CGColorSpace(name: CGColorSpace.sRGB),
+              let extendedSRGB = CGColorSpace(name: CGColorSpace.extendedSRGB) else { return nil }
+
+        let resolved: [CGFloat]
+        if CFEqual(space, sRGB) || CFEqual(space, extendedSRGB) {
+            // These spaces share an encoding. Avoid conversion drift in existing sRGB values.
+            resolved = components
+        } else {
+            guard let converted = source.converted(to: extendedSRGB, intent: .relativeColorimetric, options: nil),
+                  let convertedComponents = converted.components else { return nil }
+            resolved = convertedComponents
+        }
+
+        return Self(sRGBComponents: resolved)
+    }
+}

--- a/Tests/ColorKitTests/ColorInspector/ColorInspectorPresentationTests.swift
+++ b/Tests/ColorKitTests/ColorInspector/ColorInspectorPresentationTests.swift
@@ -129,13 +129,13 @@ final class ColorInspectorPresentationTests: XCTestCase {
         XCTAssertNil(inspector.presentation.hexValue)
     }
 
-    func testTooFewComponentsAreUnavailable() throws {
+    func testGrayscaleHexIsAvailableWithoutMigratingOtherInspectorFields() throws {
         let color = Color(CGColor(gray: 0.5, alpha: 1))
         XCTAssertEqual(try XCTUnwrap(color.cgColor?.components).count, 2)
 
         let presentation = ColorInspectorView(color: color, backgroundColor: white).presentation
 
-        XCTAssertNil(presentation.hexValue)
+        XCTAssertNotNil(presentation.hexValue)
         XCTAssertNil(presentation.rgbValues)
         XCTAssertNil(presentation.hslValues)
         XCTAssertEqual(presentation.contrast, .unavailable)

--- a/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
@@ -16,8 +16,8 @@ final class ColorCacheIntegrationTests: XCTestCase {
     }
 
     func testNearbyInterpolationAmountsMatchColdResultsInBothCallOrders() throws {
-        let first = try cacheTestColor(components: [0.8, 0.1, 0.2, 1])
-        let second = try cacheTestColor(components: [0.1, 0.6, 0.9, 1])
+        let first = try fixedTestColor(components: [0.8, 0.1, 0.2, 1])
+        let second = try fixedTestColor(components: [0.1, 0.6, 0.9, 1])
         let amounts: [CGFloat] = [0.5001, 0.5004]
         for space: GradientColorSpace in [.rgb, .hsl, .lab] {
             let cold = amounts.map { amount in
@@ -39,9 +39,9 @@ final class ColorCacheIntegrationTests: XCTestCase {
 
     func testColorSpaceOrderDoesNotChangeColdOrWarmConversions() throws {
         let colors = try [CGColorSpace.sRGB, CGColorSpace.linearSRGB, CGColorSpace.displayP3].map {
-            try cacheTestColor(space: $0)
+            try fixedTestColor(space: $0)
         }
-        let other = try cacheTestColor(components: [0.9, 0.8, 0.7, 1])
+        let other = try fixedTestColor(components: [0.9, 0.8, 0.7, 1])
         let cold = colors.map { color in
             ColorCache.shared.clearCache()
             return conversionValues(color, other: other)
@@ -58,8 +58,8 @@ final class ColorCacheIntegrationTests: XCTestCase {
     }
 
     func testBlendAndInterpolationPreserveOperandOrderWhenWarm() throws {
-        let first = try cacheTestColor(components: [0.8, 0.1, 0.2, 1])
-        let second = try cacheTestColor(components: [0.1, 0.6, 0.9, 0.5])
+        let first = try fixedTestColor(components: [0.8, 0.1, 0.2, 1])
+        let second = try fixedTestColor(components: [0.1, 0.6, 0.9, 0.5])
         let pairs = [(first, second), (second, first)]
         let coldBlends = pairs.map { base, blend in
             ColorCache.shared.clearCache()
@@ -84,9 +84,9 @@ final class ColorCacheIntegrationTests: XCTestCase {
     }
 
     func testGrayscaleFallbacksDoNotChangeWhenCacheIsWarm() throws {
-        let other = try cacheTestColor()
+        let other = try fixedTestColor()
         let grays = try [0.25, 0.75].map { value in
-            try cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [value, 1])
+            try fixedTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [value, 1])
         }
         let cold = grays.map { color in
             ColorCache.shared.clearCache()
@@ -108,7 +108,7 @@ final class ColorCacheIntegrationTests: XCTestCase {
     }
 
     func testUnresolvedColorsKeepTheirFallbacksAfterOtherCalls() throws {
-        let other = try cacheTestColor()
+        let other = try fixedTestColor()
         let colors = [Color.primary, Color.secondary]
         let cold = colors.map { color in
             ColorCache.shared.clearCache()
@@ -130,8 +130,8 @@ final class ColorCacheIntegrationTests: XCTestCase {
     }
 
     func testInterpolationKeepsExistingClampingBeforeCacheLookup() throws {
-        let first = try cacheTestColor()
-        let second = try cacheTestColor(components: [0.8, 0.7, 0.1, 1])
+        let first = try fixedTestColor()
+        let second = try fixedTestColor(components: [0.8, 0.7, 0.1, 1])
         for (amount, clamped): (CGFloat, CGFloat) in [(-0.25, 0), (1.25, 1)] {
             ColorCache.shared.clearCache()
             let cold = first.interpolated(with: second, amount: clamped)
@@ -143,11 +143,11 @@ final class ColorCacheIntegrationTests: XCTestCase {
 
     func testContrastingEndpointMatchesWithColdAndWarmCachesInBothOrders() throws {
         let cases: [(color: Color, expected: Color)] = try [
-            (cacheTestColor(components: [0.46, 0.46, 0.46, 1]), .white),
-            (cacheTestColor(components: [0.461, 0.461, 0.461, 1]), .black),
-            (cacheTestColor(components: [0.5, 0.5, 0.5, 1]), .black),
-            (cacheTestColor(components: [1, 0, 0, 1]), .black),
-            (cacheTestColor(components: [0, 0, 1, 1]), .white)
+            (fixedTestColor(components: [0.46, 0.46, 0.46, 1]), .white),
+            (fixedTestColor(components: [0.461, 0.461, 0.461, 1]), .black),
+            (fixedTestColor(components: [0.5, 0.5, 0.5, 1]), .black),
+            (fixedTestColor(components: [1, 0, 0, 1]), .black),
+            (fixedTestColor(components: [0, 0, 1, 1]), .white)
         ]
 
         for (color, expected) in cases {
@@ -180,7 +180,7 @@ final class ColorCacheIntegrationTests: XCTestCase {
     }
 
     func testContrastingEndpointBreaksExactRatioTiesWithoutRounding() throws {
-        let color = try cacheTestColor(components: [0.4603, 0.4603, 0.4603, 1])
+        let color = try fixedTestColor(components: [0.4603, 0.4603, 0.4603, 1])
         let ratio = sqrt(21.0)
         let cases: [(blackRatio: Double, expected: Color)] = [
             (ratio.nextDown, .white), (ratio, .black), (ratio.nextUp, .black)

--- a/Tests/ColorKitTests/Utilities/ColorCacheTestSupport.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheTestSupport.swift
@@ -3,24 +3,6 @@ import XCTest
 
 @testable import ColorKit
 
-func cacheTestColor(
-    space name: CFString = CGColorSpace.sRGB,
-    components: [CGFloat] = [0.2, 0.4, 0.6, 0.8]
-) throws -> Color {
-    let space = try XCTUnwrap(CGColorSpace(name: name))
-    return try cacheTestColor(space: space, components: components)
-}
-
-func cacheTestColor(space: CGColorSpace, components: [CGFloat]) throws -> Color {
-    let cgColor = try XCTUnwrap(CGColor(colorSpace: space, components: components))
-    let color = Color(cgColor)
-    let represented = try XCTUnwrap(color.cgColor)
-    XCTAssertTrue(CFEqual(try XCTUnwrap(represented.colorSpace), space))
-    let representedBits = try XCTUnwrap(represented.components).map { Double($0).bitPattern }
-    XCTAssertEqual(representedBits, components.map { Double($0).bitPattern })
-    return color
-}
-
 func assertCacheColorEqual(
     _ actual: Color?, _ expected: Color,
     file: StaticString = #filePath, line: UInt = #line

--- a/Tests/ColorKitTests/Utilities/ColorCacheTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class ColorCacheTests: XCTestCase {
     func testSupportedSpacesHaveSeparateEntriesInEveryStore() throws {
         let cache = ColorCache()
-        let other = try cacheTestColor(components: [0.9, 0.1, 0.3, 1])
+        let other = try fixedTestColor(components: [0.9, 0.1, 0.3, 1])
         let names = [
             CGColorSpace.sRGB, CGColorSpace.linearSRGB, CGColorSpace.extendedSRGB,
             CGColorSpace.extendedLinearSRGB, CGColorSpace.displayP3,
@@ -15,7 +15,7 @@ final class ColorCacheTests: XCTestCase {
         ]
         let colors = try names.map { name in
             let space = try XCTUnwrap(CGColorSpace(name: name))
-            return try cacheTestColor(space: space, components: space.model == .rgb ? [0.2, 0.4, 0.6, 0.8] : [0.2, 0.8])
+            return try fixedTestColor(space: space, components: space.model == .rgb ? [0.2, 0.4, 0.6, 0.8] : [0.2, 0.8])
         }
 
         for (index, color) in colors.enumerated() {
@@ -29,13 +29,13 @@ final class ColorCacheTests: XCTestCase {
 
     func testGrayscaleComponentsAndAlphaAreNotAliasedToRGB() throws {
         let cache = ColorCache()
-        let other = try cacheTestColor()
+        let other = try fixedTestColor()
         let colors = try [
-            cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.25, 1]),
-            cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.75, 1]),
-            cacheTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.25, 0.5]),
-            cacheTestColor(components: [0.25, 0.25, 0.25, 1]),
-            cacheTestColor(components: [0.25, 0.25, 0.25, 0.5])
+            fixedTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.25, 1]),
+            fixedTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.75, 1]),
+            fixedTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [0.25, 0.5]),
+            fixedTestColor(components: [0.25, 0.25, 0.25, 1]),
+            fixedTestColor(components: [0.25, 0.25, 0.25, 0.5])
         ]
         for (index, color) in colors.enumerated() {
             XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
@@ -47,7 +47,7 @@ final class ColorCacheTests: XCTestCase {
     }
 
     func testUnsupportedColorsMissAndCannotInsertInAnyStore() throws {
-        let supported = try cacheTestColor()
+        let supported = try fixedTestColor()
         #if canImport(AppKit)
         let dynamic = Color(NSColor(name: nil) { _ in .red })
         #else
@@ -57,10 +57,10 @@ final class ColorCacheTests: XCTestCase {
         let customSpace = try XCTUnwrap(CGColorSpace(calibratedGrayWhitePoint: [0.9505, 1, 1.089], blackPoint: nil, gamma: 1.8))
         let unsupported = try [
             Color.primary, Color.secondary, dynamic,
-            cacheTestColor(space: CGColorSpace.adobeRGB1998),
-            cacheTestColor(space: CGColorSpaceCreateDeviceRGB(), components: [0.2, 0.4, 0.6, 0.8]),
-            cacheTestColor(space: CGColorSpaceCreateDeviceGray(), components: [0.2, 0.8]),
-            cacheTestColor(space: customSpace, components: [0.2, 0.8])
+            fixedTestColor(space: CGColorSpace.adobeRGB1998),
+            fixedTestColor(space: CGColorSpaceCreateDeviceRGB(), components: [0.2, 0.4, 0.6, 0.8]),
+            fixedTestColor(space: CGColorSpaceCreateDeviceGray(), components: [0.2, 0.8]),
+            fixedTestColor(space: customSpace, components: [0.2, 0.8])
         ]
         XCTAssertNil(Color.primary.cgColor)
         XCTAssertNil(Color.secondary.cgColor)
@@ -80,30 +80,9 @@ final class ColorCacheTests: XCTestCase {
     }
 
     func testPatternColorCannotUseAnOrdinaryColorEntry() throws {
-        var callbacks = CGPatternCallbacks(
-            version: 0,
-            drawPattern: { _, context in
-                context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
-                context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
-            },
-            releaseInfo: nil
-        )
-        let pattern = try XCTUnwrap(CGPattern(
-            info: nil,
-            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
-            matrix: .identity,
-            xStep: 1,
-            yStep: 1,
-            tiling: .constantSpacing,
-            isColored: true,
-            callbacks: &callbacks
-        ))
-        let space = try XCTUnwrap(CGColorSpace(patternBaseSpace: nil))
-        let cgColor = try XCTUnwrap(CGColor(patternSpace: space, pattern: pattern, components: [1]))
-        let color = Color(cgColor)
-        XCTAssertEqual(color.cgColor?.colorSpace?.model, .pattern)
+        let color = try patternTestColor()
         let cache = ColorCache()
-        let other = try cacheTestColor()
+        let other = try fixedTestColor()
         populateCache(cache, color: other, other: other)
         populateCache(cache, color: color, other: other)
         XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
@@ -114,10 +93,10 @@ final class ColorCacheTests: XCTestCase {
 
     func testFiniteComponentBitsRemainDistinct() throws {
         let cache = ColorCache()
-        let other = try cacheTestColor()
+        let other = try fixedTestColor()
         let values: [CGFloat] = [-0.0, 0.0, 0.5001, 0.5004, -0.25, 1.25]
         let colors = try values.map { value in
-            try cacheTestColor(space: CGColorSpace.extendedSRGB, components: [value, 0.2, 0.3, 1])
+            try fixedTestColor(space: CGColorSpace.extendedSRGB, components: [value, 0.2, 0.3, 1])
         }
         for (index, color) in colors.enumerated() {
             XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
@@ -129,9 +108,9 @@ final class ColorCacheTests: XCTestCase {
     }
 
     func testNonfiniteComponentsBypassEveryStore() throws {
-        let other = try cacheTestColor()
+        let other = try fixedTestColor()
         for value: CGFloat in [.nan, .infinity, -.infinity] {
-            let color = try cacheTestColor(space: CGColorSpace.extendedSRGB, components: [value, 0.2, 0.3, 1])
+            let color = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: [value, 0.2, 0.3, 1])
             let cache = ColorCache()
             populateCache(cache, color: color, other: other)
             XCTAssertEqual(cachePresence(cache, color: color, other: other), Array(repeating: false, count: 6))
@@ -142,8 +121,8 @@ final class ColorCacheTests: XCTestCase {
 
     func testContrastIsSymmetricButBlendAndInterpolationAreOrdered() throws {
         let cache = ColorCache()
-        let first = try cacheTestColor(components: [0.8, 0.1, 0.2, 1])
-        let second = try cacheTestColor(components: [0.2, 0.6, 0.9, 0.5])
+        let first = try fixedTestColor(components: [0.8, 0.1, 0.2, 1])
+        let second = try fixedTestColor(components: [0.2, 0.6, 0.9, 0.5])
         populateCache(cache, color: first, other: second)
         XCTAssertEqual(cache.getCachedContrastRatio(for: second, with: first), 0.25)
         XCTAssertNil(cache.getCachedBlendedColor(color1: second, with: first, blendMode: "normal"))
@@ -158,8 +137,8 @@ final class ColorCacheTests: XCTestCase {
 
     func testOperationNamesAreKeptExact() throws {
         let cache = ColorCache()
-        let first = try cacheTestColor()
-        let second = try cacheTestColor(components: [0.8, 0.7, 0.1, 1])
+        let first = try fixedTestColor()
+        let second = try fixedTestColor(components: [0.8, 0.7, 0.1, 1])
         let names = ["rgb", "RGB", "rgb|hsl", "", "normal"]
         for (index, name) in names.enumerated() {
             let result = index.isMultiple(of: 2) ? first : second
@@ -176,8 +155,8 @@ final class ColorCacheTests: XCTestCase {
     }
 
     func testInterpolationAmountsAreExactInBothInsertionOrders() throws {
-        let first = try cacheTestColor()
-        let second = try cacheTestColor(components: [0.8, 0.7, 0.1, 1])
+        let first = try fixedTestColor()
+        let second = try fixedTestColor(components: [0.8, 0.7, 0.1, 1])
         let amounts: [CGFloat] = [0.5001, 0.5004, -0.0, 0.0, -0.25, 1.25]
         for order in [amounts, amounts.reversed().map { $0 }] {
             let cache = ColorCache()
@@ -193,7 +172,7 @@ final class ColorCacheTests: XCTestCase {
 
     func testNonfiniteInterpolationAmountsCannotInsert() throws {
         let cache = ColorCache()
-        let color = try cacheTestColor()
+        let color = try fixedTestColor()
         for amount: CGFloat in [.nan, .infinity, -.infinity] {
             cache.cacheInterpolatedColor(color1: color, with: color, amount: amount, colorSpace: "rgb", result: color)
             XCTAssertNil(cache.getCachedInterpolatedColor(color1: color, with: color, amount: amount, colorSpace: "rgb"))
@@ -203,7 +182,7 @@ final class ColorCacheTests: XCTestCase {
     }
 
     func testEachClearOnlyRemovesItsOwnStore() throws {
-        let color = try cacheTestColor()
+        let color = try fixedTestColor()
         let clearOperations: [(ColorCache) -> Void] = [
             { $0.clearLABCache() }, { $0.clearHSLCache() }, { $0.clearLuminanceCache() },
             { $0.clearContrastCache() }, { $0.clearBlendedColorCache() }, { $0.clearInterpolatedColorCache() }
@@ -220,7 +199,7 @@ final class ColorCacheTests: XCTestCase {
     }
 
     func testGlobalClearRemovesEveryStoreWithoutAffectingOtherInstances() throws {
-        let color = try cacheTestColor()
+        let color = try fixedTestColor()
         let first = ColorCache()
         let second = ColorCache()
         populateCache(first, color: color, other: color)

--- a/Tests/ColorKitTests/Utilities/ColorTestSupport.swift
+++ b/Tests/ColorKitTests/Utilities/ColorTestSupport.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import XCTest
+
+func fixedTestColor(
+    space name: CFString = CGColorSpace.sRGB,
+    components: [CGFloat] = [0.2, 0.4, 0.6, 0.8],
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> Color {
+    let space = try XCTUnwrap(CGColorSpace(name: name), file: file, line: line)
+    return try fixedTestColor(space: space, components: components, file: file, line: line)
+}
+
+func fixedTestColor(
+    space: CGColorSpace,
+    components: [CGFloat],
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> Color {
+    let source = try XCTUnwrap(CGColor(colorSpace: space, components: components), file: file, line: line)
+    let color = Color(source)
+    let represented = try XCTUnwrap(color.cgColor, file: file, line: line)
+    XCTAssertTrue(CFEqual(try XCTUnwrap(represented.colorSpace, file: file, line: line), space), file: file, line: line)
+    let actual = try XCTUnwrap(represented.components, file: file, line: line)
+    XCTAssertEqual(actual.map { Double($0).bitPattern }, components.map { Double($0).bitPattern }, file: file, line: line)
+    return color
+}
+
+func patternTestColor(file: StaticString = #filePath, line: UInt = #line) throws -> Color {
+    var callbacks = CGPatternCallbacks(
+        version: 0,
+        drawPattern: { _, context in
+            context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        },
+        releaseInfo: nil
+    )
+    let pattern = try XCTUnwrap(
+        CGPattern(
+            info: nil,
+            bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+            matrix: .identity,
+            xStep: 1,
+            yStep: 1,
+            tiling: .constantSpacing,
+            isColored: true,
+            callbacks: &callbacks
+        ),
+        file: file,
+        line: line
+    )
+    let space = try XCTUnwrap(CGColorSpace(patternBaseSpace: nil), file: file, line: line)
+    let source = try XCTUnwrap(CGColor(patternSpace: space, pattern: pattern, components: [1]), file: file, line: line)
+    let color = Color(source)
+    XCTAssertEqual(color.cgColor?.colorSpace?.model, .pattern, file: file, line: line)
+    return color
+}

--- a/Tests/ColorKitTests/Utilities/ResolvedSRGBATests.swift
+++ b/Tests/ColorKitTests/Utilities/ResolvedSRGBATests.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class ResolvedSRGBATests: XCTestCase {
+    func testSRGBSnapshotsPreserveComponentsIncludingTransparentRGB() throws {
+        for space in [CGColorSpace.sRGB, CGColorSpace.extendedSRGB] {
+            for alpha: CGFloat in [0, 0.5, 1] {
+                let expected: [CGFloat] = [0.5, 0.25, 0.75, alpha]
+                let color = try fixedTestColor(space: space, components: expected)
+                let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+
+                XCTAssertEqual(values(snapshot), expected)
+                XCTAssertTrue(snapshot.isInSRGBGamut)
+            }
+        }
+    }
+
+    func testEquivalentRGBRepresentationsProduceTheSameExtraction() throws {
+        let original = try fixedTestColor(components: [0.2, 0.4, 0.6, 0.5])
+        let source = try XCTUnwrap(original.cgColor)
+        let expected = try XCTUnwrap(ResolvedSRGBA.resolve(original))
+        let expectedCMYK = try XCTUnwrap(original.cmykComponents())
+
+        for name in [CGColorSpace.linearSRGB, CGColorSpace.extendedLinearSRGB, CGColorSpace.displayP3] {
+            let space = try XCTUnwrap(CGColorSpace(name: name))
+            let represented = try XCTUnwrap(source.converted(to: space, intent: .relativeColorimetric, options: nil))
+            let components = try XCTUnwrap(represented.components)
+            XCTAssertNotEqual(Array(components.prefix(3)), [expected.red, expected.green, expected.blue])
+            let color = try fixedTestColor(space: name, components: components)
+            let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+            let cmyk = try XCTUnwrap(color.cmykComponents())
+
+            for (actual, expected) in zip(values(snapshot), values(expected)) {
+                XCTAssertEqual(actual, expected, accuracy: 0.00001)
+            }
+            XCTAssertEqual(color.hexValue(), "#33669980")
+            XCTAssertEqual(cmyk.cyan, expectedCMYK.cyan, accuracy: 0.00001)
+            XCTAssertEqual(cmyk.magenta, expectedCMYK.magenta, accuracy: 0.00001)
+            XCTAssertEqual(cmyk.yellow, expectedCMYK.yellow, accuracy: 0.00001)
+            XCTAssertEqual(cmyk.key, expectedCMYK.key, accuracy: 0.00001)
+        }
+    }
+
+    func testLinearRGBAndGrayscaleUseTheSRGBTransferFunction() throws {
+        // The sRGB encoding of linear 0.25 is 0.5370987304831942.
+        let encoded: CGFloat = 0.5370987304831942
+        let reference = try fixedTestColor(components: [encoded, encoded, encoded, 0.5])
+        for name in [CGColorSpace.linearSRGB, CGColorSpace.linearGray, CGColorSpace.extendedLinearGray] {
+            let space = try XCTUnwrap(CGColorSpace(name: name))
+            let components = Array(repeating: CGFloat(0.25), count: space.numberOfComponents) + [0.5]
+            let color = try fixedTestColor(space: name, components: components)
+            let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+
+            for channel in [snapshot.red, snapshot.green, snapshot.blue] {
+                XCTAssertEqual(channel, encoded, accuracy: 0.000001)
+            }
+            XCTAssertEqual(snapshot.alpha, 0.5)
+            XCTAssertEqual(color.hexValue(), reference.hexValue())
+            let cmyk = try XCTUnwrap(color.cmykComponents())
+            XCTAssertEqual(cmyk.cyan, 0)
+            XCTAssertEqual(cmyk.magenta, 0)
+            XCTAssertEqual(cmyk.yellow, 0)
+            XCTAssertEqual(cmyk.key, 1 - encoded, accuracy: 0.000001)
+        }
+    }
+
+    func testEncodedGrayscaleExpandsToRGB() throws {
+        for name in [CGColorSpace.genericGrayGamma2_2, CGColorSpace.extendedGray] {
+            let color = try fixedTestColor(space: name, components: [0.5, 0.25])
+            let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+
+            XCTAssertEqual(snapshot.red, 0.5, accuracy: 0.00001)
+            XCTAssertEqual(snapshot.green, snapshot.red)
+            XCTAssertEqual(snapshot.blue, snapshot.red)
+            XCTAssertEqual(snapshot.alpha, 0.25)
+            XCTAssertEqual(color.hexValue(), "#80808040")
+            XCTAssertNotNil(color.cmykComponents())
+        }
+    }
+
+    func testConvertibleSourceDoesNotGainCacheEligibility() throws {
+        let color = try fixedTestColor(space: CGColorSpace.adobeRGB1998, components: [0.5, 0.4, 0.6, 1])
+        XCTAssertNotNil(ResolvedSRGBA.resolve(color))
+        XCTAssertNotNil(color.hexValue())
+        XCTAssertNotNil(color.cmykComponents())
+
+        let cache = ColorCache()
+        cache.cacheLuminance(for: color, luminance: 0.25)
+        XCTAssertNil(cache.getCachedLuminance(for: color))
+    }
+
+    func testExtendedRangeIsRetainedButCannotBeExtractedAsHexOrCMYK() throws {
+        for red: CGFloat in [-0.25, 1.25, -CGFloat.leastNonzeroMagnitude, CGFloat(1).nextUp, .greatestFiniteMagnitude] {
+            let color = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: [red, 0.4, 0.6, 0.5])
+            let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+
+            XCTAssertEqual(snapshot.red, red)
+            XCTAssertFalse(snapshot.isInSRGBGamut)
+            assertExtractionUnavailable(color)
+        }
+        let linear = try fixedTestColor(space: CGColorSpace.extendedLinearSRGB, components: [-0.25, 1.25, 0.25, 0.5])
+        let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(linear))
+        XCTAssertEqual(snapshot.red, -0.5370987304831942, accuracy: 0.000001)
+        XCTAssertGreaterThan(snapshot.green, 1)
+        XCTAssertEqual(snapshot.alpha, 0.5)
+        assertExtractionUnavailable(linear)
+    }
+
+    func testDisplayP3RedIsConvertedWithoutClipping() throws {
+        let color = try fixedTestColor(space: CGColorSpace.displayP3, components: [1, 0, 0, 0.5])
+        let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+
+        XCTAssertGreaterThan(snapshot.red, 1)
+        XCTAssertLessThan(snapshot.green, 0)
+        XCTAssertLessThan(snapshot.blue, 0)
+        XCTAssertEqual(snapshot.alpha, 0.5)
+        assertExtractionUnavailable(color)
+    }
+
+    func testConvertedWhiteUsesStrictRangeChecksWithoutTolerance() throws {
+        for name in [CGColorSpace.linearSRGB, CGColorSpace.displayP3] {
+            let color = try fixedTestColor(space: name, components: [1, 1, 1, 1])
+            let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+            for channel in [snapshot.red, snapshot.green, snapshot.blue] {
+                XCTAssertEqual(channel, 1, accuracy: 0.000001)
+            }
+            // Platform conversion may overshoot 1 by a few ulps; do not silently snap it.
+            if snapshot.isInSRGBGamut {
+                XCTAssertEqual(color.hexValue(), "#FFFFFFFF")
+                XCTAssertNotNil(color.cmykComponents())
+            } else {
+                assertExtractionUnavailable(color)
+            }
+        }
+    }
+
+    func testSnapshotRejectsMalformedComponentsAndInvalidAlpha() {
+        for components: [CGFloat] in [[], [0.5], [0.5, 1], [0, 0, 0], [0, 0, 0, 1, 1]] {
+            XCTAssertNil(ResolvedSRGBA(sRGBComponents: components))
+        }
+        for alpha: CGFloat in [-0.1, 1.1, .nan, .infinity, -.infinity] {
+            XCTAssertNil(ResolvedSRGBA(sRGBComponents: [0.2, 0.4, 0.6, alpha]))
+        }
+        for index in 0..<4 {
+            for value: CGFloat in [.nan, .infinity, -.infinity] {
+                var components: [CGFloat] = [0.2, 0.4, 0.6, 0.5]
+                components[index] = value
+                XCTAssertNil(ResolvedSRGBA(sRGBComponents: components))
+            }
+        }
+    }
+
+    func testNonfiniteSourceComponentsDoNotBecomeZeroValues() throws {
+        for index in 0..<3 {
+            for value: CGFloat in [.nan, .infinity, -.infinity] {
+                var components: [CGFloat] = [0.2, 0.4, 0.6, 0.5]
+                components[index] = value
+                let color = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: components)
+                XCTAssertNil(ResolvedSRGBA.resolve(color))
+                assertExtractionUnavailable(color)
+            }
+        }
+        let invalidAlpha = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: [0.2, 0.4, 0.6, .nan])
+        XCTAssertNil(ResolvedSRGBA.resolve(invalidAlpha))
+        assertExtractionUnavailable(invalidAlpha)
+    }
+
+    func testPlatformSanitizedAlphaIsNotAnInvalidFixture() throws {
+        let space = try XCTUnwrap(CGColorSpace(name: CGColorSpace.extendedSRGB))
+        for (input, represented): (CGFloat, CGFloat) in [(-0.2, 0), (1.2, 1)] {
+            let source = try XCTUnwrap(CGColor(colorSpace: space, components: [0.2, 0.4, 0.6, input]))
+            let color = Color(source)
+            XCTAssertEqual(try XCTUnwrap(color.cgColor).alpha, represented)
+            XCTAssertEqual(try XCTUnwrap(ResolvedSRGBA.resolve(color)).alpha, represented)
+        }
+    }
+
+    func testDynamicAndSemanticColorsRemainUnavailable() {
+        #if canImport(AppKit)
+        let dynamic = Color(NSColor(name: nil) { _ in .red })
+        #else
+        let dynamic = Color(UIColor { _ in .red })
+        #endif
+        for color in [dynamic, Color.primary, Color.secondary] {
+            XCTAssertNil(color.cgColor)
+            XCTAssertNil(ResolvedSRGBA.resolve(color))
+            assertExtractionUnavailable(color)
+        }
+    }
+
+    func testPatternAndCMYKSourcesRemainUnavailable() throws {
+        let pattern = try patternTestColor()
+        let space = CGColorSpaceCreateDeviceCMYK()
+        let source = try XCTUnwrap(CGColor(colorSpace: space, components: [0.2, 0.4, 0.6, 0.1, 1]))
+        let cmyk = Color(source)
+        XCTAssertEqual(cmyk.cgColor?.colorSpace?.model, .cmyk)
+
+        for color in [pattern, cmyk] {
+            XCTAssertNil(ResolvedSRGBA.resolve(color))
+            assertExtractionUnavailable(color)
+        }
+    }
+
+    func testCompatibilityFallbacksRemainAtLegacyCallers() throws {
+        let color = try patternTestColor()
+        XCTAssertNil(ResolvedSRGBA.resolve(color))
+        let rgba = color.rgbaComponents()
+        XCTAssertEqual([rgba.red, rgba.green, rgba.blue, rgba.alpha], [0, 0, 0, 0])
+        let aggregate = color.colorSpaceComponents()
+        XCTAssertEqual([aggregate.cmyk.cyan, aggregate.cmyk.magenta, aggregate.cmyk.yellow, aggregate.cmyk.key], [0, 0, 0, 0])
+    }
+
+    func testHexFormattingAndCMYKAlphaCompatibility() throws {
+        for (alpha, suffix): (CGFloat, String) in [(0, "00"), (0.5, "80"), (1, "FF")] {
+            let color = try fixedTestColor(components: [1, 0, 0, alpha])
+            let hex = try XCTUnwrap(color.hexComponents())
+            XCTAssertEqual([hex.red, hex.green, hex.blue, hex.alpha], ["FF", "00", "00", suffix])
+            XCTAssertEqual(color.hexValue(), "#FF0000" + suffix)
+            XCTAssertEqual(color.hexString(), color.hexValue())
+            XCTAssertEqual(color.cmykString(), "cmyk(0%, 100%, 100%, 0%)")
+        }
+        let black = try fixedTestColor(components: [0, 0, 0, 0])
+        XCTAssertEqual(black.hexValue(), "#00000000")
+        XCTAssertEqual(black.cmykString(), "cmyk(0%, 0%, 0%, 100%)")
+        let fractional = try fixedTestColor(components: [0.5, 0.25, 0.125, 1])
+        XCTAssertEqual(fractional.hexValue(), "#804020FF")
+        XCTAssertEqual(fractional.cmykString(), "cmyk(0%, 50%, 75%, 50%)")
+        let truncated = try fixedTestColor(components: [1, 0.333, 0.666, 1])
+        XCTAssertEqual(truncated.cmykString(), "cmyk(0%, 66%, 33%, 0%)")
+        let roundTrip = try XCTUnwrap(Color(hex: "#23232380"))
+        XCTAssertEqual(roundTrip.hexString(), "#23232380")
+    }
+
+    private func values(_ snapshot: ResolvedSRGBA) -> [CGFloat] {
+        [snapshot.red, snapshot.green, snapshot.blue, snapshot.alpha]
+    }
+
+    private func assertExtractionUnavailable(_ color: Color, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertNil(color.hexValue(), file: file, line: line)
+        XCTAssertNil(color.hexString(), file: file, line: line)
+        XCTAssertNil(color.hexComponents(), file: file, line: line)
+        XCTAssertNil(color.cmykComponents(), file: file, line: line)
+        XCTAssertNil(color.cmykString(), file: file, line: line)
+    }
+}

--- a/docs/design/resolved-srgba.md
+++ b/docs/design/resolved-srgba.md
@@ -1,0 +1,65 @@
+# F07 — Fallible resolved-sRGBA snapshot
+
+Status: accepted for implementation.
+
+## Agreed scope
+
+- Introduce an internal immutable optional resolved-sRGBA snapshot obtained through an uncached platform resolver.
+- Adopt the snapshot in uncached Hex and CMYK extraction only. Preserve public signatures and compatibility fallbacks.
+- Defer migration of cached consumers. Preserve original-component cache identity and never construct cache keys through cached conversions.
+- Add cross-representation and failure tests for macOS and iOS.
+
+## Agreed representation and range policy
+
+- The snapshot represents nonlinear sRGB with separate, unpremultiplied alpha.
+- Preserve finite extended-range RGB values, including negative values and values greater than one; do not clamp during resolution.
+- Failed conversion or any nonfinite component produces no snapshot.
+- Hex and CMYK extraction return `nil` when resolved RGB values fall outside 0–1. Neither consumer clips those values or introduces a gamut-mapping policy.
+- Preserve existing Hex rounding and CMYK calculations for in-range resolved values.
+- Range checks are strict, with no tolerance or endpoint snapping. A tiny platform conversion overshoot near white is out of range and returns `nil` from Hex and CMYK.
+
+## Agreed appearance policy
+
+- Resolve only inputs that expose a fixed `Color.cgColor`.
+- Dynamic and semantic colors without fixed components produce no snapshot, preserving `nil` from Hex and CMYK extraction.
+- Do not select or consult an ambient light/dark appearance. Callers may supply an already-resolved fixed color.
+- Explicit appearance-aware resolution is deferred.
+
+## Agreed alpha policy
+
+- Alpha must be finite and within 0–1; invalid alpha produces no snapshot and is not clamped.
+- Preserve RGB independently of alpha, including at alpha zero. Do not premultiply or composite against a background.
+- Hex includes alpha using the existing nearest-byte rounding.
+- CMYK continues to ignore alpha. Transparent red retains the same CMYK components as opaque red.
+
+## Agreed source policy
+
+- Accept fixed RGB and grayscale inputs when the platform can convert their source color space to extended sRGB.
+- This includes sRGB, linear RGB, Display P3, extended-range RGB, and grayscale representations; raw component positions do not establish sRGB values.
+- Patterns, other color models, malformed components, and failed conversions produce no snapshot.
+- Conversion support is independent of cache eligibility. Supporting conversion of a source does not make it cacheable or change its cache identity.
+
+## Compatibility consequences
+
+- Ordinary in-range sRGB extraction retains existing formatting, rounding, and CMYK arithmetic.
+- Grayscale can now produce Hex and CMYK values. Linear RGB and wide-gamut sources are converted rather than interpreted as raw sRGB.
+- The inspector already calls `hexValue()` directly, so grayscale Hex can become available while its RGB, HSL, and contrast fields retain their existing behavior. Update the affected Hex assertion without migrating those other fields.
+- Existing aggregate callers inherit the changed Hex/CMYK results. Keep their nonoptional compatibility fallbacks unchanged.
+- Leave `rgbaComponents()`, `wcagRGBAComponents()`, cached conversions, cache keys, and other conversion algorithms unchanged in this slice.
+
+## Validation plan
+
+- Run macOS and iOS Simulator tests. Xcode 26.5 and an iOS 26.5 iPhone 17 simulator are available locally.
+- Compare equivalent interior colors represented as sRGB, linear RGB, Display P3, and grayscale, verifying that fixtures retain their intended source spaces and component layouts.
+- Cover ordinary sRGB Hex round trips, rounding, aliases, component formatting, CMYK black handling, and CMYK percentage truncation.
+- Verify finite extended-range values survive snapshot resolution while Hex and CMYK reject RGB outside 0–1, including out-of-gamut Display P3.
+- Verify alpha preservation at zero, partial opacity, and one; Hex includes alpha and CMYK ignores it.
+- Verify unavailable results for dynamic/semantic colors, patterns, unsupported models, malformed/nonfinite components, invalid alpha, and failed conversion. Account for values sanitized by platform construction rather than treating them as surviving invalid fixtures.
+- Keep tests of legacy nonoptional fallbacks and original cache identity. Run shared-cache integration tests separately with parallel testing disabled, following existing test isolation.
+
+## Resolver implementation
+
+- Use Core Graphics on both platforms, targeting `extendedSRGB` with relative-colorimetric intent and no conversion options.
+- Preserve components directly only when the source space equals standard sRGB or extended sRGB; they share the nonlinear encoding. This avoids changing existing sRGB rounding through an unnecessary transform.
+- Validate source component shape, finiteness, and alpha before conversion and validate the resulting snapshot again afterward.
+- The snapshot validates the color that reaches it. Core Graphics can sanitize invalid finite alpha during color construction; it cannot recover those original values.


### PR DESCRIPTION
## Summary

Hex and CMYK extraction currently interpret raw color components as sRGB, producing incorrect results for linear RGB and Display P3 while rejecting grayscale. This implements the agreed first slice of F07: a fallible resolved-sRGBA snapshot shared by those uncached extraction paths.

## Changes

- Resolve fixed RGB and grayscale inputs through Core Graphics to extended, nonlinear sRGB on macOS and iOS. Preserve existing sRGB components without an unnecessary transform.
- Validate component shape, finiteness, and alpha; retain extended RGB in the immutable snapshot and return `nil` from Hex/CMYK when RGB falls outside 0–1.
- Preserve unpremultiplied alpha in Hex and continue ignoring alpha in CMYK. Keep existing rounding, formatting, CMYK arithmetic, and public signatures.
- Consolidate Hex formatting and fixed/pattern test fixtures. Add 15 tests covering representations, gamut, transparency, unavailable inputs, compatibility fallbacks, and cache independence.
- Document the policy and update the inspector test for newly available grayscale Hex without migrating its other fields.

## Alternatives considered

Clipping or adding a tolerance would silently change the resolved color, so Hex and CMYK reject out-of-range values instead. Ambient appearance resolution and cached-consumer migration are deferred. The existing raw-component approach cannot distinguish source encodings or safely represent failure.

## Notes

- Strict range checks also reject tiny platform-conversion overshoots near white; there is no endpoint snapping.
- Dynamic/semantic colors without a fixed `cgColor` remain unavailable. Callers can provide an already-resolved fixed color.
- Core Graphics can sanitize alpha at construction time; validation applies to values that actually reach the resolver.
- Cache implementation, cache keys, cached conversions, and legacy nonoptional RGBA fallbacks are unchanged. CMYK remains an arithmetic approximation, not a printer-profile conversion.
- Independent Standards and Spec reviews are clear after consolidating duplicated test fixtures.

## Screenshots

Not applicable; no UI changes.

## Testing

- Full ColorKit suite: 155 regular tests passed on each of macOS 26.5.2 and iPhone 17 Simulator with iOS 26.5, built using Xcode 26.5.
- All 13 shared cache/theme integration tests passed separately on each platform with parallel testing disabled (168 tests per platform).
- After fixture cleanup, reran the resolver, cache, inspector, and shared-state suites on both platforms.
- Verified the new suite actually executes on iOS after an initial full run omitted it during test discovery.
- `swiftlint lint --strict --quiet` and `git diff --check` pass; no new TODO/FIXME markers.
