### PR TITLE
fix(animation): Own and cancel preview monitoring sessions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,3 +69,6 @@ The palette or theme entries, export name, and format selected for one export ac
 
 **Palette export artifact**:
 The prepared output of one palette export snapshot, ready to share or save in the selected format.
+
+**Animation monitoring session**:
+One continuous visit to the animation preview, with fresh performance metrics for each visit. Pausing animation or hiding metrics does not begin or end the session.

--- a/Sources/ColorKit/PreviewCatalog/AnimationPerformanceMonitor.swift
+++ b/Sources/ColorKit/PreviewCatalog/AnimationPerformanceMonitor.swift
@@ -1,0 +1,56 @@
+import Combine
+import Foundation
+
+@MainActor
+final class AnimationPerformanceMonitor: ObservableObject {
+    @Published private(set) var frameCount = 0
+    @Published private(set) var fps = 0.0
+    private(set) var lastFrameTime = Date()
+    private(set) var timer: Timer?
+    private(set) var sessionID: UUID?
+
+    init(now: @escaping () -> Date = Date.init) {
+        self.now = now
+    }
+
+    func start(isAnimating: @escaping @MainActor () -> Bool) {
+        guard timer == nil else { return }
+
+        let sessionID = UUID()
+        self.sessionID = sessionID
+        frameCount = 0
+        fps = 0
+        lastFrameTime = now()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
+            guard let self else {
+                timer.invalidate()
+                return
+            }
+            self.enqueueTick(for: sessionID, isAnimating: isAnimating)
+        }
+    }
+
+    func stop() {
+        sessionID = nil
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // Check the captured session after the actor hop: stop and restart may both
+    // have happened since the timer fired. A Boolean would accept the old tick.
+    @discardableResult
+    nonisolated func enqueueTick(
+        for sessionID: UUID,
+        isAnimating: @escaping @MainActor () -> Bool
+    ) -> Task<Void, Never> {
+        Task { @MainActor [weak self] in
+            guard let self, self.sessionID == sessionID, isAnimating() else { return }
+            self.frameCount += 1
+            let currentTime = self.now()
+            self.fps = 1.0 / currentTime.timeIntervalSince(self.lastFrameTime)
+            self.lastFrameTime = currentTime
+        }
+    }
+
+    private let now: () -> Date
+}

--- a/Sources/ColorKit/PreviewCatalog/ColorAnimationPreview.swift
+++ b/Sources/ColorKit/PreviewCatalog/ColorAnimationPreview.swift
@@ -30,9 +30,11 @@ public struct ColorAnimationPreview: View {
     @State private var isAnimating = false
     @State private var selectedInterpolation: ColorInterpolation = .rgb
     @State private var showPerformanceMetrics = false
-    @State private var frameCount: Int = 0
-    @State private var lastFrameTime = Date()
-    @State private var fps: Double = 0
+    @StateObject private var monitor: AnimationPerformanceMonitor
+
+    init(monitor: @autoclosure @escaping () -> AnimationPerformanceMonitor = AnimationPerformanceMonitor()) {
+        _monitor = StateObject(wrappedValue: monitor())
+    }
 
     // MARK: - Constants
 
@@ -77,7 +79,11 @@ public struct ColorAnimationPreview: View {
             .padding()
         }
         .onAppear {
-            startPerformanceMonitoring()
+            let animationState = $isAnimating
+            monitor.start { animationState.wrappedValue }
+        }
+        .onDisappear {
+            monitor.stop()
         }
     }
 
@@ -196,7 +202,7 @@ public struct ColorAnimationPreview: View {
                 VStack(alignment: .leading) {
                     Text("FPS")
                         .font(.subheadline)
-                    Text(String(format: "%.1f", fps))
+                    Text(String(format: "%.1f", monitor.fps))
                         .font(.system(.title, design: .monospaced))
                 }
 
@@ -205,7 +211,7 @@ public struct ColorAnimationPreview: View {
                 VStack(alignment: .leading) {
                     Text("Frame Count")
                         .font(.subheadline)
-                    Text("\(frameCount)")
+                    Text("\(monitor.frameCount)")
                         .font(.system(.title, design: .monospaced))
                 }
             }
@@ -252,19 +258,6 @@ public struct ColorAnimationPreview: View {
         } else {
             withAnimation(.easeInOut(duration: animationDuration)) {
                 currentColor = startColor
-            }
-        }
-    }
-
-    private func startPerformanceMonitoring() {
-        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-            Task { @MainActor in
-                guard self.isAnimating else { return }
-                self.frameCount += 1
-                let currentTime = Date()
-                let timeInterval = currentTime.timeIntervalSince(self.lastFrameTime)
-                self.fps = 1.0 / timeInterval
-                self.lastFrameTime = currentTime
             }
         }
     }

--- a/Tests/ColorKitTests/AnimationPerformanceMonitorTests.swift
+++ b/Tests/ColorKitTests/AnimationPerformanceMonitorTests.swift
@@ -1,0 +1,212 @@
+import Combine
+import XCTest
+
+@testable import ColorKit
+
+@MainActor
+final class AnimationPerformanceMonitorTests: XCTestCase {
+    // Keep real timers for invalidation checks, but deliver ticks explicitly.
+    // Moving fireDate prevents automatic firings from racing async assertions.
+    func testStartAndStopAreIdempotentAndInvalidateTheOwnedTimer() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let monitor = AnimationPerformanceMonitor(now: { now })
+        XCTAssertNil(monitor.timer)
+        XCTAssertNil(monitor.sessionID)
+
+        monitor.start { true }
+        monitor.timer?.fireDate = .distantFuture
+        defer { monitor.stop() }
+        let timer = try XCTUnwrap(monitor.timer)
+        let session = try XCTUnwrap(monitor.sessionID)
+        XCTAssertTrue(timer.isValid)
+        XCTAssertEqual(timer.timeInterval, 0.1)
+
+        now.addTimeInterval(0.25)
+        await monitor.enqueueTick(for: session, isAnimating: { true }).value
+        monitor.start { false }
+        monitor.timer?.fireDate = .distantFuture
+        XCTAssertTrue(monitor.timer === timer)
+        XCTAssertEqual(monitor.sessionID, session)
+        assertMetrics(monitor, count: 1, fps: 4, time: now)
+
+        monitor.stop()
+        monitor.stop()
+        XCTAssertFalse(timer.isValid)
+        XCTAssertNil(monitor.timer)
+        XCTAssertNil(monitor.sessionID)
+        assertMetrics(monitor, count: 1, fps: 4, time: now)
+    }
+
+    func testRestartResetsMetricsAndExcludesTimeAway() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let monitor = AnimationPerformanceMonitor(now: { now })
+        monitor.start { true }
+        monitor.timer?.fireDate = .distantFuture
+        defer { monitor.stop() }
+        let oldTimer = try XCTUnwrap(monitor.timer)
+        let oldSession = try XCTUnwrap(monitor.sessionID)
+        now.addTimeInterval(0.5)
+        await monitor.enqueueTick(for: oldSession, isAnimating: { true }).value
+        assertMetrics(monitor, count: 1, fps: 2, time: now)
+        monitor.stop()
+
+        now.addTimeInterval(100)
+        monitor.start { true }
+        monitor.timer?.fireDate = .distantFuture
+        let session = try XCTUnwrap(monitor.sessionID)
+        XCTAssertNotEqual(session, oldSession)
+        XCTAssertFalse(monitor.timer === oldTimer)
+        XCTAssertFalse(oldTimer.isValid)
+        assertMetrics(monitor, count: 0, fps: 0, time: now)
+
+        now.addTimeInterval(0.25)
+        await monitor.enqueueTick(for: session, isAnimating: { true }).value
+        assertMetrics(monitor, count: 1, fps: 4, time: now)
+    }
+
+    func testQueuedTickAfterStopCannotChangeAnyMetric() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let monitor = AnimationPerformanceMonitor(now: { now })
+        monitor.start { true }
+        monitor.timer?.fireDate = .distantFuture
+        let session = try XCTUnwrap(monitor.sessionID)
+        let baseline = now
+
+        // This task cannot reach the main actor until the test suspends below.
+        let queuedTick = monitor.enqueueTick(for: session, isAnimating: { true })
+        monitor.stop()
+        now.addTimeInterval(5)
+        await queuedTick.value
+        assertMetrics(monitor, count: 0, fps: 0, time: baseline)
+    }
+
+    func testQueuedTickFromOldSessionCannotChangeRestartedSession() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let monitor = AnimationPerformanceMonitor(now: { now })
+        monitor.start { true }
+        monitor.timer?.fireDate = .distantFuture
+        defer { monitor.stop() }
+        let oldSession = try XCTUnwrap(monitor.sessionID)
+        let queuedTick = monitor.enqueueTick(for: oldSession, isAnimating: { true })
+        monitor.stop()
+        now.addTimeInterval(10)
+        monitor.start { true }
+        monitor.timer?.fireDate = .distantFuture
+        let baseline = now
+        now.addTimeInterval(0.5)
+
+        await queuedTick.value
+        assertMetrics(monitor, count: 0, fps: 0, time: baseline)
+        let session = try XCTUnwrap(monitor.sessionID)
+        await monitor.enqueueTick(for: session, isAnimating: { true }).value
+        assertMetrics(monitor, count: 1, fps: 2, time: now)
+    }
+
+    func testAnimationGateIsReadAfterQueueingAndPreservesIdleTime() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let animation = AnimationGate()
+        let monitor = AnimationPerformanceMonitor(now: { now })
+        monitor.start { animation.isAnimating }
+        monitor.timer?.fireDate = .distantFuture
+        defer { monitor.stop() }
+        let session = try XCTUnwrap(monitor.sessionID)
+        let baseline = now
+        let queuedTick = monitor.enqueueTick(for: session, isAnimating: { animation.isAnimating })
+        animation.isAnimating = false
+        now.addTimeInterval(2)
+        await queuedTick.value
+        assertMetrics(monitor, count: 0, fps: 0, time: baseline)
+
+        animation.isAnimating = true
+        now.addTimeInterval(2)
+        await monitor.enqueueTick(for: session, isAnimating: { animation.isAnimating }).value
+        assertMetrics(monitor, count: 1, fps: 0.25, time: now)
+        XCTAssertEqual(monitor.sessionID, session)
+    }
+
+    func testStoppingOneMonitorDoesNotAffectAnother() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let first = AnimationPerformanceMonitor(now: { now })
+        let second = AnimationPerformanceMonitor(now: { now })
+        first.start { true }
+        first.timer?.fireDate = .distantFuture
+        second.start { true }
+        second.timer?.fireDate = .distantFuture
+        defer {
+            first.stop()
+            second.stop()
+        }
+        let secondTimer = try XCTUnwrap(second.timer)
+        let secondSession = try XCTUnwrap(second.sessionID)
+
+        first.stop()
+        first.start { true }
+        first.timer?.fireDate = .distantFuture
+        now.addTimeInterval(0.5)
+        await second.enqueueTick(for: secondSession, isAnimating: { true }).value
+        XCTAssertTrue(second.timer === secondTimer)
+        XCTAssertTrue(secondTimer.isValid)
+        XCTAssertEqual(second.sessionID, secondSession)
+        assertMetrics(first, count: 0, fps: 0, time: now.addingTimeInterval(-0.5))
+        assertMetrics(second, count: 1, fps: 2, time: now)
+    }
+
+    func testTimerCallbackPublishesMetricsUsingCurrentAnimationState() async throws {
+        var now = Date(timeIntervalSinceReferenceDate: 100)
+        let animation = AnimationGate()
+        animation.isAnimating = false
+        let monitor = AnimationPerformanceMonitor(now: { now })
+        monitor.start { animation.isAnimating }
+        monitor.timer?.fireDate = .distantFuture
+        defer { monitor.stop() }
+        let timer = try XCTUnwrap(monitor.timer)
+        let published = expectation(description: "Timer callback publishes FPS")
+        let subscription = monitor.$fps.dropFirst().sink { fps in
+            if fps == 4 { published.fulfill() }
+        }
+        defer { subscription.cancel() }
+
+        animation.isAnimating = true
+        now.addTimeInterval(0.25)
+        timer.fire()
+        await fulfillment(of: [published], timeout: 3)
+        assertMetrics(monitor, count: 1, fps: 4, time: now)
+    }
+
+    func testStoppedMonitorIsReleasedEvenWithQueuedWorkAndRetainedTimer() async throws {
+        var monitor: AnimationPerformanceMonitor? = AnimationPerformanceMonitor()
+        monitorUnderLifetimeTest = monitor
+        monitor?.start { true }
+        monitor?.timer?.fireDate = .distantFuture
+        let timer = try XCTUnwrap(monitor?.timer)
+        let session = try XCTUnwrap(monitor?.sessionID)
+        let queuedTick = monitor?.enqueueTick(for: session, isAnimating: { true })
+
+        monitor?.stop()
+        monitor = nil
+        XCTAssertNil(monitorUnderLifetimeTest)
+        XCTAssertFalse(timer.isValid)
+        await queuedTick?.value
+        XCTAssertNil(monitorUnderLifetimeTest)
+    }
+
+    private weak var monitorUnderLifetimeTest: AnimationPerformanceMonitor?
+
+    @MainActor
+    private final class AnimationGate {
+        var isAnimating = true
+    }
+
+    private func assertMetrics(
+        _ monitor: AnimationPerformanceMonitor,
+        count: Int,
+        fps: Double,
+        time: Date,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(monitor.frameCount, count, file: file, line: line)
+        XCTAssertEqual(monitor.fps, fps, accuracy: 1e-12, file: file, line: line)
+        XCTAssertEqual(monitor.lastFrameTime, time, file: file, line: line)
+    }
+}

--- a/Tests/ColorKitTests/AnimationPreviewLifecycleTests.swift
+++ b/Tests/ColorKitTests/AnimationPreviewLifecycleTests.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+@MainActor
+final class AnimationPreviewLifecycleTests: XCTestCase {
+    func testAppearanceRedrawDisappearanceAndReentryUseOneTimerPerVisit() async throws {
+        let monitor = AnimationPerformanceMonitor()
+        let state = AnimationPreviewLifecycleState()
+        let appeared = expectation(description: "Preview appeared")
+        state.onAppear = { appeared.fulfill() }
+        let host = ThemeTestHost(rootView: AnimationPreviewLifecycleHarness(monitor: monitor, state: state))
+        defer {
+            host.close()
+            monitor.stop()
+        }
+        await fulfillment(of: [appeared], timeout: 3)
+        let firstTimer = try XCTUnwrap(monitor.timer)
+        let firstSession = try XCTUnwrap(monitor.sessionID)
+        await monitor.enqueueTick(for: firstSession, isAnimating: { true }).value
+        XCTAssertEqual(monitor.frameCount, 1)
+
+        let redrawn = expectation(description: "Preview redrawn")
+        state.onRedraw = { redrawn.fulfill() }
+        state.redraw += 1
+        await fulfillment(of: [redrawn], timeout: 3)
+        XCTAssertTrue(monitor.timer === firstTimer)
+        XCTAssertEqual(monitor.sessionID, firstSession)
+        XCTAssertEqual(monitor.frameCount, 1)
+
+        let disappeared = expectation(description: "Preview disappeared")
+        state.onDisappear = { disappeared.fulfill() }
+        state.isVisible = false
+        await fulfillment(of: [disappeared], timeout: 3)
+        XCTAssertFalse(firstTimer.isValid)
+        XCTAssertNil(monitor.timer)
+        XCTAssertNil(monitor.sessionID)
+
+        let reappeared = expectation(description: "Preview reappeared")
+        state.onAppear = { reappeared.fulfill() }
+        state.isVisible = true
+        await fulfillment(of: [reappeared], timeout: 3)
+        XCTAssertNotEqual(monitor.sessionID, firstSession)
+        XCTAssertFalse(monitor.timer === firstTimer)
+        XCTAssertTrue(try XCTUnwrap(monitor.timer).isValid)
+        XCTAssertEqual(monitor.frameCount, 0)
+        XCTAssertEqual(monitor.fps, 0)
+    }
+}
+
+@MainActor
+private final class AnimationPreviewLifecycleState: ObservableObject {
+    @Published var isVisible = true
+    @Published var redraw = 0
+    // Observe each transition once, even if SwiftUI repeats a lifecycle callback.
+    var onAppear: (() -> Void)?
+    var onDisappear: (() -> Void)?
+    var onRedraw: (() -> Void)?
+}
+
+private struct AnimationPreviewLifecycleHarness: View {
+    let monitor: AnimationPerformanceMonitor
+    @ObservedObject var state: AnimationPreviewLifecycleState
+
+    var body: some View {
+        if state.isVisible {
+            ColorAnimationPreview(monitor: monitor)
+                .padding(CGFloat(state.redraw))
+                .onAppear {
+                    state.onAppear?()
+                    state.onAppear = nil
+                }
+                .onDisappear {
+                    state.onDisappear?()
+                    state.onDisappear = nil
+                }
+                .onChange(of: state.redraw) { _ in
+                    state.onRedraw?()
+                    state.onRedraw = nil
+                }
+        }
+    }
+}

--- a/docs/design/animation-monitoring-lifecycle.md
+++ b/docs/design/animation-monitoring-lifecycle.md
@@ -1,0 +1,112 @@
+# F14 — Animation preview monitoring lifecycle
+
+Status: implemented. Focused automated checks pass on macOS and iOS; validation results and manual-check limits are recorded below.
+
+## Agreed scope
+
+- Give each `ColorAnimationPreview` instance ownership of zero or one repeating monitoring timer.
+- Make startup idempotent and clean up monitoring on disappearance.
+- Prevent callbacks queued before cancellation from changing metrics after cancellation, including after a subsequent appearance.
+- Reset metrics for each new animation monitoring session; duplicate startup within a session does not reset anything.
+- Preserve animation behavior, the iOS 14 and macOS 12 deployment targets, and the existing monitoring cadence and FPS calculation.
+- Do not introduce a scheduler framework or redesign FPS measurement.
+- Keep monitoring tied to appearance and disappearance. Animation activity gates metric updates; the metrics toggle controls display only.
+- Keep app-background and scene-phase handling outside F14.
+
+## Existing behavior being corrected
+
+Before F14, `ColorAnimationPreview` started an unretained repeating timer on every appearance, with no disappearance cleanup. Each tick created a main-actor task that updated metrics only when `isAnimating` was true. The performance-metrics toggle controlled visibility only; that behavior is preserved.
+
+The current 0.1-second timer increments `frameCount` once per accepted monitoring tick and computes `fps` as the reciprocal of the elapsed time since the previous accepted tick. These values are not measurements of rendered frames. F14 preserves this calculation and the existing labels.
+
+## Ownership and isolation
+
+- Use a small internal `@MainActor` monitoring object, conforming to `ObservableObject`, owned by each preview through `@StateObject`.
+- The object owns the optional timer, current session identity, `frameCount`, `fps`, and timestamp baseline. Publish the displayed metrics so the performance section updates.
+- A new owner is inactive. Constructing the owner or evaluating the view body does not schedule a timer; appearance calls start and disappearance calls stop.
+- Each preview owns its own monitor. There is no singleton or shared timer, and repeated view evaluation preserves the owner for the same view identity.
+- Start, stop, and metric mutations run on the main actor. Callback acceptance and its metric updates form one synchronous operation with no suspension between the checks and updates.
+- Avoid strong retention cycles through timer callbacks, queued tasks, or callbacks that read animation state. Use weak owner captures where needed, and verify release after disappearance and teardown.
+- Keep implementation details internal. Do not add a public lifecycle/testing API, a dependency, a scheduler framework, or unchecked concurrency annotations to silence diagnostics. Preserve the package's existing toolchain and deployment requirements.
+
+## Lifecycle contract
+
+At lifecycle method boundaries, an inactive monitor has no owned timer and no current session identity. An active monitor has exactly one timer and one session identity.
+
+| Event | Required result |
+| --- | --- |
+| Start while inactive | Create a fresh session identity, reset `frameCount` and `fps` to zero, set the timestamp baseline to the start time, and retain one repeating timer. |
+| Start while active | No operation: retain the same timer and session identity, without changing metrics or the timestamp baseline. |
+| Stop while active | Clear the session identity, invalidate the timer, and release the timer reference before returning. Leave metric values frozen until the next accepted start. |
+| Stop while inactive | No operation; do not reset metrics or change animation state. |
+| Re-entry after stop | Start a fresh session and timer, regardless of whether SwiftUI retained the previous owner or created a new one. |
+
+Clearing the session identity happens before invalidating and releasing the timer. Disappearance calls stop synchronously on the main actor; cleanup is not deferred to another task.
+
+## Queued callbacks after cancellation
+
+- Each timer's callback captures the identity of the session that created it. That captured identity must not be replaced by the latest identity when queued work eventually executes.
+- After reaching the main actor, a callback may update metrics only if its captured identity is still the current active session and animation is currently running.
+- A callback from session A must be ignored both after A stops and after session B starts. An `isMonitoring` Boolean alone cannot distinguish A from B.
+- Rejected callbacks change nothing: no frame increment, FPS update, or timestamp update.
+- Timer invalidation stops future timer activity; the session check protects against work already queued. Task cancellation alone is not the correctness mechanism, and F14 need not maintain a collection of per-tick task handles.
+- A callback that completed before stop may have updated metrics; stop does not undo completed work. Once stop returns, work from that session cannot change metrics.
+
+## Metrics and animation behavior
+
+- Keep the repeating interval at 0.1 seconds and preserve the existing scheduled timer's run-loop behavior.
+- For an accepted tick while animating, increment the count once, read the current time at processing, calculate `fps = 1.0 / elapsedTime`, and update the timestamp baseline.
+- Ticks while animation is stopped leave all metrics, including the timestamp baseline, unchanged. Preserve the existing treatment of idle time within a visit; do not add resets on animation start, stop, or resume as part of F14.
+- A new visit resets the timestamp baseline, so time spent away does not enter its first sample.
+- The animation gate must reflect the view's current `isAnimating` value when queued work executes, rather than a snapshot taken when the timer was created.
+- Keep animation state and actions in the view. Do not change color selection, interpolation choices, duration, easing, repeat/autoreverse behavior, or the stop animation action.
+- Monitoring lifecycle methods do not change `isAnimating` or force animation to stop or restart. Preserve SwiftUI's existing view-identity behavior rather than adding persistence across destroyed views.
+- Hiding or showing metrics does not start, stop, or reset monitoring. Preserve the displayed labels and formatting.
+
+## Focused automated validation
+
+Use the repository's XCTest conventions and fresh monitor instances. Exercise the production lifecycle and callback acceptance path through a narrow internal seam with explicit timestamps and controllable callback delivery. Do not build a general scheduler abstraction, use a separate test-only state machine, or rely on sleeps and exact wall-clock firing counts.
+
+1. **Ownership and idempotency:** a new owner has no timer; start twice retains the same single valid timer and session. Deliver an accepted sample before the second start and verify that its count, FPS, and timestamp are not reset. Stop twice leaves no timer or active session. Retain a test reference to the original real timer and assert that it is invalidated, not merely discarded by the owner.
+2. **Fresh metrics on re-entry:** accumulate metrics, stop, and start at a controlled later time. Assert a new timer and session, zero count/FPS, and a fresh baseline. Deliver a current-session sample and verify the unchanged reciprocal-elapsed-time calculation excludes the previous visit and time away.
+3. **Cancellation before queued delivery:** retain work from session A, stop A, then deliver it. Assert that every metric and the baseline remain unchanged.
+4. **Cancellation followed by restart:** retain work from A, stop A, start B, and then deliver A's work while animation is running. Assert that B's metrics and baseline remain unchanged. Deliver B's work and verify one accepted update. Exercise delayed delivery through the same main-actor boundary used by production, with explicit completion coordination instead of sleeps.
+5. **Animation gating:** verify that a current-session callback does nothing while animation is stopped, including when animation stops after the callback is queued. Resume animation within the same session and confirm the existing count and timestamp behavior are preserved.
+6. **Instance independence and release:** start two monitors; stopping or restarting one does not affect the other. After disappearance cleanup and release of the owner, verify no callback retention cycle keeps it alive and its real timer remains invalidated.
+
+## Hosted-view and manual validation
+
+- Add a hosted-view check using the actual preview and an internal observation/injection seam if needed. Mount it, cause an unrelated redraw, and remove it. Observe that appearance starts one timer, redraw preserves that timer and owner, and disappearance invalidates and clears it. Calling helper methods directly does not substitute for this wiring check.
+- Exercise appearance again after disappearance, including a retained owner, to prove the reset policy is not merely a consequence of constructing a new object.
+- Run the focused automated checks on macOS and iOS Simulator using the existing test tooling. Build with the unchanged iOS 14 and macOS 12 minimum targets; inspect availability and strict concurrency diagnostics without raising those targets or changing concurrency settings to make the build pass.
+- On both platforms, manually enter and leave the preview repeatedly, including while animating. Show and hide metrics, start and stop animation, change duration, and exercise RGB/HSL/LAB choices. Verify the agreed lifecycle behavior and unchanged controls and visual behavior. Do not assert that this timer-derived FPS matches display refresh rate.
+- Record actual test/build results, manual observations, and any unavailable environment during implementation. The accepted validation plan is not evidence that these checks have passed.
+
+## Documentation boundary
+
+The domain glossary defines an animation monitoring session. This note holds the lifecycle and implementation decisions. No ADR is needed for this localized, reversible change.
+
+## Validation results — 2026-08-31
+
+- Xcode 26.5: all nine focused tests passed on macOS 26.5.2 and an iPhone 17 simulator running iOS 26.5. Each run includes eight monitor tests and one hosted-view lifecycle test.
+- `swiftlint lint --strict --quiet` and `git diff --check` passed. The hosted test uses the older `onChange` overload to retain minimum-OS compatibility; its deprecation warning does not require a deployment-target change. No new concurrency warnings remain.
+- Temporary native harness apps outside the repository built successfully against this checkout with iOS 14 and macOS 12 minimum targets. These are compile/availability checks, not runs on those older OS versions.
+- On both platforms, native checks confirmed that samples advance during animation even with metrics hidden, freeze after animation stops or the preview disappears, and reset to zero on re-entry with the same monitor retained. Timer invalidation itself is asserted by the automated tests, not inferred from frozen UI values.
+- macOS checks also exercised RGB/HSL/LAB selection, animation start/stop, and duration changes. iOS checks exercised RGB animation and metrics visibility; HSL/LAB selection and duration behavior were not fully verified because the UI driver could not reliably target those controls. Source comparison confirms that the animation action and controls were left unchanged.
+- Native lifecycle checks removed and restored the actual preview in a temporary host; catalog navigation was not independently exercised. The existing complete repository test suite was not rerun for this localized change.
+- The first iOS hosted run exposed duplicate fulfillment of a lifecycle expectation. The test now consumes each pending observation once, tolerating repeated SwiftUI lifecycle callbacks. Both platform runs passed after that correction. Real timers in unit tests have automatic firing deferred; explicit callback delivery and task completion make the assertions independent of wall-clock scheduling.
+
+Reproduce the focused runs from the repository root:
+
+```sh
+scripts/run_tests.sh --log-file /tmp/colorkit-f14-macos.log \
+  macOS 'platform=macOS' \
+  -only-testing:ColorKitTests/AnimationPerformanceMonitorTests \
+  -only-testing:ColorKitTests/AnimationPreviewLifecycleTests \
+  -parallel-testing-enabled NO -skipPackagePluginValidation -skipMacroValidation
+scripts/run_tests.sh --log-file /tmp/colorkit-f14-ios.log \
+  iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
+  -only-testing:ColorKitTests/AnimationPerformanceMonitorTests \
+  -only-testing:ColorKitTests/AnimationPreviewLifecycleTests \
+  -parallel-testing-enabled NO -skipPackagePluginValidation -skipMacroValidation
+```


### PR DESCRIPTION
## Summary

Fix F14 in `ColorAnimationPreview`: each appearance previously created another repeating timer with no cleanup. The preview now owns one monitoring session, stops it on disappearance, and rejects queued callbacks from ended sessions so they cannot update metrics after a later visit starts.

## Changes

- Add a small main-actor monitor owned through `@StateObject`, with idempotent startup and timer invalidation on disappearance.
- Check the captured session identity after the main-actor hop, before reading current animation state and changing metrics.
- Reset frame count, FPS, and the timestamp baseline for each new visit; duplicate starts do not reset them.
- Preserve animation actions, the metrics visibility toggle, the 0.1-second cadence, the existing FPS calculation, and iOS 14/macOS 12 deployment targets.
- Add eight monitor tests, one hosted SwiftUI lifecycle test, and the agreed lifecycle documentation.

## Alternatives considered

Timer invalidation alone cannot reject tasks already queued on the main actor. An active Boolean also cannot distinguish an old callback after monitoring restarts, so each session has its own identity. Continuing metrics across visits was rejected in favor of fresh metrics that exclude time away. A scheduler framework or FPS redesign would exceed this lifecycle repair.

## Notes

- Standards and spec reviews have no remaining actionable findings.
- Native lifecycle checks used a temporary host outside the repository. Catalog navigation, iOS HSL/LAB and duration interactions, older-OS execution, and the full repository suite were not fully exercised.
- The hosted test retains the older `onChange` overload for minimum-OS compatibility; its deprecation warning remains.
- See `docs/design/animation-monitoring-lifecycle.md` for the contract, validation results, and reproduction commands.

## Screenshots

Screenshots pending.

Opened as a draft because this changes a SwiftUI view and no screenshots are attached. Layout and styling are unchanged.

## Testing

- All nine focused tests pass on macOS and iPhone 17 Simulator with iOS 26.5 using Xcode 26.5.
- Coverage includes duplicate starts, repeated stops, real timer invalidation, callbacks delivered after stop and restart, metric resets, current animation gating, instance independence, owner release, and hosted appearance/redraw/disappearance/re-entry.
- `swiftlint lint --strict --quiet` and `git diff --check` pass.
- Temporary native apps built with unchanged minimum deployment targets. Native checks confirmed metric updates while hidden, frozen samples after stopping or disappearing, and reset on re-entry. See Notes for manual-check limits.
