### PR TITLE
fix(benchmark): keep CPU workloads off main actor

### DIFF
--- a/Sources/ColorKit/PreviewCatalog/PerformanceBenchmark.swift
+++ b/Sources/ColorKit/PreviewCatalog/PerformanceBenchmark.swift
@@ -45,7 +45,11 @@ public struct PerformanceBenchmark: View {
         .navigationTitle("Performance Insights")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button(action: runBenchmark) {
+                Button {
+                    Task {
+                        await runBenchmark()
+                    }
+                } label: {
                     if isRunningBenchmark {
                         ProgressView()
                             .progressViewStyle(.circular)
@@ -107,7 +111,7 @@ public struct PerformanceBenchmark: View {
     // MARK: - Actions
 
     @MainActor
-    private func runBenchmark() {
+    private func runBenchmark() async {
         guard !isRunningBenchmark else { return }
 
         isRunningBenchmark = true
@@ -116,31 +120,35 @@ public struct PerformanceBenchmark: View {
         let operation = selectedOperation
         let iterations = iterationCount
 
-        // Run benchmark in background
-        Task.detached {
-            var results: [BenchmarkResult] = []
+        // This detached boundary intentionally keeps synchronous CPU loops off MainActor.
+        // Keep its closure limited to Sendable captured inputs and returned results.
+        let results = await Task.detached(priority: .userInitiated) { [operation, iterations] in
+            Self.benchmark(operation: operation, iterations: iterations)
+        }.value
 
-            switch operation {
-            case .blending:
-                results = await self.benchmarkBlending(iterations: iterations)
-            case .conversion:
-                results = await self.benchmarkConversion(iterations: iterations)
-            case .gradient:
-                results = await self.benchmarkGradient(iterations: iterations)
-            case .accessibility:
-                results = await self.benchmarkAccessibility(iterations: iterations)
-            }
-
-            // Update UI on main thread
-            await MainActor.run {
-                benchmarkResults = results
-                isRunningBenchmark = false
-            }
-        }
+        benchmarkResults = results
+        isRunningBenchmark = false
     }
 
     // MARK: - Benchmark Methods
-    private func benchmarkBlending(iterations: Int) async -> [BenchmarkResult] {
+
+    nonisolated static func benchmark(
+        operation: BenchmarkOperation,
+        iterations: Int
+    ) -> [BenchmarkResult] {
+        switch operation {
+        case .blending:
+            benchmarkBlending(iterations: iterations)
+        case .conversion:
+            benchmarkConversion(iterations: iterations)
+        case .gradient:
+            benchmarkGradient(iterations: iterations)
+        case .accessibility:
+            benchmarkAccessibility(iterations: iterations)
+        }
+    }
+
+    nonisolated private static func benchmarkBlending(iterations: Int) -> [BenchmarkResult] {
         let color1 = Color.blue
         let color2 = Color.red
         var results: [BenchmarkResult] = []
@@ -172,7 +180,7 @@ public struct PerformanceBenchmark: View {
         return results
     }
 
-    private func benchmarkConversion(iterations: Int) async -> [BenchmarkResult] {
+    nonisolated private static func benchmarkConversion(iterations: Int) -> [BenchmarkResult] {
         let color = Color.blue
         var results: [BenchmarkResult] = []
 
@@ -197,7 +205,7 @@ public struct PerformanceBenchmark: View {
         return results
     }
 
-    private func benchmarkGradient(iterations: Int) async -> [BenchmarkResult] {
+    nonisolated private static func benchmarkGradient(iterations: Int) -> [BenchmarkResult] {
         let colors = [Color.blue, Color.purple, Color.red]
         var results: [BenchmarkResult] = []
 
@@ -249,7 +257,7 @@ public struct PerformanceBenchmark: View {
         return results
     }
 
-    private func benchmarkAccessibility(iterations: Int) async -> [BenchmarkResult] {
+    nonisolated private static func benchmarkAccessibility(iterations: Int) -> [BenchmarkResult] {
         let color1 = Color.white
         let color2 = Color.black
         var results: [BenchmarkResult] = []
@@ -278,7 +286,7 @@ public struct PerformanceBenchmark: View {
 
 // MARK: - Supporting Types
 
-enum BenchmarkOperation: String, CaseIterable {
+enum BenchmarkOperation: String, CaseIterable, Sendable {
     case blending
     case conversion
     case gradient
@@ -289,7 +297,7 @@ enum BenchmarkOperation: String, CaseIterable {
     }
 }
 
-struct BenchmarkResult: Identifiable {
+struct BenchmarkResult: Identifiable, Sendable {
     let id = UUID()
     let name: String
     let duration: TimeInterval

--- a/Tests/ColorKitTests/PerformanceBenchmarkTests.swift
+++ b/Tests/ColorKitTests/PerformanceBenchmarkTests.swift
@@ -1,0 +1,96 @@
+//
+//  PerformanceBenchmarkTests.swift
+//  ColorKitTests
+//
+//  Created by Agisilaos Tsaraboulidis on 01.09.2026.
+//
+//  Description:
+//  Tests for the performance benchmark result contract.
+//
+//  License:
+//  MIT License. See LICENSE file for details.
+//
+
+import XCTest
+
+@testable import ColorKit
+
+final class PerformanceBenchmarkTests: XCTestCase {
+    func testBlendingResultsPreserveOrderAndMeasurements() async {
+        let iterations = 100
+
+        let results = await benchmark(.blending, iterations: iterations)
+
+        XCTAssertEqual(results.map(\.name), [
+            "Blend Mode: normal",
+            "Blend Mode: multiply",
+            "Blend Mode: screen",
+            "Blend Mode: overlay",
+            "Blend Mode: darken",
+            "Blend Mode: lighten",
+            "Blend Mode: colorDodge",
+            "Blend Mode: colorBurn",
+            "Blend Mode: softLight",
+            "Blend Mode: hardLight",
+            "Blend Mode: difference",
+            "Blend Mode: exclusion"
+        ])
+        assertValidMeasurements(results, iterations: iterations)
+    }
+
+    func testConversionResultsPreservePresentationAndMeasurements() async {
+        let iterations = 100
+
+        let results = await benchmark(.conversion, iterations: iterations)
+
+        XCTAssertEqual(results.map(\.name), ["Color Space Conversion"])
+        assertValidMeasurements(results, iterations: iterations)
+    }
+
+    func testGradientResultsPreserveOrderAndMeasurements() async {
+        let iterations = 100
+
+        let results = await benchmark(.gradient, iterations: iterations)
+
+        XCTAssertEqual(results.map(\.name), ["Linear Gradient", "Radial Gradient"])
+        assertValidMeasurements(results, iterations: iterations)
+    }
+
+    func testAccessibilityResultsPreservePresentationAndMeasurements() async {
+        let iterations = 100
+
+        let results = await benchmark(.accessibility, iterations: iterations)
+
+        XCTAssertEqual(results.map(\.name), ["Contrast Ratio"])
+        assertValidMeasurements(results, iterations: iterations)
+    }
+
+    private func benchmark(
+        _ operation: BenchmarkOperation,
+        iterations: Int
+    ) async -> [BenchmarkResult] {
+        await Task.detached { [operation, iterations] in
+            PerformanceBenchmark.benchmark(operation: operation, iterations: iterations)
+        }.value
+    }
+
+    private func assertValidMeasurements(
+        _ results: [BenchmarkResult],
+        iterations: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for result in results {
+            XCTAssertGreaterThan(result.duration, 0, file: file, line: line)
+            XCTAssertTrue(result.duration.isFinite, file: file, line: line)
+            XCTAssertGreaterThan(result.operationsPerSecond, 0, file: file, line: line)
+            XCTAssertTrue(result.operationsPerSecond.isFinite, file: file, line: line)
+            XCTAssertEqual(
+                result.operationsPerSecond,
+                Double(iterations) / result.duration,
+                file: file,
+                line: line
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes F15 by keeping `PerformanceBenchmark`'s synchronous CPU workloads off `MainActor` while preserving the existing workloads, result ordering, timing boundaries, and presentation.

## Changes

- Snapshot the selected operation and iteration count on `MainActor`, then await a `.userInitiated` detached computation.
- Make the view-owned dispatcher and workload helpers synchronous and explicitly `nonisolated`.
- Make benchmark inputs and results explicitly `Sendable` across the executor boundary.
- Add XCTest coverage for every operation's result names, ordering, and threshold-free measurement invariants.

## Alternatives considered

Swift 6.2's `@concurrent` would provide a modern offload boundary but would raise ColorKit's declared Swift 6.0 toolchain requirement. A shared benchmark engine, stored task lifecycle, or cancellation redesign would broaden this focused correctness repair.

## Notes

- The formal Standards and Spec reviews both returned zero findings.
- Configuration controls remain interactive during a run; the in-flight workload uses the values captured at launch.
- Xcode Preview requires local authorization for the SwiftLint package plugin, so the interactive maximum-iteration smoke check remains pending.

## Screenshots

Screenshots pending.

## Testing

- `swiftlint lint --strict` — 0 violations.
- `swift test` — 194 tests passed.
- `swift test -Xswiftc -strict-concurrency=complete --filter PerformanceBenchmarkTests` — 4 tests passed.
- Focused `ColorKit/PerformanceBenchmarkTests` scheme runs passed on iOS Simulator 26.5 and macOS through `scripts/run_tests.sh`.
- Xcode Preview interaction was not run because the SwiftLint package plugin is not authorized in the local Xcode installation.
