### PR TITLE
fix(theme): Select canonical registered themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to ColorKit will be documented in this file.
 
 ### Changed
 - Isolate `ThemeManager` and `withThemeManager(_:)` to `MainActor`. Nonisolated callers must adopt actor-aware access; see [the migration guide](MIGRATION.md#unreleased-theme-ownership-f05).
+- Make `switchTo(theme:)` select the canonical registered theme with the supplied name instead of installing a same-name replacement payload; see [the migration guide](MIGRATION.md#unreleased-canonical-theme-selection-f06).
 
 ### Fixed
-- Publish successful theme registrations and refresh the environment theme on selection changes without requiring parent observation, while preserving nested overrides and selection semantics.
+- Publish successful theme registrations and refresh the environment theme on selection changes without requiring parent observation, while preserving nested overrides.
 - Round RGB and alpha channels to the nearest byte when generating hexadecimal colors, preserving round trips such as `#232323FF`.
 - Preserve already-compliant colors, including opacity, in `adjustedForAccessibility` and `highContrastColor` instead of replacing them with black or white.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,6 +55,9 @@ _Avoid_: White RGB color when referring to the reference white itself.
 **Theme registry**:
 The collection of themes available for selection, with each registered name appearing at most once. Registration alone does not select a theme.
 
+**Registered theme**:
+The canonical theme value associated with a unique name in the theme registry. A same-name theme supplied for selection identifies this value and does not replace it.
+
 **Current theme**:
 The theme selected by the theme manager. A view subtree may use a different theme through a local override.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,33 @@
 # Migration Guide
 
+## Unreleased: Canonical theme selection (F06)
+
+`switchTo(theme:)` now treats its argument as a selection request identified by
+name. When that name is registered, the manager selects the canonical registered
+theme rather than installing the supplied value.
+
+Previously, a caller could pass altered colors under an existing registered name
+and make that unregistered value current. Code relying on that behavior must give
+the variant a unique name, register it, and then select it:
+
+```swift
+let variant = ColorTheme(
+    name: "Custom Variant",
+    primary: .red,
+    secondary: .gray,
+    accent: .orange,
+    background: .white,
+    text: .black
+)
+
+manager.register(theme: variant)
+manager.switchTo(theme: variant)
+```
+
+The public method signatures and return values are unchanged. Both selection
+overloads return `false` and preserve the current theme when the requested name
+is not registered. F06 does not add replacement semantics for registered themes.
+
 ## Unreleased: Theme ownership (F05)
 
 `ThemeManager` is now isolated to `MainActor` as a whole. Previously only
@@ -39,10 +67,11 @@ publishes successful registrations. `withThemeManager(_:)` observes the manager
 itself, so parents no longer need to observe it just to refresh the environment.
 Local `applyTheme(_:)` overrides retain their normal subtree precedence.
 
-Selection behavior is unchanged: registration rejects duplicate names, switching
-by name selects the registered value, and switching by instance selects the
-supplied value if its name is registered. A failed switch leaves the selection
-unchanged. Changes to those semantics belong to F06.
+At the time of F05, selection behavior was unchanged: registration rejected
+duplicate names, switching by name selected the registered value, and switching
+by instance selected the supplied value if its name was registered. F06 now
+supersedes those instance-selection semantics; see
+[Canonical theme selection](#unreleased-canonical-theme-selection-f06).
 
 ## ColorKit 1.5.0
 

--- a/Sources/ColorKit/Theme/ThemeManager.swift
+++ b/Sources/ColorKit/Theme/ThemeManager.swift
@@ -213,10 +213,12 @@ public class ThemeManager: ObservableObject {
         return true
     }
 
-    /// Switches to a specific theme instance.
+    /// Switches to the registered theme identified by a theme instance.
     ///
-    /// This method attempts to activate the provided theme. The theme must be
-    /// registered with the manager for the switch to succeed.
+    /// This method uses the provided theme's name to find and activate the
+    /// registered theme. The provided value does not replace the registered
+    /// value, even when its colors differ. If no matching name is registered,
+    /// the current theme remains unchanged.
     ///
     /// Example:
     /// ```swift
@@ -236,15 +238,10 @@ public class ThemeManager: ObservableObject {
     /// }
     /// ```
     ///
-    /// - Parameter theme: The theme to switch to
-    /// - Returns: `true` if the theme was found and applied, `false` otherwise
+    /// - Parameter theme: A theme whose name identifies the registered theme to select
+    /// - Returns: `true` if a registered theme was found and applied, `false` otherwise
     @discardableResult
     public func switchTo(theme: ColorTheme) -> Bool {
-        guard availableThemes.contains(where: { $0.name == theme.name }) else {
-            return false
-        }
-
-        currentTheme = theme
-        return true
+        switchToTheme(named: theme.name)
     }
 }

--- a/Tests/ColorKitTests/ThemeManagerIntegrationTests.swift
+++ b/Tests/ColorKitTests/ThemeManagerIntegrationTests.swift
@@ -39,28 +39,40 @@ final class ThemeManagerIntegrationTests: XCTestCase {
         XCTAssertEqual(objectChanges, 1)
     }
 
-    func testSelectionPreservesNameAndInstanceSemantics() {
+    func testSelectionOverloadsResolveToRegisteredTheme() throws {
         let manager = ThemeManager.shared
         let originalTheme = manager.currentTheme
-        defer { manager.switchTo(theme: originalTheme) }
-        let registeredTheme = makeTheme()
-        let suppliedTheme = makeTheme(name: registeredTheme.name, primary: .red)
+        let originalRegistry = manager.availableThemes
+        defer { manager.switchToTheme(named: originalTheme.name) }
+        let lightTheme = try XCTUnwrap(originalRegistry.first { $0.name == "Default Light" })
+        let darkTheme = try XCTUnwrap(originalRegistry.first { $0.name == "Default Dark" })
+        let suppliedDarkTheme = makeTheme(name: darkTheme.name, primary: .red)
+
+        XCTAssertNotEqual(suppliedDarkTheme, darkTheme)
+        XCTAssertTrue(manager.switchToTheme(named: lightTheme.name))
+        XCTAssertEqual(manager.currentTheme, lightTheme)
+        XCTAssertTrue(manager.switchToTheme(named: darkTheme.name))
+        XCTAssertEqual(manager.currentTheme, darkTheme)
+
+        XCTAssertTrue(manager.switchToTheme(named: lightTheme.name))
+        XCTAssertEqual(manager.currentTheme, lightTheme)
+        XCTAssertTrue(manager.switchTo(theme: suppliedDarkTheme))
+        XCTAssertEqual(manager.currentTheme, darkTheme)
+        XCTAssertEqual(manager.availableThemes, originalRegistry)
+    }
+
+    func testSelectionOverloadsPreserveStateWhenNameIsMissing() {
+        let manager = ThemeManager.shared
+        let originalTheme = manager.currentTheme
+        let originalRegistry = manager.availableThemes
+        defer { manager.switchToTheme(named: originalTheme.name) }
         let missingTheme = makeTheme()
 
-        XCTAssertTrue(manager.availableThemes.contains { $0.name == "Default Light" })
-        XCTAssertTrue(manager.availableThemes.contains { $0.name == "Default Dark" })
-        XCTAssertTrue(manager.register(theme: registeredTheme))
-        XCTAssertNotEqual(registeredTheme, suppliedTheme)
-        XCTAssertTrue(manager.switchTo(theme: suppliedTheme))
-        XCTAssertEqual(manager.currentTheme, suppliedTheme)
-        XCTAssertEqual(manager.availableThemes.last, registeredTheme)
-
         XCTAssertFalse(manager.switchToTheme(named: missingTheme.name))
+        XCTAssertEqual(manager.currentTheme, originalTheme)
         XCTAssertFalse(manager.switchTo(theme: missingTheme))
-        XCTAssertEqual(manager.currentTheme, suppliedTheme)
-
-        XCTAssertTrue(manager.switchToTheme(named: registeredTheme.name))
-        XCTAssertEqual(manager.currentTheme, registeredTheme)
+        XCTAssertEqual(manager.currentTheme, originalTheme)
+        XCTAssertEqual(manager.availableThemes, originalRegistry)
     }
 
     func testEnvironmentThemeUpdatesWithoutParentObservation() async {

--- a/Tests/ColorKitTests/ThemeManagerIntegrationTests.swift
+++ b/Tests/ColorKitTests/ThemeManagerIntegrationTests.swift
@@ -61,7 +61,7 @@ final class ThemeManagerIntegrationTests: XCTestCase {
         XCTAssertEqual(manager.availableThemes, originalRegistry)
     }
 
-    func testSelectionOverloadsPreserveStateWhenNameIsMissing() {
+    func testSelectionOverloadsPreserveStateForUnregisteredTheme() {
         let manager = ThemeManager.shared
         let originalTheme = manager.currentTheme
         let originalRegistry = manager.availableThemes

--- a/docs/design/theme-ownership.md
+++ b/docs/design/theme-ownership.md
@@ -13,7 +13,7 @@ Status: accepted for implementation.
 
 ## Existing selection behavior to preserve
 
-Registration rejects duplicate names and does not change the current theme. Switching by name selects the registered value; switching by instance checks that its name is registered but selects the supplied value, even if its colors differ from the registered value. Failed switches leave the current theme unchanged.
+Registration rejects duplicate names and does not change the current theme. At the time of F05, switching by name selected the registered value while switching by instance selected the supplied value after checking its name. [F06 canonical theme selection](theme-selection.md) supersedes that instance-selection behavior. Failed switches still leave the current theme unchanged.
 
 ## Required validation
 

--- a/docs/design/theme-selection.md
+++ b/docs/design/theme-selection.md
@@ -1,0 +1,40 @@
+# F06 — Canonical theme selection
+
+Status: accepted and implemented.
+
+## Resolved behavior
+
+- The theme registry owns the canonical value for every registered name.
+- `switchTo(theme:)` treats its argument as a name-bearing selection request. When the supplied theme has a registered name but different colors, the registered theme becomes the current theme.
+- `switchTo(theme:)` delegates directly to `switchToTheme(named:)`, making the named selector the single implementation of registry lookup and selection.
+- The behavior change is deliberate: a same-name supplied theme is no longer installed outside the registry.
+
+## Preserved boundaries
+
+- `ThemeManager` remains isolated to `MainActor`.
+- Both public method names, parameter labels, and return types remain unchanged.
+- Registry lookup retains its existing order.
+- An unregistered name returns `false` and leaves the current theme unchanged.
+
+## Non-goal
+
+F06 does not add a way to replace or update a registered theme. A distinct variant must use a unique name and be registered before selection; a deliberate replacement API, if needed, is separate work.
+
+## Test design
+
+Cover both return-value parity and resulting-state parity without registering test fixtures:
+
+- For successful selection, use both existing default registrations. Select Default Light as the baseline, select Default Dark through the named overload, return to Default Light, then select through the instance overload using a deliberately different payload named Default Dark. Both overloads must return `true` and select the registered Default Dark value. The intervening baseline transition prevents a no-op implementation from passing.
+- For failed selection, use one unregistered name. Both overloads must return `false` and leave the current theme unchanged.
+- Snapshot the registry and assert it is unchanged by both scenarios.
+- Restore the previous current theme after each test so later singleton tests do not inherit the selection.
+
+Failed-switch coverage is state-based: it verifies the return value, current theme, and registry. It does not make exact Combine notification counts part of the contract.
+
+## Documentation
+
+- Update the `switchTo(theme:)` API comment to say that the argument identifies a registered theme by name and that the registered value is selected.
+- Add an Unreleased F06 migration section describing the deliberate same-name payload behavior change.
+- Tell callers that relied on installing altered colors under an existing name to register the variant under a unique name.
+- Add the behavior change to the Unreleased changelog.
+- Keep the accepted F05 design note as historical context, but point readers to F06 where its preserved selection semantics are superseded.


### PR DESCRIPTION
## Summary

Make the theme registry authoritative when selecting through `switchTo(theme:)`. A supplied theme now identifies the registered theme by name instead of installing an unregistered same-name payload.

## Changes

- Delegate instance-based selection to `switchToTheme(named:)` so both overloads share registry lookup and selection behavior.
- Replace the previous mixed-semantics test with focused success and failure parity tests using existing registrations without polluting singleton state.
- Document the deliberate semantic change in the API comment, migration guide, changelog, glossary, and F05/F06 design notes.

## Alternatives considered

- Adding a replacement API for registered themes was rejected as separate design work; callers needing a variant can register it under a unique name.
- Keeping duplicate lookup and assignment logic in both overloads was rejected because it could let their behavior diverge again.

## Notes

This is source-compatible but deliberately changes behavior for callers that pass altered colors under an existing registered name. Migration guidance is included. The commits are unsigned because the configured 1Password signer was unavailable; the repository does not require signed commits.

## Screenshots

Not applicable; no UI changes.

## Testing

- `swift test`: 195 tests passed.
- `swift test -Xswiftc -strict-concurrency=complete --filter ThemeManagerIntegrationTests`: 6 tests passed, including a clean isolated rerun before opening this PR.
- Focused ThemeManager integration tests passed through the repository test runner on iOS Simulator and macOS.
- `swiftlint lint --strict`: zero violations.
- `git diff --check`: passed.
