### PR TITLE
fix(wcag): Replace redundant endpoint loop

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,12 @@ A foreground color whose existing contrast against the specified background meet
 **Exhausted adjustment**:
 A contrast adjustment attempt that ends without finding a color that meets the requested minimum. It does not establish that no suitable color exists.
 
+**Directional endpoint attempt**:
+A contrast adjustment candidate at the lightness endpoint selected by the existing direction: zero when darkening and one when lightening. Failure preserves that direction and does not cause the opposite endpoint to be considered.
+
+**Successful directional endpoint attempt**:
+A directional endpoint attempt whose contrast meets the requested level. It is distinct from an already-compliant input, which succeeds before any adjustment is attempted.
+
 **Contrast fallback**:
 The black or white color selected when contrast adjustment is unsuccessful. It is not guaranteed to meet every requested minimum.
 _Avoid_: Guaranteed compliant color

--- a/Sources/ColorKit/WCAG/WCAGColorSuggestions.swift
+++ b/Sources/ColorKit/WCAG/WCAGColorSuggestions.swift
@@ -57,13 +57,6 @@ public struct WCAGColorSuggestions {
     /// the original saturation.
     private static let initialSaturationFactor: CGFloat = 0.8
 
-    /// Step size for reducing saturation.
-    ///
-    /// The amount by which saturation is reduced in each iteration when
-    /// searching for a compliant color. Value of 0.2 means reducing
-    /// saturation by 20% each step.
-    private static let saturationStepSize: CGFloat = 0.2
-
     /// The base color that will remain unchanged (typically the background).
     private let baseColor: Color
 
@@ -205,29 +198,20 @@ public struct WCAGColorSuggestions {
     /// Generates suggestions by adjusting both saturation and lightness.
     ///
     /// This method is used when lightness adjustments alone cannot achieve
-    /// the required contrast ratio. It progressively reduces saturation
-    /// while setting lightness to either minimum or maximum.
+    /// the required contrast ratio. It checks the directional lightness endpoint
+    /// using the initial saturation adjustment.
     private func generateSaturationAdjustedSuggestions(
         from hsl: (hue: CGFloat, saturation: CGFloat, lightness: CGFloat),
         needsDarkening: Bool
     ) -> [Color] {
-        var saturationFactor = Self.initialSaturationFactor
-        while saturationFactor > 0 {
-            let adjustedSaturation = hsl.saturation * saturationFactor
-            let adjustedLightness = needsDarkening ? 0.0 : 1.0
+        let adjustedSaturation = hsl.saturation * Self.initialSaturationFactor
+        let adjustedLightness = needsDarkening ? 0.0 : 1.0
+        let adjustedColor = Color(
+            hue: hsl.hue,
+            saturation: adjustedSaturation,
+            lightness: CGFloat(adjustedLightness)
+        )
 
-            let adjustedColor = Color(
-                hue: hsl.hue,
-                saturation: adjustedSaturation,
-                lightness: CGFloat(adjustedLightness)
-            )
-
-            if isColorCompliant(adjustedColor) {
-                return [adjustedColor]
-            }
-
-            saturationFactor -= Self.saturationStepSize
-        }
-        return []
+        return isColorCompliant(adjustedColor) ? [adjustedColor] : []
     }
 }

--- a/Sources/ColorKit/WCAG/WCAGColorSuggestions.swift
+++ b/Sources/ColorKit/WCAG/WCAGColorSuggestions.swift
@@ -50,11 +50,10 @@ public struct WCAGColorSuggestions {
     /// A higher number of steps provides more granular adjustments but may impact performance.
     private static let defaultLightnessSteps = 10
 
-    /// Starting saturation factor for adjustments.
+    /// Saturation factor for the directional endpoint attempt.
     ///
-    /// The initial saturation multiplier when attempting to achieve compliance
-    /// through saturation adjustments. Value of 0.8 means starting at 80% of
-    /// the original saturation.
+    /// The multiplier used to construct the single directional endpoint candidate.
+    /// A value of 0.8 uses 80% of the original saturation.
     private static let initialSaturationFactor: CGFloat = 0.8
 
     /// The base color that will remain unchanged (typically the background).
@@ -195,7 +194,7 @@ public struct WCAGColorSuggestions {
         return []
     }
 
-    /// Generates suggestions by adjusting both saturation and lightness.
+    /// Generates a suggestion by adjusting both saturation and lightness.
     ///
     /// This method is used when lightness adjustments alone cannot achieve
     /// the required contrast ratio. It checks the directional lightness endpoint

--- a/Tests/ColorKitTests/WCAG/WCAGColorSuggestionsTests.swift
+++ b/Tests/ColorKitTests/WCAG/WCAGColorSuggestionsTests.swift
@@ -8,11 +8,12 @@ final class WCAGColorSuggestionsTests: XCTestCase {
         try assertPreservedHueSuggestion(
             baseColor: .white,
             targetColor: Color(.sRGB, red: 1, green: 0.8, blue: 0.2, opacity: 1),
+            knownCompliantIntermediateLightness: 0.24,
             needsDarkening: true
         )
     }
 
-    func testSuccessfulDarkeningEndpointWithoutHuePreservation() throws {
+    func testSuccessfulDirectionalEndpointAttemptWhenDarkeningWithoutHuePreservation() throws {
         let baseColor = Color.white
         let targetColor = Color(.sRGB, red: 1, green: 1, blue: 0.8, opacity: 1)
 
@@ -35,11 +36,12 @@ final class WCAGColorSuggestionsTests: XCTestCase {
         try assertPreservedHueSuggestion(
             baseColor: .black,
             targetColor: Color(.sRGB, red: 0, green: 0, blue: 0.3, opacity: 1),
+            knownCompliantIntermediateLightness: 0.745,
             needsDarkening: false
         )
     }
 
-    func testSuccessfulLighteningEndpointWithoutHuePreservation() throws {
+    func testSuccessfulDirectionalEndpointAttemptWhenLighteningWithoutHuePreservation() throws {
         let baseColor = Color.black
         let targetColor = Color(.sRGB, red: 0, green: 0, blue: 0.3, opacity: 1)
 
@@ -80,7 +82,7 @@ final class WCAGColorSuggestionsTests: XCTestCase {
         }
     }
 
-    func testFailedLighteningEndpointPreservesWhiteFallbackForBothHueSettings() throws {
+    func testFailedDirectionalEndpointAttemptPreservesWhiteContrastFallbackForBothHueSettings() throws {
         let baseColor = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5, opacity: 1)
         let targetColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6, opacity: 1)
 
@@ -124,6 +126,7 @@ final class WCAGColorSuggestionsTests: XCTestCase {
     private func assertPreservedHueSuggestion(
         baseColor: Color,
         targetColor: Color,
+        knownCompliantIntermediateLightness: CGFloat,
         needsDarkening: Bool,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -131,6 +134,22 @@ final class WCAGColorSuggestionsTests: XCTestCase {
         let targetHSL = try XCTUnwrap(targetColor.hslComponents(), file: file, line: line)
         XCTAssertEqual(baseColor.wcagRelativeLuminance() > 0.5, needsDarkening, file: file, line: line)
         XCTAssertFalse(baseColor.wcagCompliance(with: targetColor).passes.contains(.AA), file: file, line: line)
+        XCTAssertEqual(
+            knownCompliantIntermediateLightness < targetHSL.lightness,
+            needsDarkening,
+            file: file,
+            line: line
+        )
+        let knownCompliantIntermediate = Color(
+            hue: targetHSL.hue,
+            saturation: targetHSL.saturation,
+            lightness: knownCompliantIntermediateLightness
+        )
+        XCTAssertTrue(
+            baseColor.wcagCompliance(with: knownCompliantIntermediate).passes.contains(.AA),
+            file: file,
+            line: line
+        )
 
         let suggestions = WCAGColorSuggestions(
             baseColor: baseColor,

--- a/Tests/ColorKitTests/WCAG/WCAGColorSuggestionsTests.swift
+++ b/Tests/ColorKitTests/WCAG/WCAGColorSuggestionsTests.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class WCAGColorSuggestionsTests: XCTestCase {
+    func testLightnessSearchPreservesHueAndSaturationWhenDarkening() throws {
+        try assertPreservedHueSuggestion(
+            baseColor: .white,
+            targetColor: Color(.sRGB, red: 1, green: 0.8, blue: 0.2, opacity: 1),
+            needsDarkening: true
+        )
+    }
+
+    func testSuccessfulDarkeningEndpointWithoutHuePreservation() throws {
+        let baseColor = Color.white
+        let targetColor = Color(.sRGB, red: 1, green: 1, blue: 0.8, opacity: 1)
+
+        XCTAssertNotNil(targetColor.hslComponents())
+        XCTAssertGreaterThan(baseColor.wcagRelativeLuminance(), 0.5)
+        XCTAssertFalse(baseColor.wcagCompliance(with: targetColor).passes.contains(.AA))
+        XCTAssertTrue(baseColor.wcagCompliance(with: .black).passes.contains(.AA))
+
+        let suggestions = WCAGColorSuggestions(
+            baseColor: baseColor,
+            targetColor: targetColor,
+            targetLevel: .AA
+        ).generateSuggestions(preserveHue: false)
+
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertEqual(try XCTUnwrap(suggestions.first), .black)
+    }
+
+    func testLightnessSearchPreservesHueAndSaturationWhenLightening() throws {
+        try assertPreservedHueSuggestion(
+            baseColor: .black,
+            targetColor: Color(.sRGB, red: 0, green: 0, blue: 0.3, opacity: 1),
+            needsDarkening: false
+        )
+    }
+
+    func testSuccessfulLighteningEndpointWithoutHuePreservation() throws {
+        let baseColor = Color.black
+        let targetColor = Color(.sRGB, red: 0, green: 0, blue: 0.3, opacity: 1)
+
+        XCTAssertNotNil(targetColor.hslComponents())
+        XCTAssertLessThanOrEqual(baseColor.wcagRelativeLuminance(), 0.5)
+        XCTAssertFalse(baseColor.wcagCompliance(with: targetColor).passes.contains(.AA))
+        XCTAssertTrue(baseColor.wcagCompliance(with: .white).passes.contains(.AA))
+
+        let suggestions = WCAGColorSuggestions(
+            baseColor: baseColor,
+            targetColor: targetColor,
+            targetLevel: .AA
+        ).generateSuggestions(preserveHue: false)
+
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertEqual(try XCTUnwrap(suggestions.first), .white)
+    }
+
+    func testAlreadyCompliantInputsRemainUnchangedForBothHueSettings() throws {
+        let fixtures = [
+            (baseColor: Color.white, targetColor: Color.black.opacity(0.8)),
+            (baseColor: Color.black, targetColor: Color.white)
+        ]
+
+        for fixture in fixtures {
+            XCTAssertTrue(fixture.baseColor.wcagCompliance(with: fixture.targetColor).passes.contains(.AA))
+
+            for preserveHue in [true, false] {
+                let suggestions = WCAGColorSuggestions(
+                    baseColor: fixture.baseColor,
+                    targetColor: fixture.targetColor,
+                    targetLevel: .AA
+                ).generateSuggestions(preserveHue: preserveHue)
+
+                XCTAssertEqual(suggestions.count, 1)
+                XCTAssertEqual(try XCTUnwrap(suggestions.first), fixture.targetColor)
+            }
+        }
+    }
+
+    func testFailedLighteningEndpointPreservesWhiteFallbackForBothHueSettings() throws {
+        let baseColor = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5, opacity: 1)
+        let targetColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6, opacity: 1)
+
+        XCTAssertNotNil(targetColor.hslComponents())
+        XCTAssertLessThanOrEqual(baseColor.wcagRelativeLuminance(), 0.5)
+        XCTAssertFalse(baseColor.wcagCompliance(with: targetColor).passes.contains(.AAA))
+        XCTAssertFalse(baseColor.wcagCompliance(with: .white).passes.contains(.AAA))
+
+        for preserveHue in [true, false] {
+            let suggestions = WCAGColorSuggestions(
+                baseColor: baseColor,
+                targetColor: targetColor,
+                targetLevel: .AAA
+            ).generateSuggestions(preserveHue: preserveHue)
+
+            XCTAssertEqual(suggestions.count, 1)
+            XCTAssertEqual(try XCTUnwrap(suggestions.first), .white)
+            XCTAssertFalse(baseColor.wcagCompliance(with: .white).passes.contains(.AAA))
+        }
+    }
+
+    func testUnavailableHSLTargetRemainsUnchanged() throws {
+        let baseColor = Color.black
+        let targetColor = try patternTestColor()
+
+        XCTAssertNil(targetColor.hslComponents())
+        XCTAssertFalse(baseColor.wcagCompliance(with: targetColor).passes.contains(.AA))
+
+        for preserveHue in [true, false] {
+            let suggestions = WCAGColorSuggestions(
+                baseColor: baseColor,
+                targetColor: targetColor,
+                targetLevel: .AA
+            ).generateSuggestions(preserveHue: preserveHue)
+
+            XCTAssertEqual(suggestions.count, 1)
+            XCTAssertEqual(try XCTUnwrap(suggestions.first), targetColor)
+        }
+    }
+
+    private func assertPreservedHueSuggestion(
+        baseColor: Color,
+        targetColor: Color,
+        needsDarkening: Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let targetHSL = try XCTUnwrap(targetColor.hslComponents(), file: file, line: line)
+        XCTAssertEqual(baseColor.wcagRelativeLuminance() > 0.5, needsDarkening, file: file, line: line)
+        XCTAssertFalse(baseColor.wcagCompliance(with: targetColor).passes.contains(.AA), file: file, line: line)
+
+        let suggestions = WCAGColorSuggestions(
+            baseColor: baseColor,
+            targetColor: targetColor,
+            targetLevel: .AA
+        ).generateSuggestions(preserveHue: true)
+
+        XCTAssertEqual(suggestions.count, 1, file: file, line: line)
+        let suggestion = try XCTUnwrap(suggestions.first, file: file, line: line)
+        XCTAssertNotEqual(suggestion, needsDarkening ? .black : .white, file: file, line: line)
+        XCTAssertTrue(baseColor.wcagCompliance(with: suggestion).passes.contains(.AA), file: file, line: line)
+
+        let suggestionHSL = try XCTUnwrap(suggestion.hslComponents(), file: file, line: line)
+        if needsDarkening {
+            XCTAssertLessThan(suggestionHSL.lightness, targetHSL.lightness, file: file, line: line)
+        } else {
+            XCTAssertGreaterThan(suggestionHSL.lightness, targetHSL.lightness, file: file, line: line)
+        }
+        let hueDistance = min(abs(targetHSL.hue - suggestionHSL.hue), 1 - abs(targetHSL.hue - suggestionHSL.hue))
+        XCTAssertEqual(hueDistance, 0, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(suggestionHSL.saturation, targetHSL.saturation, accuracy: 0.01, file: file, line: line)
+    }
+}

--- a/docs/design/wcag-saturation-endpoint.md
+++ b/docs/design/wcag-saturation-endpoint.md
@@ -1,0 +1,103 @@
+# F08 — Single directional saturation endpoint attempt
+
+Status: accepted and implemented.
+
+## Problem
+
+`WCAGColorSuggestions.generateSaturationAdjustedSuggestions` currently checks saturation factors `0.8`, `0.6`, `0.4`, and `0.2` while fixing HSL lightness at zero when darkening or one when lightening. At either lightness endpoint, HSL construction produces black or white regardless of hue or saturation, so every iteration checks the same effective color.
+
+F08 removes the redundant checks without changing which endpoint is tried or what happens before or after that attempt.
+
+## Agreed scope
+
+- Replace the saturation-adjustment loop with one directional endpoint attempt.
+- Preserve the first iteration's construction exactly:
+  - multiply the source HSL saturation by `initialSaturationFactor`, which remains `0.8`;
+  - use lightness `0` when `needsDarkening` is true and `1` otherwise;
+  - construct the candidate with `Color(hue:saturation:lightness:)` using the source hue, adjusted saturation, and directional lightness endpoint.
+- Check that candidate once with the existing `isColorCompliant` method.
+- Return a one-element array containing the candidate on success and an empty array on failure.
+- Remove `saturationStepSize` and comments that describe progressive saturation reduction. Retain the existing private helper and its place in the generation sequence.
+
+The one-attempt body is equivalent to the loop's first pass:
+
+```swift
+let adjustedSaturation = hsl.saturation * Self.initialSaturationFactor
+let adjustedLightness = needsDarkening ? 0.0 : 1.0
+let adjustedColor = Color(
+    hue: hsl.hue,
+    saturation: adjustedSaturation,
+    lightness: CGFloat(adjustedLightness)
+)
+
+return isColorCompliant(adjustedColor) ? [adjustedColor] : []
+```
+
+This is an implementation target, not authorization to alter the surrounding algorithm.
+
+## Existing behavior to preserve
+
+- An already-compliant input is returned unchanged before HSL conversion or adjustment, for either `preserveHue` value.
+- A target whose HSL components are unavailable is returned unchanged.
+- Direction remains based solely on `baseColor.wcagRelativeLuminance() > 0.5`: true selects darkening and false selects lightening.
+- With `preserveHue == true`, the existing ten-step lightness search runs first with the original hue and saturation. The endpoint attempt runs only if that search returns no suggestion.
+- With `preserveHue == false`, the lightness search remains skipped and the single directional endpoint attempt runs immediately.
+- Compliance remains `baseColor.wcagCompliance(with: candidate).passes.contains(targetLevel)`.
+- An exhausted adjustment still falls back to black when darkening and white when lightening, even if that fallback does not meet the requested level.
+- Generation continues to return exactly one color on every existing terminal path.
+
+## Excluded work
+
+- Do not compare black and white or select the stronger endpoint.
+- Do not try the endpoint opposite the existing direction.
+- Do not add or imply a guarantee that every returned suggestion meets the requested level.
+- Do not change the direction threshold, HSL initializer, lightness search, target levels, compliance calculation, fallback, or public API.
+- Do not introduce a generalized candidate-search abstraction, strategy type, instrumentation hook, or test-only visibility change.
+- Do not redesign hue preservation or other accessibility-adjustment APIs.
+
+## Validation approach
+
+Use focused black-box tests through `WCAGColorSuggestions.generateSuggestions(preserveHue:)`. Establish every fixture's routing preconditions independently so a passing result cannot conceal entry into the wrong branch. Keep the helper private; verify the exactly-one-attempt property structurally in the production diff.
+
+### Direction and hue-preservation matrix
+
+| Direction | `preserveHue` | Required route and assertions |
+| --- | --- | --- |
+| Darkening | `true` | Use a noncompliant chromatic target against a base whose luminance is greater than `0.5`, with a compliant intermediate lightness candidate. Assert the result moves to lower lightness, is not black, preserves hue using circular hue distance, preserves saturation within conversion tolerance, and meets the requested level. This validates that the unchanged lightness search still wins before the endpoint attempt. |
+| Darkening | `false` | Use a noncompliant target against a base whose luminance is greater than `0.5`. Independently assert that black meets the requested level, then assert the result is black. This is a successful directional endpoint attempt with the lightness search skipped. |
+| Lightening | `true` | Use a noncompliant chromatic target against a base whose luminance is at most `0.5`, with a compliant intermediate lightness candidate. Assert the result moves to higher lightness, is not white, preserves hue using circular hue distance, preserves saturation within conversion tolerance, and meets the requested level. This validates that the unchanged lightness search still wins before the endpoint attempt. |
+| Lightening | `false` | Use a noncompliant target against a sufficiently dark base whose luminance is at most `0.5`. Independently assert that white meets the requested level, then assert the result is white. This is a successful directional endpoint attempt with the lightness search skipped. |
+
+For each case, assert before generation that the target has HSL components, the target initially fails the requested level, and the base luminance selects the stated direction. Assert that generation returns exactly one color.
+
+### Already-compliant inputs
+
+Use already-compliant targets in both light-base and dark-base contexts. For each target, call generation with `preserveHue` set to both `true` and `false` and assert that the exact original `Color` value is returned as the sole result. Include opacity in at least one fixture so the assertion proves the original value was returned rather than reconstructed. Direction is only hypothetical in these cases because the early return must occur before direction selection.
+
+### Failed directional endpoint and fallback
+
+Use a noncompliant target and a base with luminance at most `0.5` but high enough that white fails `.AAA`. Establish these facts before generation:
+
+- the target fails `.AAA`;
+- the base selects lightening;
+- the white directional endpoint also fails `.AAA`.
+
+Run the fixture with both hue-preservation settings:
+
+- With `preserveHue == false`, the single endpoint attempt fails and generation returns the unchanged white contrast fallback.
+- With `preserveHue == true`, the lightness search exhausts, the same endpoint attempt fails, and generation returns the unchanged white contrast fallback.
+
+In both cases, assert that white is the sole result and still fails `.AAA`. This protects fallback behavior without creating a new accessibility guarantee.
+
+A failed darkening endpoint is unreachable under the current public levels: darkening requires base luminance greater than `0.5`, which gives black a contrast ratio greater than `11:1`, above the maximum `.AAA` requirement of `7:1`. Do not fabricate a private level or alter direction merely to add a symmetric failure case.
+
+### Structural and regression checks
+
+- Inspect the helper after implementation: it contains no loop or saturation decrement, constructs one candidate, and performs one compliance branch.
+- Confirm `saturationStepSize` is removed and `initialSaturationFactor` remains `0.8`.
+- Run the focused suggestion tests and the existing WCAG test suite on macOS and iOS Simulator where available, because SwiftUI color conversion is platform-backed.
+- Run the repository's normal lint and formatting checks, including `git diff --check`.
+
+## Documentation boundary
+
+The domain glossary defines already-compliant input, directional endpoint attempt, successful directional endpoint attempt, exhausted adjustment, and contrast fallback. This design note holds F08's localized implementation and validation contract. No ADR is needed because the correction is narrow, unsurprising once the HSL endpoint behavior is understood, and inexpensive to reverse.


### PR DESCRIPTION
## Summary

Replace the redundant saturation-adjustment loop in `WCAGColorSuggestions` with its first behaviorally equivalent directional endpoint attempt. Every former iteration fixed lightness at black or white, making its changing saturation factor observationally irrelevant.

## Changes

- Construct and check one endpoint candidate using the retained `0.8` saturation factor and existing direction.
- Remove the unused saturation decrement and stale progressive-search documentation.
- Add black-box coverage for both directions, both hue-preservation paths, already-compliant identity, unavailable HSL conversion, successful endpoint attempts, and failed-endpoint fallback.
- Record the accepted F08 behavior, exclusions, validation matrix, and domain vocabulary.

## Alternatives considered

- Comparing both endpoints or selecting the stronger endpoint was rejected because it would change existing behavior.
- Exposing the private helper or adding instrumentation to count attempts was rejected in favor of public regression coverage and structural diff verification.
- Introducing a generalized candidate-search abstraction was rejected as unnecessary for this localized correction.

## Notes

The returned colors, direction threshold, lightness search, compliance calculation, fallback, and public API remain unchanged. A failed lightening endpoint can still return the existing white contrast fallback even when it does not meet `.AAA`; this PR does not introduce a new accessibility guarantee. Commits are unsigned because the configured 1Password signer was unavailable; the repository does not require signed commits.

## Screenshots

Not applicable; no UI changes.

## Testing

- `swift test`: 202 tests passed on the combined current-main tree.
- `swift test --filter WCAGColorSuggestionsTests`: 7 focused tests passed, including a final pre-push rerun.
- Focused F08 and merged F06 suites passed through the repository test runner on iOS Simulator and macOS.
- `swiftlint lint --strict`: zero violations.
- `git diff --check`: passed.
