### PR TITLE
fix(export): reject nonfinite JSON components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 ## Agent skills
 
+### Branch naming
+
+Branch names must start with `feature/`, `fix/`, `refactor/`, or `chore/`.
+
 ### Issue tracker
 
 Issues and PRDs live in GitHub Issues for `agisilaos/ColorKit`; external PRs are also a triage surface. See `docs/agents/issue-tracker.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to ColorKit will be documented in this file.
 - Make `switchTo(theme:)` select the canonical registered theme with the supplied name instead of installing a same-name replacement payload; see [the migration guide](MIGRATION.md#unreleased-canonical-theme-selection-f06).
 
 ### Fixed
+- Return `nil` from JSON palette export when a resolved RGBA component is nonfinite instead of raising a Foundation exception.
 - Publish successful theme registrations and refresh the environment theme on selection changes without requiring parent observation, while preserving nested overrides.
 - Round RGB and alpha channels to the nearest byte when generating hexadecimal colors, preserving round trips such as `#232323FF`.
 - Preserve already-compliant colors, including opacity, in `adjustedForAccessibility` and `highContrastColor` instead of replacing them with black or white.

--- a/Sources/ColorKit/Utilities/PaletteExporter.swift
+++ b/Sources/ColorKit/Utilities/PaletteExporter.swift
@@ -101,7 +101,8 @@ public struct PaletteExporter {
     /// - Parameters:
     ///   - palette: The array of colors to export
     ///   - paletteName: The name of the palette
-    /// - Returns: JSON data representing the palette
+    /// - Returns: JSON data representing the palette, or `nil` if a resolved
+    ///   color component is nonfinite
     private static func exportToJSON(palette: [PaletteEntry], paletteName: String) -> Data? {
         var jsonObject: [String: Any] = [
             "name": paletteName,
@@ -112,6 +113,9 @@ public struct PaletteExporter {
 
         for entry in palette {
             let rgba = entry.color.rgbaComponents()
+            guard [rgba.red, rgba.green, rgba.blue, rgba.alpha].allSatisfy(\.isFinite) else {
+                return nil
+            }
 
             let colorDict: [String: Any] = [
                 "name": entry.name,

--- a/Tests/ColorKitTests/PaletteExporterTests.swift
+++ b/Tests/ColorKitTests/PaletteExporterTests.swift
@@ -74,6 +74,18 @@ final class PaletteExporterTests: XCTestCase {
         }
     }
 
+    func testExportToJSONRejectsNonfiniteAlpha() {
+        let palette = [
+            PaletteExporter.PaletteEntry(
+                name: "Invalid Alpha",
+                color: Color(.sRGB, red: 0.25, green: 0.5, blue: 0.75, opacity: .nan)
+            )
+        ]
+
+        XCTAssertTrue(palette[0].color.rgbaComponents().alpha.isNaN)
+        XCTAssertNil(PaletteExporter.export(palette: palette, to: .json, paletteName: "Invalid"))
+    }
+
     func testExportToCSS() {
         // Export to CSS
         guard let cssData = PaletteExporter.export(

--- a/docs/screenshots/f11/README.md
+++ b/docs/screenshots/f11/README.md
@@ -63,9 +63,8 @@ scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
   -skipPackagePluginValidation -skipMacroValidation
 ```
 
-## Existing serializer limitation
+## Serializer follow-up
 
-An exploratory non-finite-alpha JSON fixture raises `NSInvalidArgumentException`
-in `JSONSerialization`, rather than returning nil. That is outside F11's UI scope;
-serializers remain unchanged. Failure-alert checks above use explicit nil/false
-results instead of treating that exception as an ordinary export failure.
+F11 left JSON serialization unchanged. A later focused fix made nonfinite resolved
+RGBA components return `nil` before calling `JSONSerialization`, so the exploratory
+nonfinite-alpha fixture no longer raises `NSInvalidArgumentException`.


### PR DESCRIPTION
## Summary

Prevent JSON palette export from passing nonfinite resolved color components to Foundation, which otherwise raises an Objective-C exception that Swift error handling cannot catch. This PR also records the repository's approved branch-name prefixes.

## Changes

- Return `nil` when any resolved RGBA component is nonfinite before building the JSON object.
- Add a regression test covering a color with a `NaN` alpha channel.
- Update the changelog and F11 serializer validation notes.
- Document `feature/`, `fix/`, `refactor/`, and `chore/` branch prefixes in `AGENTS.md`.

## Alternatives considered

Rejecting nonfinite values in shared color resolution was considered, but that would broaden the behavior change to export formats that do not require JSON-safe finite numbers. Leaving branch naming implicit was also rejected because it allowed inconsistent generated branch names.

## Notes

No public API or migration changes are required. Other export formats retain their existing behavior.

## Screenshots

Not applicable; no UI changes.

## Testing

- 20 relevant exporter and accessible-export integration tests passed on macOS.
- The same 20 tests passed on an iPhone 17 simulator running iOS 26.5.
- Strict SwiftLint passed.
- `git diff --check` passed.
