### PR TITLE
fix(accessibility): simplify variant fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to ColorKit will be documented in this file.
 - Make `switchTo(theme:)` select the canonical registered theme with the supplied name instead of installing a same-name replacement payload; see [the migration guide](MIGRATION.md#unreleased-canonical-theme-selection-f06).
 
 ### Fixed
+- Return no accessible variants for nonpositive counts and avoid repeating identical fallback adjustments when distinct candidates are exhausted.
 - Return `nil` from JSON palette export when a resolved RGBA component is nonfinite instead of raising a Foundation exception.
 - Publish successful theme registrations and refresh the environment theme on selection changes without requiring parent observation, while preserving nested overrides.
 - Round RGB and alpha channels to the nearest byte when generating hexadecimal colors, preserving round trips such as `#232323FF`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,10 @@ _Avoid_: Guaranteed compliant color
 Whichever of black or white has the greater WCAG contrast ratio against a given color. This choice may still fall short of the requested contrast level, including AAA.
 _Avoid_: Guaranteed compliant color
 
+**Accessible variant request**:
+A request for up to a specified number of perceptually distinct adjusted colors. A nonpositive count requests no suggestions; a positive request may return fewer when no additional distinct suggestions are available.
+_Avoid_: Required variant count
+
 **LAB**:
 CIE L*a*b* coordinates relative to a reference white: L* describes lightness, a* the green–red axis, and b* the blue–yellow axis. ColorKit uses D65 as the reference white.
 _Avoid_: RGB brightness when referring to L*.

--- a/Sources/ColorKit/WCAG/AccessibilityEnhancer.swift
+++ b/Sources/ColorKit/WCAG/AccessibilityEnhancer.swift
@@ -136,12 +136,15 @@ public class AccessibilityEnhancer {
         /// The strategy to use when adjusting colors.
         public let strategy: AdjustmentStrategy
 
-        /// The maximum allowed perceptual difference from the original color.
+        /// The requested maximum perceptual difference from the original color.
         ///
         /// Values range from 0 to 100, where:
         /// - 0-20: Subtle changes
         /// - 20-40: Moderate changes
         /// - 40+: Significant changes
+        ///
+        /// This value is retained for source compatibility. Current enhancement
+        /// strategies do not enforce it.
         public let maxPerceptualDistance: Double
 
         /// Whether to prefer darker adjustments when possible.
@@ -152,7 +155,8 @@ public class AccessibilityEnhancer {
         /// - Parameters:
         ///   - targetLevel: The WCAG level to target (default: .AA)
         ///   - strategy: The adjustment strategy to use (default: .preserveHue)
-        ///   - maxPerceptualDistance: The maximum perceptual distance allowed (default: 30)
+        ///   - maxPerceptualDistance: The requested perceptual-distance limit. Current
+        ///     enhancement strategies do not enforce it (default: 30)
         ///   - preferDarker: Whether to prioritize darker adjustments (default: false)
         public init(
             targetLevel: WCAGContrastLevel = .AA,
@@ -250,9 +254,17 @@ public class AccessibilityEnhancer {
     /// - Parameters:
     ///   - color: The original color to base variants on
     ///   - backgroundColor: The background color to check against
-    ///   - count: The number of variants to generate (default: 3)
-    /// - Returns: An array of accessible color variants
-    public func suggestAccessibleVariants(for color: Color, against backgroundColor: Color, count: Int = 3) -> [Color] {
+    ///   - count: The maximum number of variants to generate. Nonpositive values
+    ///     request no variants (default: 3)
+    /// - Returns: Up to `count` accessible color variants
+    public func suggestAccessibleVariants(
+        for color: Color,
+        against backgroundColor: Color,
+        count requestedCount: Int = 3
+    ) -> [Color] {
+        guard requestedCount > 0 else { return [] }
+
+        let distinctnessThreshold = 5.0
         var variants: [Color] = []
 
         // Create variants with different strategies
@@ -267,39 +279,35 @@ public class AccessibilityEnhancer {
             ))
 
             let variant = enhancer.enhanceColor(color, against: backgroundColor)
-            if !variants.contains(where: { $0.isPerceptuallySimilar(to: variant, threshold: 5) }) {
+            if !variants.contains(where: {
+                $0.isPerceptuallySimilar(to: variant, threshold: distinctnessThreshold)
+            }) {
                 variants.append(variant)
             }
 
-            if variants.count >= count {
+            if variants.count >= requestedCount {
                 break
             }
         }
 
-        // If we don't have enough variants, create more with different perceptual distances
-        if variants.count < count {
-            let distances = [15.0, 20.0, 25.0, 35.0, 40.0]
+        // If needed, try the configured strategy once in the opposite direction.
+        if variants.count < requestedCount {
+            let enhancer = AccessibilityEnhancer(configuration: Configuration(
+                targetLevel: configuration.targetLevel,
+                strategy: configuration.strategy,
+                maxPerceptualDistance: configuration.maxPerceptualDistance,
+                preferDarker: !configuration.preferDarker
+            ))
 
-            for distance in distances {
-                let enhancer = AccessibilityEnhancer(configuration: Configuration(
-                    targetLevel: configuration.targetLevel,
-                    strategy: configuration.strategy,
-                    maxPerceptualDistance: distance,
-                    preferDarker: !configuration.preferDarker
-                ))
-
-                let variant = enhancer.enhanceColor(color, against: backgroundColor)
-                if !variants.contains(where: { $0.isPerceptuallySimilar(to: variant, threshold: 5) }) {
-                    variants.append(variant)
-                }
-
-                if variants.count >= count {
-                    break
-                }
+            let variant = enhancer.enhanceColor(color, against: backgroundColor)
+            if !variants.contains(where: {
+                $0.isPerceptuallySimilar(to: variant, threshold: distinctnessThreshold)
+            }) {
+                variants.append(variant)
             }
         }
 
-        return Array(variants.prefix(count))
+        return Array(variants.prefix(requestedCount))
     }
 
     // MARK: - Private Methods
@@ -510,8 +518,9 @@ public extension Color {
     /// - Parameters:
     ///   - backgroundColor: The background color to check against
     ///   - targetLevel: The WCAG level to target (default: .AA)
-    ///   - count: The number of variants to suggest (default: 3)
-    /// - Returns: An array of accessible color variants
+    ///   - count: The maximum number of variants to suggest. Nonpositive values
+    ///     request no variants (default: 3)
+    /// - Returns: Up to `count` accessible color variants
     func suggestAccessibleVariants(
         with backgroundColor: Color,
         targetLevel: WCAGContrastLevel = .AA,

--- a/Tests/ColorKitTests/WCAG/AccessibilityEnhancerTests.swift
+++ b/Tests/ColorKitTests/WCAG/AccessibilityEnhancerTests.swift
@@ -196,6 +196,40 @@ final class AccessibilityEnhancerTests: XCTestCase {
         }
     }
 
+    func testSuggestAccessibleVariantsReturnsNoVariantsForNonpositiveCounts() {
+        let enhancer = AccessibilityEnhancer()
+        let zeroCountVariants = enhancer.suggestAccessibleVariants(for: .blue, against: .black, count: 0)
+        let negativeCountVariants = enhancer.suggestAccessibleVariants(for: .blue, against: .black, count: -1)
+
+        XCTAssertTrue(zeroCountVariants.isEmpty)
+        XCTAssertTrue(negativeCountVariants.isEmpty)
+    }
+
+    func testSuggestAccessibleVariantsReturnsOnlyDistinctAvailableVariants() {
+        let enhancer = AccessibilityEnhancer()
+        let requestedCount = 10
+        let distinctnessThreshold = 5.0
+        let variants = enhancer.suggestAccessibleVariants(
+            for: .blue,
+            against: .black,
+            count: requestedCount
+        )
+
+        XCTAssertFalse(variants.isEmpty)
+        XCTAssertLessThan(variants.count, requestedCount)
+
+        for index in variants.indices {
+            for otherIndex in variants.indices where otherIndex > index {
+                XCTAssertFalse(
+                    variants[index].isPerceptuallySimilar(
+                        to: variants[otherIndex],
+                        threshold: distinctnessThreshold
+                    )
+                )
+            }
+        }
+    }
+
     // MARK: - Test Color Extension Methods
 
     func testColorEnhancedExtension() {


### PR DESCRIPTION
## Summary

Simplify accessible-variant fallback generation by removing repeated enhancement attempts that cannot produce different results. The distance values varied between attempts, but no enhancement strategy currently reads `maxPerceptualDistance`, so every pass repeated the same work.

## Changes

- Return an empty variant list immediately for zero or negative requested counts.
- Keep the existing ordered strategy pass and replace five equivalent fallback attempts with one opposite-direction attempt.
- Carry the caller's configured target, strategy, and distance into the fallback while inverting `preferDarker`.
- Name and preserve the existing perceptual-distinctness threshold.
- Document that variant count is an upper bound and that `maxPerceptualDistance` remains public but is not currently enforced.
- Add glossary, changelog, and regression-test coverage for the clarified contract.

## Alternatives considered

Enforcing or removing `maxPerceptualDistance` was rejected because either choice would broaden F09 into a behavioral or source-compatibility change. Extracting a helper or attempt registry was also rejected because the primary strategy pass and optional fallback are clearer as two explicit local phases.

## Notes

Positive-count variant ordering and results are preserved. Implementing an enforced perceptual-distance limit remains separate work.

## Screenshots

Not applicable; no UI changes.

## Testing

- `AccessibilityEnhancerTests`: 14 tests passed on macOS.
- `AccessibilityEnhancerTests`: 14 tests passed on an iPhone 17 simulator running iOS 26.5.
- Strict SwiftLint passed.
- `git diff --check` passed.
- Independent Standards and Spec reviews completed; the documentation mismatch found during review was fixed before commit.
