### PR TITLE
doc(release): Prepare ColorKit 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,33 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-09-02
+
+### Added
+- Add a Spanish README translation and language links from the main README.
+
 ### Changed
-- Isolate `ThemeManager` and `withThemeManager(_:)` to `MainActor`. Nonisolated callers must adopt actor-aware access; see [the migration guide](MIGRATION.md#unreleased-theme-ownership-f05).
-- Make `switchTo(theme:)` select the canonical registered theme with the supplied name instead of installing a same-name replacement payload; see [the migration guide](MIGRATION.md#unreleased-canonical-theme-selection-f06).
+- Isolate `ThemeManager` and `withThemeManager(_:)` to `MainActor`. Nonisolated callers must adopt actor-aware access; see [the migration guide](MIGRATION.md#theme-ownership).
+- Make `switchTo(theme:)` select the canonical registered theme with the supplied name instead of installing a same-name replacement payload; see [the migration guide](MIGRATION.md#canonical-theme-selection).
+- Resolve Hex and CMYK values through a fallible sRGB snapshot. Fixed grayscale, linear RGB, and Display P3 colors are converted to sRGB; unavailable, nonfinite, or out-of-range values return `nil`.
+- Present only platform-supported palette export actions: Copy and Share on iOS, and Copy and Export on macOS.
+- Derive color-inspector output from its current color and background inputs so reused views cannot display stale conversion or accessibility results.
+- Give each animation preview its own cancellable performance-monitoring session, and keep benchmark CPU work off the main actor.
+- Use exact, color-space-aware cache identities and bypass caching when a stable identity cannot be formed.
+- Use one RGB-to-XYZ conversion path for LAB conversion and public color-space conversion.
 
 ### Fixed
+- Preserve already-compliant colors, including opacity, in `adjustedForAccessibility` and `highContrastColor` instead of replacing them with black or white.
+- Choose the stronger black-or-white contrast endpoint when neither endpoint meets the requested WCAG level.
 - Return no accessible variants for nonpositive counts and avoid repeating identical fallback adjustments when distinct candidates are exhausted.
+- Round RGB and alpha channels to the nearest byte when generating hexadecimal colors, preserving round trips such as `#232323FF`.
+- Prepare accessible-palette export artifacts once before presentation, retain the presented payload through redraws and dismissal, and create a fresh file for each later share.
 - Return `nil` from JSON palette export when a resolved RGBA component is nonfinite instead of raising a Foundation exception.
 - Publish successful theme registrations and refresh the environment theme on selection changes without requiring parent observation, while preserving nested overrides.
-- Round RGB and alpha channels to the nearest byte when generating hexadecimal colors, preserving round trips such as `#232323FF`.
-- Preserve already-compliant colors, including opacity, in `adjustedForAccessibility` and `highContrastColor` instead of replacing them with black or white.
+- Cancel obsolete animation-monitor callbacks so a previous preview session cannot update current metrics.
+
+### Tooling
+- Centralize iOS and macOS test execution in `scripts/run_tests.sh`, preserve result bundles and logs on failures, and serialize shared cache and theme-manager integration tests.
 
 ## [1.6.0] - 2025-04-01
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,34 +1,12 @@
 # Migration Guide
 
-## Unreleased: Canonical theme selection (F06)
+## ColorKit 2.0.0
 
-`switchTo(theme:)` now treats its argument as a selection request identified by
-name. When that name is registered, the manager selects the canonical registered
-theme rather than installing the supplied value.
+ColorKit 2.0.0 makes theme ownership explicit at compile time and tightens
+selection of registered themes. Most color conversion, accessibility, export,
+and preview fixes in this release require no caller changes.
 
-Previously, a caller could pass altered colors under an existing registered name
-and make that unregistered value current. Code relying on that behavior must give
-the variant a unique name, register it, and then select it:
-
-```swift
-let variant = ColorTheme(
-    name: "Custom Variant",
-    primary: .red,
-    secondary: .gray,
-    accent: .orange,
-    background: .white,
-    text: .black
-)
-
-manager.register(theme: variant)
-manager.switchTo(theme: variant)
-```
-
-The public method signatures and return values are unchanged. Both selection
-overloads return `false` and preserve the current theme when the requested name
-is not registered. F06 does not add replacement semantics for registered themes.
-
-## Unreleased: Theme ownership (F05)
+### Theme ownership
 
 `ThemeManager` is now isolated to `MainActor` as a whole. Previously only
 `ThemeManager.shared` required main-actor access; code holding a manager reference
@@ -67,11 +45,40 @@ publishes successful registrations. `withThemeManager(_:)` observes the manager
 itself, so parents no longer need to observe it just to refresh the environment.
 Local `applyTheme(_:)` overrides retain their normal subtree precedence.
 
-At the time of F05, selection behavior was unchanged: registration rejected
+Before ColorKit 2.0.0, registration rejected
 duplicate names, switching by name selected the registered value, and switching
-by instance selected the supplied value if its name was registered. F06 now
-supersedes those instance-selection semantics; see
-[Canonical theme selection](#unreleased-canonical-theme-selection-f06).
+by instance selected the supplied value if its name was registered. ColorKit
+2.0.0 changes those instance-selection semantics; see
+[Canonical theme selection](#canonical-theme-selection).
+
+### Canonical theme selection
+
+`switchTo(theme:)` now treats its argument as a selection request identified by
+name. When that name is registered, the manager selects the canonical registered
+theme rather than installing the supplied value.
+
+Previously, a caller could pass altered colors under an existing registered name
+and make that unregistered value current. Code relying on that behavior must give
+the variant a unique name, register it, and then select it:
+
+```swift
+let variant = ColorTheme(
+    name: "Custom Variant",
+    primary: .red,
+    secondary: .gray,
+    accent: .orange,
+    background: .white,
+    text: .black
+)
+
+manager.register(theme: variant)
+manager.switchTo(theme: variant)
+```
+
+The public method signatures and return values are unchanged. Both selection
+overloads return `false` and preserve the current theme when the requested name
+is not registered. ColorKit 2.0.0 does not add replacement semantics for
+registered themes.
 
 ## ColorKit 1.5.0
 

--- a/docs/screenshots/f13/README.md
+++ b/docs/screenshots/f13/README.md
@@ -11,7 +11,7 @@ Using Xcode 26.5 on macOS and an iPhone 17 simulator running iOS 26.5:
 - `PaletteExporterTests`: all 6 existing export tests passed on each platform.
 - Strict SwiftLint passed.
 
-The final runs include the alert-state fix and the repeat-share test correction on top of `main` at `c3d5d6a`. This is focused export coverage, not a full repository test run.
+The focused runs include the alert-state fix and the repeat-share test correction on top of `main` at `c3d5d6a`. The remaining native iOS checks were completed on `main` at `b3b8f7f`. This is focused export coverage; the full repository release gate is tracked separately.
 
 The lifecycle tests cover preparation counts, ignored actions during sharing, captured inputs, preparation and write failures, retry, file retention after dismissal and owner release, unique request directories, cleanup across simulated app runs, and save cancellation/success/failure. The hosted test changes the color scheme while sharing and after dismissal, verifying no additional preparation and a stable file.
 
@@ -41,14 +41,15 @@ swiftlint lint --strict
 - Saving a palette as JSON produces a valid file with the expected palette name and five entries, followed by the existing success message. A theme PNG save also produced a valid PNG file.
 - A temporary macOS host injected a directory as the save destination to force a write failure. The demo's native alert displayed the save error text. This checks error presentation without changing the production save panel.
 - Native checking exposed an empty result alert when the modifier captured an outdated message value. The modifier now observes the export helper and reads its current message when presenting the alert; success and error messages were rechecked in the native host.
-- Remaining manual checks: repeated native iOS sharing/cancellation and confirmed generation completion during native sharing. The share sheet is visible, but these interactions could not be verified with the available UI automation. Related state and file behavior is covered by the automated tests above; the PR remains draft pending these checks.
+- A temporary XCTest UI harness outside the repository completed two native iOS share-and-cancel cycles. Each dismissal restored enabled export actions, and each later action presented a fresh share sheet.
+- The same harness used a temporary two-second delay in the demo's background generation to make the overlap deterministic. It observed the generating state, presented the native share sheet, observed generation complete while that sheet remained active, confirmed export actions stayed disabled during sharing, then dismissed the sheet and confirmed exporting became available again. The timing hook and harness were removed after validation.
 
 ## Review and corrections
 
 - Separate Standards and Spec reviews found no implementation or scope defects. The Standards review's two organization findings were corrected; the Spec review identified the remaining native validation gap above.
 - Cleanup compares app-run directory names rather than complete URLs, whose trailing-slash representations can differ.
 - The repeated-export test compares each file with its own captured bytes. Separate JSON serializations may use different dictionary key orders, so byte equality between independently prepared artifacts is not a requirement.
-- Both review axes rechecked the final alert-state and test corrections: no remaining Standards findings; Spec retains only the documented native iOS validation gap.
+- Both review axes rechecked the final alert-state and test corrections with no remaining findings. The later native XCTest pass closes the previously documented iOS validation gap.
 
 ## Screenshots
 


### PR DESCRIPTION
## Summary

Prepare the reviewed changes since v1.6.0 for a ColorKit 2.0.0 release. The major version reflects the source compatibility impact of making theme ownership main-actor isolated, and the final native iOS export lifecycle gap is now closed.

## Changes

- expand the changelog into complete 2.0.0 release notes covering color conversion, accessibility, caching, themes, exports, previews, documentation, and test infrastructure
- turn the F05/F06 draft migration notes into versioned guidance for main-actor theme access and canonical registered-theme selection
- record successful native iOS validation for repeated share cancellation and generation completing while the share sheet remains active

## Alternatives considered

- Ship another 1.x release. Rejected because `ThemeManager` main-actor isolation is a source compatibility break for nonisolated callers.
- Leave the notes under `Unreleased`. Rejected because the completed work now has a concrete release target and migration path.
- Retain audit IDs in the public migration headings. Rejected in favor of consumer-facing versioned headings.

## Notes

- This PR changes documentation only; it does not tag or publish the release.
- After merge, tag the resulting `main` commit as `v2.0.0` and create the GitHub release from the reviewed changelog.
- The native overlap check used a temporary two-second generation delay and an XCTest UI harness outside the repository. Both were removed after validation.

## Screenshots

No UI source changed in this PR. Existing F13 screenshots remain representative; this change updates their validation record.

## Testing

- `swift package resolve`
- `swiftlint lint --strict` — 0 violations
- CI-equivalent parallel iOS suite — passed
- CI-equivalent parallel macOS suite — passed
- serial shared-state iOS suite — 14 tests passed
- serial shared-state macOS suite — 14 tests passed
- temporary native iOS XCTest UI validation — passed
- ColorKit demo simulator build — passed
- `xcodebuild docbuild` for macOS — passed
- local Markdown links and anchors — passed
- `git diff --check` — passed
