### PR TITLE
doc(audit): Close remaining finding statuses

### DIFF
--- a/docs/design/cache-identity.md
+++ b/docs/design/cache-identity.md
@@ -1,6 +1,6 @@
 # F03 · S04 — Optional, exact cache identity
 
-Status: accepted for implementation.
+Status: implemented.
 
 ## Agreed scope
 

--- a/docs/design/resolved-srgba.md
+++ b/docs/design/resolved-srgba.md
@@ -1,6 +1,6 @@
 # F07 — Fallible resolved-sRGBA snapshot
 
-Status: accepted for implementation.
+Status: implemented.
 
 ## Agreed scope
 

--- a/docs/design/theme-ownership.md
+++ b/docs/design/theme-ownership.md
@@ -1,6 +1,6 @@
 # F05 — Observed theme ownership
 
-Status: accepted for implementation.
+Status: implemented.
 
 ## Requested scope
 


### PR DESCRIPTION
## Summary

Close the final bookkeeping inconsistency from the simplification audit. F03, F05, and F07 shipped before ColorKit 2.0.0, but their design notes still described them as awaiting implementation.

## Changes

- mark the optional exact cache identity design as implemented
- mark the observed theme ownership design as implemented
- mark the fallible resolved-sRGBA design as implemented

## Alternatives considered

- Normalize every design note to identical status wording. The remaining notes already describe their state accurately, so that would add unrelated churn.

## Notes

This PR changes documentation only. It does not change public APIs, runtime behavior, or validation requirements.

## Screenshots

Not applicable; no UI changes.

## Testing

- verified no design note still says `Status: accepted for implementation.`
- `git diff --check`
