### PR TITLE
fix(docs): align the 2.0 public contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,26 @@ jobs:
       - name: Run SwiftLint
         run: swiftlint lint --strict
 
+  documentation:
+    name: Documentation
+    runs-on: macos-26
+    if: github.event.pull_request.draft == false
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app/Contents/Developer
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build DocC Documentation
+        run: |
+          xcodebuild docbuild \
+            -scheme ColorKit \
+            -destination 'generic/platform=macOS' \
+            -derivedDataPath "$RUNNER_TEMP/ColorKitDocumentation" \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            DOCC_TREAT_WARNINGS_AS_ERRORS=YES
+
   test:
     name: Build and Test
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
             -derivedDataPath "$RUNNER_TEMP/ColorKitDocumentation" \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            DOCC_TREAT_WARNINGS_AS_ERRORS=YES
+            'OTHER_DOCC_FLAGS=--warnings-as-errors'
 
   test:
     name: Build and Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Report the current 2.0.0 release from `ColorKit.version`.
+- Correct documentation examples that referenced unavailable APIs and clarify the palette generator's contrast guarantees.
+
+### Tooling
+- Build DocC documentation with warnings treated as errors in pull-request CI.
+
 ## [2.0.0] - 2026-09-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ swiftlint lint --strict
 xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' \
   -derivedDataPath /tmp/ColorKitDocumentation \
   -skipPackagePluginValidation -skipMacroValidation \
-  DOCC_TREAT_WARNINGS_AS_ERRORS=YES
+  'OTHER_DOCC_FLAGS=--warnings-as-errors'
 scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
   -skip-testing:ColorKitTests/ColorCacheIntegrationTests \
   -skip-testing:ColorKitTests/ThemeManagerIntegrationTests \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,8 +127,9 @@ func testColorInitialization() {
 
 ### CI Validation
 
-CI runs strict SwiftLint checks and tests on both iOS and macOS. The test job uses
-the `macos-26` runner with Xcode 26.5 and an iPhone 17 simulator running iOS 26.5.
+CI runs strict SwiftLint checks, builds the DocC catalog with warnings treated as
+errors, and tests on both iOS and macOS. The jobs use the `macos-26` runner with
+Xcode 26.5 and an iPhone 17 simulator running iOS 26.5.
 When changing Xcode versions, also check the simulator runtime against the
 [runner image inventory](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md).
 
@@ -136,6 +137,10 @@ To run the same platform checks locally with Xcode 26.5 selected:
 
 ```sh
 swiftlint lint --strict
+xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' \
+  -derivedDataPath /tmp/ColorKitDocumentation \
+  -skipPackagePluginValidation -skipMacroValidation \
+  DOCC_TREAT_WARNINGS_AS_ERRORS=YES
 scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 17,OS=26.5' \
   -skip-testing:ColorKitTests/ColorCacheIntegrationTests \
   -skip-testing:ColorKitTests/ThemeManagerIntegrationTests \

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -154,7 +154,7 @@ color.monochromaticGradient(amount: 0.5)
    ```swift
    // In your Package.swift
    dependencies: [
-       .package(url: "https://github.com/yourusername/ColorKit.git", from: "1.5.0")
+       .package(url: "https://github.com/agisilaos/ColorKit.git", from: "1.5.0")
    ]
    ```
 
@@ -187,8 +187,8 @@ color.monochromaticGradient(amount: 0.5)
 ## Support
 
 If you encounter any issues during migration:
-1. Check the [ColorKit documentation](https://github.com/yourusername/ColorKit/wiki)
-2. Open an issue on the [GitHub repository](https://github.com/yourusername/ColorKit/issues)
+1. Check the documentation included with the ColorKit package in Xcode
+2. Open an issue on the [GitHub repository](https://github.com/agisilaos/ColorKit/issues)
 3. Contact the maintainers through the project's communication channels
 
 ## Next Steps

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -159,12 +159,12 @@ let theme = seedColor.generateAccessibleTheme(
 
 // Encontrar un color de contraste que cumpla con los estándares de accesibilidad
 let backgroundColor = Color.purple
-let textColor = backgroundColor.accessibleContrastingColor(with: backgroundColor, targetLevel: .AA)
+let textColor = backgroundColor.accessibleContrastingColor(for: .AA)
 
 // Usar la vista de demostración para experimentar con la generación de paletas
 struct ContentView: View {
     var body: some View {
-        ColorKit.WCAG.accessiblePaletteDemoView()
+        ColorKit.ColorInspector.accessiblePaletteDemoView()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ let theme = seedColor.generateAccessibleTheme(
 
 // Find a contrasting color that meets accessibility standards
 let backgroundColor = Color.purple
-let textColor = backgroundColor.accessibleContrastingColor(with: backgroundColor, targetLevel: .AA)
+let textColor = backgroundColor.accessibleContrastingColor(for: .AA)
 
 // Use the demo view to experiment with palette generation
 struct ContentView: View {
     var body: some View {
-        ColorKit.WCAG.accessiblePaletteDemoView()
+        ColorKit.ColorInspector.accessiblePaletteDemoView()
     }
 }
 ```

--- a/Sources/ColorKit/ColorKit.swift
+++ b/Sources/ColorKit/ColorKit.swift
@@ -41,7 +41,7 @@ public enum ColorKit {
     /// - MAJOR version for incompatible API changes
     /// - MINOR version for added functionality in a backward compatible manner
     /// - PATCH version for backward compatible bug fixes
-    public static let version = "1.6.0"
+    public static let version = "2.0.0"
 
     /// WCAG Compliance Checker namespace.
     ///
@@ -137,11 +137,12 @@ public enum ColorKit {
 
         /// Generates an accessible color palette based on a seed color.
         ///
-        /// This method creates a harmonious color palette that meets WCAG
-        /// accessibility guidelines. The generated colors are guaranteed to:
-        /// - Meet the specified contrast level when used together
-        /// - Maintain visual harmony with the seed color
-        /// - Work well in both light and dark modes
+        /// This method creates a harmonious color palette around a requested WCAG
+        /// contrast level. Generated candidates target the requested
+        /// contrast level against the seed color while remaining visually distinct.
+        /// The seed color, optional black and white entries, and fallback colors are
+        /// included without a pairwise contrast guarantee, so validate combinations
+        /// in the context where they will be used.
         ///
         /// Example:
         /// ```swift
@@ -181,15 +182,16 @@ public enum ColorKit {
 
         /// Generates an accessible theme based on a seed color.
         ///
-        /// This method creates a complete color theme that meets WCAG
-        /// accessibility guidelines. The generated theme includes:
+        /// This method creates a complete color theme around a requested WCAG
+        /// contrast level. The generated theme includes:
         /// - Primary and secondary colors
         /// - Background colors
         /// - Text colors
         /// - Accent colors
         ///
-        /// All color combinations in the theme are guaranteed to meet
-        /// the specified WCAG contrast level.
+        /// The generated text and background colors use a black-and-white pairing.
+        /// Other role combinations are not certified against the requested WCAG
+        /// level and should be checked in their intended context.
         ///
         /// Example:
         /// ```swift
@@ -202,7 +204,7 @@ public enum ColorKit {
         ///
         /// // Apply theme
         /// ContentView()
-        ///     .environmentObject(theme)
+        ///     .applyTheme(theme)
         /// ```
         ///
         /// - Parameters:

--- a/Sources/ColorKit/Documentation.docc/Accessibility-article.md
+++ b/Sources/ColorKit/Documentation.docc/Accessibility-article.md
@@ -15,16 +15,15 @@ let backgroundColor = Color.white
 let textColor = Color.gray
 
 // Check contrast ratio
-if let ratio = backgroundColor.contrastRatio(with: textColor) {
-    print("Contrast ratio: \(ratio)")
-}
+let ratio = backgroundColor.contrastRatio(with: textColor)
+print("Contrast ratio: \(ratio)")
 
 // Check WCAG compliance
 let compliance = backgroundColor.wcagCompliance(with: textColor)
-print("AA Large Text: \(compliance.passesAA(isLargeText: true))")
-print("AA Normal Text: \(compliance.passesAA(isLargeText: false))")
-print("AAA Large Text: \(compliance.passesAAA(isLargeText: true))")
-print("AAA Normal Text: \(compliance.passesAAA(isLargeText: false))")
+print("AA Large Text: \(compliance.passesAALarge)")
+print("AA Normal Text: \(compliance.passesAA)")
+print("AAA Large Text: \(compliance.passesAAALarge)")
+print("AAA Normal Text: \(compliance.passesAAA)")
 ```
 
 ### Accessible Color Generation

--- a/Sources/ColorKit/Documentation.docc/Accessibility-article.md
+++ b/Sources/ColorKit/Documentation.docc/Accessibility-article.md
@@ -90,24 +90,24 @@ ColorKit supports both WCAG 2.1 AA and AAA levels:
   - Normal text: 7:1 minimum contrast ratio
   - Large text: 4.5:1 minimum contrast ratio
 
-## Topics
+## Interface Overview
 
 ### Contrast Checking
-- ``Color/contrastRatio(with:)``
-- ``Color/wcagCompliance(with:)``
+- `Color.contrastRatio(with:)`
+- `Color.wcagCompliance(with:)`
 - ``WCAGContrastLevel``
 - ``WCAGComplianceResult``
 
 ### Color Enhancement
-- ``Color/enhanced(with:targetLevel:)``
+- `Color.enhanced(with:targetLevel:)`
 - ``AccessibilityEnhancer``
-- ``Color/suggestedAccessibleColors(for:level:)``
+- `Color.suggestedAccessibleColors(for:level:)`
 
 ### Palette Generation
-- ``Color/generateAccessiblePalette(targetLevel:paletteSize:includeBlackAndWhite:)``
-- ``Color/generateAccessibleTheme(name:targetLevel:)``
+- `Color.generateAccessiblePalette(targetLevel:paletteSize:includeBlackAndWhite:)`
+- `Color.generateAccessibleTheme(name:targetLevel:)`
 
 ### Adaptive Colors
-- ``Color/adaptiveColor(light:dark:)``
-- ``Color/highContrastColor(base:background:)``
-- ``Color/onAdaptiveColorChange(_:)``
+- `Color.adaptiveColor(light:dark:)`
+- `Color.highContrastColor(base:background:)`
+- `Color.onAdaptiveColorChange(_:)`

--- a/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
+++ b/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
@@ -88,26 +88,26 @@ let cmyk = color.cmykComponents()
 let lab = color.labComponents()
 ```
 
-## Topics
+## Interface Overview
 
 ### RGB
-- ``Color/rgbComponents()``
-- ``Color/init(red:green:blue:)``
+- `Color.rgbComponents()`
+- `Color.init(red:green:blue:)`
 
 ### HSL
-- ``Color/hslComponents()``
-- ``Color/init(hue:saturation:lightness:)``
-- ``Color/hslString()``
+- `Color.hslComponents()`
+- `Color.init(hue:saturation:lightness:)`
+- `Color.hslString()`
 
 ### CMYK
-- ``Color/cmykComponents()``
-- ``Color/init(cyan:magenta:yellow:key:)``
-- ``Color/cmykString()``
+- `Color.cmykComponents()`
+- `Color.init(cyan:magenta:yellow:key:)`
+- `Color.cmykString()`
 
 ### LAB
-- ``Color/labComponents()``
-- ``Color/init(L:a:b:)``
-- ``Color/labString()``
+- `Color.labComponents()`
+- `Color.init(L:a:b:)`
+- `Color.labString()`
 
 ### Utilities
 - ``ColorSpaceConverter``

--- a/Sources/ColorKit/Documentation.docc/ColorKit-article.md
+++ b/Sources/ColorKit/Documentation.docc/ColorKit-article.md
@@ -9,17 +9,12 @@ ColorKit provides a comprehensive set of tools for working with colors in your S
 ## Topics
 
 ### Essentials
-- ``Color``
 - ``ColorTheme``
 - ``ThemeManager``
 
 ### Color Spaces
 - <doc:Color-Spaces>
 - ``ColorSpaceConverter``
-- ``Color/init(L: CGFloat, a: CGFloat, b: CGFloat)``
-- ``Color/init(hue: CGFloat, saturation: CGFloat, lightness: CGFloat)``
-- ``Color/init?(hex: String)``
-- ``Color/init(cyan: CGFloat, magenta: CGFloat, yellow: CGFloat, key: CGFloat)``
 
 ### Accessibility
 - <doc:Accessibility-article>

--- a/Sources/ColorKit/Documentation.docc/Theming-article.md
+++ b/Sources/ColorKit/Documentation.docc/Theming-article.md
@@ -138,20 +138,20 @@ let adaptiveTheme = ColorTheme(
 }
 ```
 
-## Topics
+## Interface Overview
 
 ### Theme Management
 - ``ColorTheme``
 - ``ThemeManager``
-- ``View/withThemeManager(_:)``
+- `View.withThemeManager(_:)`
 
 ### Theme Components
-- ``View/themedText(_:)``
-- ``View/themedButton(_:)``
-- ``View/themedBackground(_:)``
+- `View.themedText(_:)`
+- `View.themedButton(_:)`
+- `View.themedBackground(_:)`
 
 ### Theme Colors
-- ``Color/themed(_:)``
+- `Color.themed(_:)`
 - ``ThemedTextModifier``
 - ``ThemedButtonModifier``
 - ``ThemedBackgroundModifier``

--- a/Sources/ColorKit/Documentation.docc/Utilities-article.md
+++ b/Sources/ColorKit/Documentation.docc/Utilities-article.md
@@ -99,7 +99,7 @@ let screen = color1.blended(with: color2, mode: .screen)
 let overlay = color1.blended(with: color2, mode: .overlay)
 ```
 
-## Topics
+## Interface Overview
 
 ### Caching
 - ``ColorCache``
@@ -111,10 +111,10 @@ let overlay = color1.blended(with: color2, mode: .overlay)
 - ``PaletteExporter/export(palette:to:paletteName:)``
 
 ### Gradients
-- ``Color/linearGradient(to:in:steps:)``
-- ``Color/monochromaticGradient(steps:)``
+- `Color.linearGradient(to:in:steps:)`
+- `Color.monochromaticGradient(steps:)`
 
 ### Blending
-- ``Color/blended(with:mode:amount:)``
+- `Color.blended(with:mode:amount:)`
 - ``BlendMode``
-- ``Color/interpolated(with:amount:in:)``
+- `Color.interpolated(with:amount:in:)`

--- a/Sources/ColorKit/WCAG/AccessibilityEnhancer.swift
+++ b/Sources/ColorKit/WCAG/AccessibilityEnhancer.swift
@@ -254,7 +254,7 @@ public class AccessibilityEnhancer {
     /// - Parameters:
     ///   - color: The original color to base variants on
     ///   - backgroundColor: The background color to check against
-    ///   - count: The maximum number of variants to generate. Nonpositive values
+    ///   - requestedCount: The maximum number of variants to generate. Nonpositive values
     ///     request no variants (default: 3)
     /// - Returns: Up to `count` accessible color variants
     public func suggestAccessibleVariants(

--- a/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.md
+++ b/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.md
@@ -21,7 +21,7 @@ The Accessible Palette Generator helps you create candidate palettes around a se
 ### Generating an Accessible Palette
 
 ```swift
-// Generate a palette from a blue color that meets AA standards
+// Generate a palette targeting AA contrast against the seed color
 let blue = Color.blue
 let palette = blue.generateAccessiblePalette(targetLevel: .AA, paletteSize: 5)
 

--- a/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.md
+++ b/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.md
@@ -1,6 +1,6 @@
 # Accessible Palette Generator
 
-The Accessible Palette Generator is a powerful feature in ColorKit that helps you create color palettes that meet WCAG (Web Content Accessibility Guidelines) accessibility standards.
+The Accessible Palette Generator helps you create candidate palettes around a seed color and requested WCAG (Web Content Accessibility Guidelines) contrast level. Generated candidates target that level against the seed color, but included and fallback colors are not guaranteed to pass every pairwise comparison. Validate the combinations you intend to use.
 
 ## Why Accessible Color Palettes Matter
 
@@ -11,9 +11,9 @@ The Accessible Palette Generator is a powerful feature in ColorKit that helps yo
 
 ## Features
 
-- Generate accessible color palettes from a seed color
-- Create complete themes with accessible color combinations
-- Find contrasting colors that meet specific WCAG levels
+- Generate candidate color palettes from a seed color
+- Create themes with a high-contrast text and background pairing
+- Find contrasting candidates that target specific WCAG levels
 - Customize palette size and accessibility requirements
 
 ## Usage Examples
@@ -55,7 +55,7 @@ Text("Body text")
 ```swift
 // Find a color that contrasts well with a background color
 let backgroundColor = Color.blue
-let textColor = backgroundColor.accessibleContrastingColor(with: backgroundColor, targetLevel: .AA)
+let textColor = backgroundColor.accessibleContrastingColor(for: .AA)
 
 // Use the colors in your UI
 Text("This text is readable")
@@ -71,7 +71,7 @@ ColorKit includes a demo view that lets you experiment with the Accessible Palet
 // Show the demo view
 struct ContentView: View {
     var body: some View {
-        ColorKit.WCAG.accessiblePaletteDemoView()
+        ColorKit.ColorInspector.accessiblePaletteDemoView()
     }
 }
 ```
@@ -116,5 +116,5 @@ let theme = primaryColor.generateAccessibleTheme(name: "Brand Theme")
 ThemeManager.shared.register(theme: theme)
 
 // Use it in your app
-ThemeManager.shared.applyTheme(name: "Brand Theme")
-``` 
+ThemeManager.shared.switchToTheme(named: "Brand Theme")
+```

--- a/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.swift
+++ b/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.swift
@@ -5,11 +5,11 @@
 //  Created by Agisilaos Tsaraboulidis on 12.03.25.
 //
 //  Description:
-//  Provides functionality to generate accessible color palettes that meet WCAG guidelines.
+//  Provides functionality to generate color palettes around requested WCAG contrast levels.
 //
 //  Features:
-//  - Generates color palettes that meet specific WCAG contrast levels
-//  - Creates accessible themes with proper contrast between elements
+//  - Generates contrast candidates around a seed color
+//  - Creates themes with a high-contrast text and background pairing
 //  - Customizable palette size and accessibility requirements
 //
 //  License:
@@ -18,15 +18,16 @@
 
 import SwiftUI
 
-/// A utility for generating accessible color palettes that meet WCAG guidelines.
+/// A utility for generating color palettes around requested WCAG contrast levels.
 ///
-/// `AccessiblePaletteGenerator` helps create color palettes and themes that are both
-/// aesthetically pleasing and accessible. It ensures that generated color combinations
-/// meet specified WCAG contrast requirements while maintaining visual harmony.
+/// `AccessiblePaletteGenerator` helps create color palettes and themes around a seed color.
+/// Generated candidates target the configured contrast level against the seed. Included
+/// and fallback colors are not pairwise certified, so callers must validate the combinations
+/// they intend to use.
 ///
 /// Key features:
-/// - Generate accessible color palettes from a seed color
-/// - Create complete themes with proper contrast between elements
+/// - Generate contrast candidates from a seed color
+/// - Create themes with a high-contrast text and background pairing
 /// - Customize palette size and accessibility requirements
 /// - Support for different WCAG compliance levels
 ///
@@ -67,8 +68,9 @@ public struct AccessiblePaletteGenerator {
     public struct Configuration {
         /// The minimum contrast ratio to enforce between foreground and background colors.
         ///
-        /// This value is derived from the target WCAG level and ensures that all
-        /// color combinations in the palette meet the required contrast ratio.
+        /// This value is derived from the target WCAG level and is used when
+        /// generating contrast candidates against the seed color. Seed, explicit
+        /// black and white, and fallback entries are not pairwise certified.
         public let minimumContrastRatio: Double
 
         /// The WCAG level to target for accessibility compliance.
@@ -142,10 +144,10 @@ public struct AccessiblePaletteGenerator {
 
     /// Generates an accessible color palette based on a seed color.
     ///
-    /// This method creates a palette of colors that:
-    /// - Meet the specified WCAG contrast requirements
-    /// - Are visually distinct from each other
-    /// - Maintain harmony with the seed color
+    /// This method creates a palette that:
+    /// - Targets the specified WCAG contrast for generated candidates against the seed
+    /// - Attempts to keep entries visually distinct
+    /// - Includes the seed, optional black and white, and fallback colors as configured
     ///
     /// The generation process:
     /// 1. Starts with the seed color
@@ -218,10 +220,10 @@ public struct AccessiblePaletteGenerator {
 
     /// Generates a theme from a seed color with accessible color combinations.
     ///
-    /// This method creates a complete color theme that ensures:
-    /// - All text is readable against its background
-    /// - Primary, secondary, and accent colors work together
-    /// - The theme maintains the character of the seed color
+    /// This method creates a color theme that:
+    /// - Uses a black-and-white text and background pairing
+    /// - Derives primary, secondary, and accent roles from the seed color
+    /// - Requires callers to validate other role combinations in their intended context
     ///
     /// The theme includes:
     /// - Primary color (based on seed)

--- a/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.swift
+++ b/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.swift
@@ -66,7 +66,7 @@ public struct AccessiblePaletteGenerator {
     /// )
     /// ```
     public struct Configuration {
-        /// The minimum contrast ratio to enforce between foreground and background colors.
+        /// The minimum contrast ratio targeted for generated candidates.
         ///
         /// This value is derived from the target WCAG level and is used when
         /// generating contrast candidates against the seed color. Seed, explicit
@@ -244,8 +244,8 @@ public struct AccessiblePaletteGenerator {
     ///
     /// // Use in SwiftUI
     /// Text("Heading")
-    ///     .foregroundColor(theme.text)
-    ///     .background(theme.background)
+    ///     .foregroundColor(theme.text.base)
+    ///     .background(theme.background.base)
     /// ```
     ///
     /// - Parameters:

--- a/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
+++ b/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
@@ -8,9 +8,9 @@
 //  Extends Color with methods to generate accessible color palettes and themes.
 //
 //  Features:
-//  - Generate accessible color palettes from any color
-//  - Create accessible themes with proper contrast ratios
-//  - Find contrasting colors that meet WCAG guidelines
+//  - Generate candidate color palettes from any color
+//  - Create themes with a high-contrast text and background pairing
+//  - Find the stronger black-or-white contrasting endpoint
 //
 //  License:
 //  MIT License. See LICENSE file for details.
@@ -20,12 +20,12 @@ import SwiftUI
 
 /// Extension providing accessible color palette and theme generation for SwiftUI's Color type.
 ///
-/// This extension adds methods for creating accessible color combinations that meet
-/// WCAG guidelines while maintaining visual harmony. Key features include:
+/// This extension adds methods for creating palette and theme candidates around requested
+/// WCAG contrast levels. Key features include:
 ///
-/// - Generating accessible color palettes
-/// - Creating complete accessible themes
-/// - Finding contrasting colors that meet WCAG requirements
+/// - Generating candidate color palettes
+/// - Creating themes with a high-contrast text and background pairing
+/// - Finding the stronger black-or-white contrasting endpoint
 ///
 /// Example usage:
 /// ```swift
@@ -48,10 +48,9 @@ import SwiftUI
 public extension Color {
     /// Generates an accessible color palette based on this color.
     ///
-    /// This method creates a palette of colors that all meet WCAG contrast
-    /// requirements while maintaining visual harmony with the base color.
-    /// The palette is suitable for use in interfaces where accessibility
-    /// is a priority.
+    /// Generated candidates target the requested contrast level against the base color.
+    /// The base color, optional black and white entries, and fallback colors are not
+    /// pairwise certified. Validate combinations in the context where they will be used.
     ///
     /// Example:
     /// ```swift
@@ -94,8 +93,9 @@ public extension Color {
 
     /// Generates an accessible theme based on this color.
     ///
-    /// This method creates a complete color theme that ensures all color combinations
-    /// meet WCAG contrast requirements. The theme includes colors for:
+    /// This method creates a complete color theme with a black-and-white text and
+    /// background pairing. Other role combinations are not certified against the
+    /// requested WCAG level. The theme includes colors for:
     /// - Primary content
     /// - Secondary content
     /// - Accents

--- a/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
+++ b/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
@@ -106,24 +106,16 @@ public extension Color {
     /// ```swift
     /// let brandColor = Color.blue
     ///
-    /// // Create a theme with AAA compliance
+    /// // Create a theme targeting AAA contrast
     /// let theme = brandColor.generateAccessibleTheme(
     ///     name: "High Contrast Theme",
     ///     targetLevel: .AAA
     /// )
     ///
     /// // Use in SwiftUI
-    /// VStack {
-    ///     Text("Heading")
-    ///         .foregroundColor(theme.text)
-    ///         .background(theme.primary)
-    ///     Button("Action") {
-    ///         // Action
-    ///     }
-    ///     .foregroundColor(theme.text)
-    ///     .background(theme.accent)
-    /// }
-    /// .background(theme.background)
+    /// Text("Heading")
+    ///     .foregroundColor(theme.text.base)
+    ///     .background(theme.background.base)
     /// ```
     ///
     /// - Parameters:

--- a/Sources/ColorKit/WCAG/README.md
+++ b/Sources/ColorKit/WCAG/README.md
@@ -9,7 +9,7 @@ The WCAG (Web Content Accessibility Guidelines) Compliance Checker is a powerful
 - **Live Previews**: See how your text looks with different color combinations in real-time.
 - **Color Blindness Simulation**: Preview how your content appears to users with different types of color blindness.
 - **Suggestions**: Get suggestions for colors that would meet WCAG compliance levels.
-- **Accessible Palette Generation**: Automatically generate accessible color palettes that meet WCAG guidelines.
+- **Palette Generation**: Generate candidate palettes around a requested WCAG contrast level.
 
 ## Usage
 
@@ -134,7 +134,7 @@ struct MyView: View {
             Button("Action") {}
                 .padding()
                 .background(theme.accent.base)
-                .foregroundColor(theme.accent.base.accessibleContrastingColor(with: theme.background.base))
+                .foregroundColor(theme.accent.base.accessibleContrastingColor(for: .AA))
                 .cornerRadius(8)
         }
         .padding()
@@ -168,7 +168,7 @@ struct ContentView: View {
                 showPaletteDemo = true
             }
             .sheet(isPresented: $showPaletteDemo) {
-                ColorKit.WCAG.accessiblePaletteDemoView()
+                ColorKit.ColorInspector.accessiblePaletteDemoView()
             }
         }
     }
@@ -200,4 +200,4 @@ The color blindness simulation supports the following types:
 ## References
 
 - [WCAG 2.1 Contrast Guidelines](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
-- [Color Blindness Simulation](https://www.color-blindness.com/types-of-color-blindness/) 
+- [Color Blindness Simulation](https://www.color-blindness.com/types-of-color-blindness/)


### PR DESCRIPTION
## Summary

ColorKit 2.0.0 shipped with stale version metadata, documentation examples that referenced unavailable interfaces, and accessibility claims stronger than the palette generator's actual behavior. This PR aligns the public documentation with the released interface and adds a strict DocC gate to prevent documentation warnings from returning.

## Changes

- Report version 2.0.0 from ColorKit.version.
- Correct README, migration, WCAG, and DocC examples to use available public interfaces.
- Describe palette and theme contrast behavior without unsupported pairwise guarantees.
- Repair existing DocC curation warnings and validate documentation with warnings treated as errors in pull-request CI.
- Document the validation command and record the fixes in the unreleased changelog.

## Alternatives considered

Changing the palette-generation algorithm in the same PR was rejected because it requires separate product design and behavioral validation. A build-only DocC gate was also rejected after verification showed it would allow broken symbol curation warnings to persist.

## Notes

This does not change palette generation, contrast calculations, or other runtime algorithms. The only runtime-facing value change is the public version constant from 1.6.0 to 2.0.0.

## Screenshots

Not applicable; no UI changes.

## Testing

- swiftlint lint --strict
- strict DocC build on macOS with OTHER_DOCC_FLAGS=--warnings-as-errors
- full iOS 26.5 simulator test suite
- full macOS test suite
- serialized iOS and macOS cache/theme-manager integration suites
- CI workflow YAML parse and documentation-job assertion
