### PR TITLE
chore(release): prepare ColorKit 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-02
+
 ### Fixed
-- Report the current 2.0.0 release from `ColorKit.version`.
+- Report the current 2.0.1 release from `ColorKit.version`.
 - Correct documentation examples that referenced unavailable APIs and clarify the palette generator's contrast guarantees.
 
 ### Tooling

--- a/Sources/ColorKit/ColorKit.swift
+++ b/Sources/ColorKit/ColorKit.swift
@@ -41,7 +41,7 @@ public enum ColorKit {
     /// - MAJOR version for incompatible API changes
     /// - MINOR version for added functionality in a backward compatible manner
     /// - PATCH version for backward compatible bug fixes
-    public static let version = "2.0.0"
+    public static let version = "2.0.1"
 
     /// WCAG Compliance Checker namespace.
     ///


### PR DESCRIPTION
## Summary

Prepare the version metadata and changelog entry that will identify the ColorKit 2.0.1 patch release.

## Changes

- Promote the pending documentation-contract fixes from Unreleased to 2.0.1.
- Report 2.0.1 from the public ColorKit.version constant.

## Alternatives considered

Leaving the changes under Unreleased or retaining the 2.0.0 constant would make the published tag disagree with its user-facing metadata.

## Notes

This release commit contains no algorithm or interface changes beyond the public version string.

## Screenshots

Not applicable; no UI changes.

## Testing

- strict SwiftLint
- strict DocC build
- full non-shared iOS 26.5 simulator suite
- full non-shared macOS suite
- serialized shared-state iOS suite
- serialized shared-state macOS suite
- git diff hygiene and new TODO/FIXME review
