### PR TITLE
fix(lab): resolve colors through sRGBA

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,9 @@ An assessment for which ColorKit cannot establish a contrast ratio from the supp
 CIE L*a*b* coordinates relative to a reference white: L* describes lightness, a* the green–red axis, and b* the blue–yellow axis. ColorKit uses D65 as the reference white.
 _Avoid_: RGB brightness when referring to L*.
 
+**Unavailable LAB conversion**:
+A conversion for which ColorKit cannot obtain LAB coordinates from the supplied color. It is absence, not black or zero-valued LAB.
+
 **XYZ**:
 CIE XYZ tristimulus coordinates. ColorKit's public XYZ values use a relative scale on which the reference white has Y = 100; this is not an upper bound on every coordinate.
 _Avoid_: XYZ percentages, XYZ in the range 0–1 without specifying a different scale.

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -70,13 +70,20 @@ let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
 
 ### **4️⃣ Conversión LAB**  
 ```swift
-// Convertir de RGB a LAB
-let lab = Color.red.labComponents()
-// (L: 53.24, a: 80.09, b: 67.20)
+// Resolver un color fijo y convertirlo a LAB
+if let lab = Color.red.labComponents() {
+    print(lab) // (L: 53.24, a: 80.09, b: 67.20)
+}
 
 // Crear color a partir de valores LAB
 let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
 ```
+
+`labComponents()` resuelve colores RGB y de escala de grises fijos —incluidos RGB
+lineal y Display P3— a sRGB no lineal antes de la conversión. Los canales finitos
+fuera de gama se conservan sin recorte. El método devuelve `nil` para los colores
+que no puede resolver, como los colores dinámicos sin resolver; el canal alfa no
+afecta a las coordenadas LAB.
 
 ### **5️⃣ Colores adaptables (Modo Claro/Oscuro)**  
 ```swift

--- a/README.md
+++ b/README.md
@@ -70,13 +70,19 @@ let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
 
 ### **4️⃣ LAB Conversion**  
 ```swift
-// Convert from RGB to LAB
-let lab = Color.red.labComponents()
-// (L: 53.24, a: 80.09, b: 67.20)
+// Resolve a fixed color and convert it to LAB
+if let lab = Color.red.labComponents() {
+    print(lab) // (L: 53.24, a: 80.09, b: 67.20)
+}
 
 // Create color from LAB values
 let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
 ```
+
+`labComponents()` resolves fixed RGB and grayscale colors—including linear RGB and
+Display P3—to nonlinear sRGB before conversion. Finite out-of-gamut channels are
+preserved without clipping. The method returns `nil` for colors it cannot resolve,
+such as unresolved dynamic colors; alpha does not affect the LAB coordinates.
 
 ### **5️⃣ Adaptive Colors (Light/Dark Mode)**  
 ```swift

--- a/Sources/ColorKit/ColorSpaces/Color+LAB.swift
+++ b/Sources/ColorKit/ColorSpaces/Color+LAB.swift
@@ -29,9 +29,9 @@ import SwiftUI
 /// - Accessibility calculations
 ///
 /// The components are:
-/// - L*: Lightness (0-100)
-/// - a*: Green to red axis (-128 to +127)
-/// - b*: Blue to yellow axis (-128 to +127)
+/// - L*: Lightness
+/// - a*: Green to red axis
+/// - b*: Blue to yellow axis
 ///
 /// Example usage:
 /// ```swift
@@ -53,18 +53,18 @@ import SwiftUI
 public extension Color {
     /// Returns the LAB (L*, a*, b*) components of the color.
     ///
-    /// This method resolves a fixed RGB or grayscale color to nonlinear sRGB, then
-    /// converts it to the CIE L*a*b* color space using the D65 illuminant as the
-    /// white point. The conversion process:
+    /// This method converts a fixed RGB or grayscale color to the CIE L*a*b* color
+    /// space using the D65 illuminant as the white point. The conversion process:
     ///
-    /// 1. Converts sRGB to linear RGB
-    /// 2. Converts linear RGB to CIE XYZ
-    /// 3. Converts CIE XYZ to CIE L*a*b*
+    /// 1. Resolves the color to nonlinear sRGB
+    /// 2. Converts sRGB to linear RGB
+    /// 3. Converts linear RGB to CIE XYZ
+    /// 4. Converts CIE XYZ to CIE L*a*b*
     ///
-    /// Fixed RGB and grayscale colors are first resolved to nonlinear sRGB. Finite
-    /// extended-range channels are preserved without gamut mapping, so LAB can describe
-    /// colors outside the sRGB gamut. Alpha does not affect the LAB coordinates.
-    /// Dynamic colors must be resolved for a specific appearance before conversion.
+    /// Finite extended-range channels are preserved without gamut mapping, so extracted
+    /// coordinates can fall outside conventional LAB ranges. Alpha does not affect the
+    /// LAB coordinates. Dynamic colors must be resolved for a specific appearance before
+    /// conversion.
     ///
     /// Results for cache-eligible colors are cached for subsequent calls.
     ///

--- a/Sources/ColorKit/ColorSpaces/Color+LAB.swift
+++ b/Sources/ColorKit/ColorSpaces/Color+LAB.swift
@@ -60,6 +60,11 @@ public extension Color {
     /// 2. Converts linear RGB to CIE XYZ
     /// 3. Converts CIE XYZ to CIE L*a*b*
     ///
+    /// Fixed RGB and grayscale colors are first resolved to nonlinear sRGB. Finite
+    /// extended-range channels are preserved without gamut mapping, so LAB can describe
+    /// colors outside the sRGB gamut. Alpha does not affect the LAB coordinates.
+    /// Dynamic colors must be resolved for a specific appearance before conversion.
+    ///
     /// The results are cached for performance in subsequent calls.
     ///
     /// Example:
@@ -80,20 +85,21 @@ public extension Color {
     /// }
     /// ```
     ///
-    /// - Returns: A tuple containing L* (0-100), a* (-128-127), and b* (-128-127),
-    ///           or `nil` if conversion fails.
+    /// - Returns: A tuple containing L*, a*, and b*, or `nil` if the color cannot be
+    ///            resolved or conversion does not produce finite coordinates.
     func labComponents() -> (L: CGFloat, a: CGFloat, b: CGFloat)? {
-        // Check cache first
         if let cachedComponents = ColorCache.shared.getCachedLABComponents(for: self) {
             return cachedComponents
         }
 
-        guard let components = cgColor?.components, components.count >= 3 else { return nil }
-        let xyz = SRGBColorConversion.xyz(from: (Double(components[0]), Double(components[1]), Double(components[2])))
+        guard let resolved = ResolvedSRGBA.resolve(self) else { return nil }
+        let xyz = SRGBColorConversion.xyz(
+            from: (Double(resolved.red), Double(resolved.green), Double(resolved.blue))
+        )
         let lab = SRGBColorConversion.lab(from: xyz)
+        guard lab.l.isFinite, lab.a.isFinite, lab.b.isFinite else { return nil }
         let result = (L: CGFloat(lab.l), a: CGFloat(lab.a), b: CGFloat(lab.b))
 
-        // Cache the result
         ColorCache.shared.cacheLABComponents(for: self, L: result.L, a: result.a, b: result.b)
 
         return result

--- a/Sources/ColorKit/ColorSpaces/Color+LAB.swift
+++ b/Sources/ColorKit/ColorSpaces/Color+LAB.swift
@@ -53,8 +53,9 @@ import SwiftUI
 public extension Color {
     /// Returns the LAB (L*, a*, b*) components of the color.
     ///
-    /// This method converts the color from sRGB to the CIE L*a*b* color space
-    /// using the D65 illuminant as the white point. The conversion process:
+    /// This method resolves a fixed RGB or grayscale color to nonlinear sRGB, then
+    /// converts it to the CIE L*a*b* color space using the D65 illuminant as the
+    /// white point. The conversion process:
     ///
     /// 1. Converts sRGB to linear RGB
     /// 2. Converts linear RGB to CIE XYZ
@@ -65,7 +66,7 @@ public extension Color {
     /// colors outside the sRGB gamut. Alpha does not affect the LAB coordinates.
     /// Dynamic colors must be resolved for a specific appearance before conversion.
     ///
-    /// The results are cached for performance in subsequent calls.
+    /// Results for cache-eligible colors are cached for subsequent calls.
     ///
     /// Example:
     /// ```swift

--- a/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
+++ b/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
@@ -76,6 +76,14 @@ when platform conversion produces a tiny overshoot near white. Supply an already
 fixed color when appearance matters. Existing nonoptional conversion fallbacks and
 cached conversions retain their previous behavior.
 
+LAB extraction also resolves fixed RGB and grayscale colors to nonlinear sRGB before
+conversion, but it preserves finite channels outside 0–1 instead of rejecting them.
+This allows LAB to describe Display P3 and other colors outside the sRGB gamut without
+clipping. Alpha does not affect LAB coordinates, though it remains part of cache identity.
+LAB extraction returns `nil` for unresolved dynamic colors, unsupported source models,
+failed resolution, nonfinite input, or nonfinite conversion results. It does not choose
+an appearance or substitute zero-valued LAB coordinates.
+
 ColorKit handles color space conversions automatically. When you create a color in one color space and request components in another, the conversion is done for you:
 
 ```swift

--- a/Sources/ColorKit/Utilities/README.md
+++ b/Sources/ColorKit/Utilities/README.md
@@ -20,7 +20,7 @@ The `ColorCache` class provides thread-safe caching for:
 - Uses `NSCache` for automatic memory management
 - Thread-safe for use in concurrent environments
 - Singleton pattern for global access
-- Available on iOS 14.0+ and macOS 11.0+
+- Available on iOS 14.0+ and macOS 12.0+
 
 ### Usage
 

--- a/Tests/ColorKitTests/ColorSpaces/LABResolutionTests.swift
+++ b/Tests/ColorKitTests/ColorSpaces/LABResolutionTests.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class LABResolutionTests: XCTestCase {
+    func testEquivalentRGBRepresentationsProduceEquivalentLAB() throws {
+        let reference = try fixedTestColor(components: [0.2, 0.4, 0.6, 0.5])
+        let source = try XCTUnwrap(reference.cgColor)
+        let expected = try XCTUnwrap(reference.labComponents())
+
+        for name in [CGColorSpace.linearSRGB, CGColorSpace.extendedLinearSRGB, CGColorSpace.displayP3] {
+            let space = try XCTUnwrap(CGColorSpace(name: name))
+            let represented = try XCTUnwrap(
+                source.converted(to: space, intent: .relativeColorimetric, options: nil)
+            )
+            let components = try XCTUnwrap(represented.components)
+            XCTAssertNotEqual(Array(components.prefix(3)), [0.2, 0.4, 0.6])
+
+            let color = try fixedTestColor(space: space, components: components)
+            try assertLABEqual(color.labComponents(), expected, accuracy: 0.001)
+        }
+    }
+
+    func testEncodedAndLinearGrayscaleResolveToEquivalentSRGBLAB() throws {
+        let encoded: CGFloat = 0.5370987304831942
+        let encodedReference = try fixedTestColor(components: [0.5, 0.5, 0.5, 0.25])
+        let linearReference = try fixedTestColor(components: [encoded, encoded, encoded, 0.25])
+        let encodedLAB = try XCTUnwrap(encodedReference.labComponents())
+        let linearLAB = try XCTUnwrap(linearReference.labComponents())
+
+        for name in [CGColorSpace.genericGrayGamma2_2, CGColorSpace.extendedGray] {
+            let color = try fixedTestColor(space: name, components: [0.5, 0.25])
+            try assertLABEqual(color.labComponents(), encodedLAB, accuracy: 0.00001)
+        }
+
+        for name in [CGColorSpace.linearGray, CGColorSpace.extendedLinearGray] {
+            let color = try fixedTestColor(space: name, components: [0.25, 0.25])
+            try assertLABEqual(color.labComponents(), linearLAB, accuracy: 0.00001)
+        }
+    }
+
+    func testDisplayP3OutsideSRGBGamutProducesUnclippedLAB() throws {
+        let color = try fixedTestColor(space: CGColorSpace.displayP3, components: [1, 0, 0, 0.5])
+        let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+        XCTAssertFalse(snapshot.isInSRGBGamut)
+
+        try assertLABEqual(color.labComponents(), expectedLAB(from: snapshot), accuracy: 0.00001)
+    }
+
+    func testFiniteExtendedRangeProducesUnclippedLAB() throws {
+        for components: [CGFloat] in [
+            [-0.25, 0.4, 0.6, 0.5],
+            [1.25, 0.4, 0.6, 0.5]
+        ] {
+            let color = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: components)
+            let snapshot = try XCTUnwrap(ResolvedSRGBA.resolve(color))
+            XCTAssertFalse(snapshot.isInSRGBGamut)
+
+            try assertLABEqual(color.labComponents(), expectedLAB(from: snapshot), accuracy: 0.00001)
+        }
+    }
+
+    func testNonfiniteSourceAndOverflowingLABRemainUnavailable() throws {
+        for value: CGFloat in [.nan, .infinity, -.infinity, .greatestFiniteMagnitude] {
+            let color = try fixedTestColor(
+                space: CGColorSpace.extendedSRGB,
+                components: [value, 0.4, 0.6, 0.5]
+            )
+            XCTAssertNil(color.labComponents())
+            XCTAssertNil(ColorCache.shared.getCachedLABComponents(for: color))
+        }
+    }
+
+    func testAlphaDoesNotChangeLABCoordinates() throws {
+        let colors = try [0, 0.5, 1].map { alpha in
+            try fixedTestColor(components: [0.2, 0.4, 0.6, CGFloat(alpha)])
+        }
+        let expected = try XCTUnwrap(colors[0].labComponents())
+
+        for color in colors.dropFirst() {
+            try assertLABEqual(color.labComponents(), expected, accuracy: 0)
+        }
+    }
+
+    func testDynamicSemanticPatternAndCMYKInputsRemainUnavailable() throws {
+        #if canImport(AppKit)
+        let dynamic = Color(NSColor(name: nil) { _ in .red })
+        #else
+        let dynamic = Color(UIColor { _ in .red })
+        #endif
+        let cmykSpace = CGColorSpaceCreateDeviceCMYK()
+        let cmyk = try fixedTestColor(space: cmykSpace, components: [0.2, 0.4, 0.6, 0.1, 1])
+        let colors = [dynamic, Color.primary, Color.secondary, try patternTestColor(), cmyk]
+
+        for color in colors {
+            XCTAssertNil(color.labComponents())
+            XCTAssertNil(color.labString())
+        }
+    }
+
+    func testConvertibleCacheIneligibleSourceStillProducesLABWithoutCaching() throws {
+        let color = try fixedTestColor(space: CGColorSpace.adobeRGB1998, components: [0.5, 0.4, 0.6, 1])
+
+        XCTAssertNotNil(color.labComponents())
+        XCTAssertNil(ColorCache.shared.getCachedLABComponents(for: color))
+    }
+
+    private func expectedLAB(from snapshot: ResolvedSRGBA) -> (L: CGFloat, a: CGFloat, b: CGFloat) {
+        let xyz = SRGBColorConversion.xyz(
+            from: (Double(snapshot.red), Double(snapshot.green), Double(snapshot.blue))
+        )
+        let lab = SRGBColorConversion.lab(from: xyz)
+        return (CGFloat(lab.l), CGFloat(lab.a), CGFloat(lab.b))
+    }
+
+    private func assertLABEqual(
+        _ actual: (L: CGFloat, a: CGFloat, b: CGFloat)?,
+        _ expected: (L: CGFloat, a: CGFloat, b: CGFloat),
+        accuracy: CGFloat,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let actual = try XCTUnwrap(actual, file: file, line: line)
+        XCTAssertEqual(actual.L, expected.L, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.a, expected.a, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.b, expected.b, accuracy: accuracy, file: file, line: line)
+    }
+}

--- a/Tests/ColorKitTests/ColorSpaces/LABResolutionTests.swift
+++ b/Tests/ColorKitTests/ColorSpaces/LABResolutionTests.swift
@@ -23,20 +23,24 @@ final class LABResolutionTests: XCTestCase {
     }
 
     func testEncodedAndLinearGrayscaleResolveToEquivalentSRGBLAB() throws {
-        let encoded: CGFloat = 0.5370987304831942
-        let encodedReference = try fixedTestColor(components: [0.5, 0.5, 0.5, 0.25])
-        let linearReference = try fixedTestColor(components: [encoded, encoded, encoded, 0.25])
-        let encodedLAB = try XCTUnwrap(encodedReference.labComponents())
-        let linearLAB = try XCTUnwrap(linearReference.labComponents())
+        // The sRGB encoding of linear 0.25 is 0.5370987304831942.
+        let sRGBEncodingOfLinearQuarter: CGFloat = 0.5370987304831942
+        let encodedGrayLAB = try XCTUnwrap(
+            fixedTestColor(components: [0.5, 0.5, 0.5, 0.25]).labComponents()
+        )
+        let linearQuarterComponents = Array(repeating: sRGBEncodingOfLinearQuarter, count: 3) + [0.25]
+        let linearQuarterLAB = try XCTUnwrap(
+            fixedTestColor(components: linearQuarterComponents).labComponents()
+        )
 
         for name in [CGColorSpace.genericGrayGamma2_2, CGColorSpace.extendedGray] {
             let color = try fixedTestColor(space: name, components: [0.5, 0.25])
-            try assertLABEqual(color.labComponents(), encodedLAB, accuracy: 0.00001)
+            try assertLABEqual(color.labComponents(), encodedGrayLAB, accuracy: 0.00001)
         }
 
         for name in [CGColorSpace.linearGray, CGColorSpace.extendedLinearGray] {
             let color = try fixedTestColor(space: name, components: [0.25, 0.25])
-            try assertLABEqual(color.labComponents(), linearLAB, accuracy: 0.00001)
+            try assertLABEqual(color.labComponents(), linearQuarterLAB, accuracy: 0.00001)
         }
     }
 

--- a/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
@@ -83,7 +83,7 @@ final class ColorCacheIntegrationTests: XCTestCase {
         }
     }
 
-    func testGrayscaleFallbacksDoNotChangeWhenCacheIsWarm() throws {
+    func testGrayscaleLABResolutionDoesNotChangeOtherFallbacksWhenCacheIsWarm() throws {
         let other = try fixedTestColor()
         let grays = try [0.25, 0.75].map { value in
             try fixedTestColor(space: CGColorSpace.genericGrayGamma2_2, components: [value, 1])
@@ -97,7 +97,7 @@ final class ColorCacheIntegrationTests: XCTestCase {
             for _ in 0..<2 {
                 for index in order {
                     let gray = grays[index]
-                    XCTAssertNil(gray.labComponents())
+                    XCTAssertNotNil(gray.labComponents())
                     XCTAssertNil(gray.hslComponents())
                     XCTAssertEqual(conversionValues(gray, other: other), cold[index])
                     try assertCacheColorEqual(gray.blended(with: other, mode: .normal), gray)

--- a/docs/design/lab-resolution.md
+++ b/docs/design/lab-resolution.md
@@ -11,7 +11,7 @@ Status: implemented.
 
 ## Agreed gamut policy
 
-- Derive LAB from the finite nonlinear sRGB channels supplied by the resolved-sRGBA snapshot.
+- Derive LAB from the finite nonlinear sRGB channels supplied by the resolved sRGBA snapshot.
 - Preserve extended-range sRGB channel values, including values below zero or above one. Do not clamp, reject, or otherwise gamut-map them before the sRGB-to-XYZ-to-LAB conversion.
 - This deliberately differs from bounded representations such as Hex and CMYK. LAB can describe colors outside the sRGB gamut, while those consumers reject snapshots they cannot represent without clipping.
 - Return no LAB value when a fixed color cannot be resolved or the resolved snapshot is invalid.

--- a/docs/design/lab-resolution.md
+++ b/docs/design/lab-resolution.md
@@ -1,0 +1,54 @@
+# LAB resolution
+
+Status: implemented.
+
+## Agreed scope
+
+- Change `Color.labComponents()` to derive LAB coordinates from `ResolvedSRGBA.resolve(_:)` instead of interpreting raw `CGColor` component positions as sRGB.
+- Preserve the public optional signature and let `labString()` inherit the corrected result through its existing call to `labComponents()`.
+- Leave `ColorSpaceConverter.getAllColorComponents()` and its nonoptional aggregate fallback behavior unchanged.
+- Preserve deployment targets and the existing sRGB-to-XYZ-to-LAB formulas.
+
+## Agreed gamut policy
+
+- Derive LAB from the finite nonlinear sRGB channels supplied by the resolved-sRGBA snapshot.
+- Preserve extended-range sRGB channel values, including values below zero or above one. Do not clamp, reject, or otherwise gamut-map them before the sRGB-to-XYZ-to-LAB conversion.
+- This deliberately differs from bounded representations such as Hex and CMYK. LAB can describe colors outside the sRGB gamut, while those consumers reject snapshots they cannot represent without clipping.
+- Return no LAB value when a fixed color cannot be resolved or the resolved snapshot is invalid.
+
+## Agreed alpha and cache policy
+
+- Ignore alpha when calculating LAB coordinates. Opacity does not change the color's LAB coordinates.
+- Require the resolved snapshot to contain valid alpha even though alpha is not an input to the LAB calculation.
+- Preserve the existing cache lookup and insertion path. Cache identity remains based on the original color space and complete component values, including alpha, so colors with different alpha retain distinct entries even when their LAB coordinates match.
+
+## Agreed appearance policy
+
+- Resolve only colors that expose a fixed `Color.cgColor`.
+- Dynamic and semantic colors without fixed components return no LAB value on both iOS and macOS.
+- Do not infer or consult a light or dark appearance. Callers that need appearance-specific LAB coordinates must supply an already-resolved fixed color.
+
+## Agreed source and failure policy
+
+- Accept exactly the fixed RGB and grayscale inputs that `ResolvedSRGBA.resolve(_:)` can resolve. Do not add a LAB-specific source-space allowlist.
+- Return no LAB value for patterns, CMYK sources, nonfinite components, malformed snapshots, failed conversions, and every other input for which resolution is unavailable.
+- Do not substitute black, zero LAB coordinates, or another compatibility fallback.
+- Keep resolution support independent of cache eligibility. A convertible source may produce LAB coordinates while bypassing the cache under the existing identity rules.
+
+## Agreed result policy
+
+- Require the calculated L*, a*, and b* coordinates to be finite before returning or caching them.
+- Ordinary finite extended-range channels remain valid inputs and are not gamut-mapped.
+- If finite input channels cause arithmetic overflow or another nonfinite LAB result, return no LAB value and do not cache the result.
+
+## Validation plan
+
+- Verify ordinary sRGB values retain their existing LAB coordinates and cache behavior.
+- Compare equivalent colors represented in sRGB, grayscale, linear RGB, and Display P3, confirming that conversion uses resolved nonlinear sRGB rather than raw source component positions.
+- Verify in-gamut and out-of-sRGB-gamut Display P3 inputs, plus finite extended-sRGB values below zero and above one, produce finite unclipped LAB coordinates when the arithmetic remains representable.
+- Verify extreme finite extended-range input that overflows the conversion returns no LAB value and is not cached.
+- Verify transparent, translucent, and opaque versions have equal LAB coordinates while retaining distinct original-color cache identities.
+- Verify dynamic and semantic colors, patterns, CMYK sources, nonfinite components, malformed snapshots, and failed resolution return no LAB value.
+- Where Core Graphics rejects or sanitizes an invalid color during construction, test snapshot validation directly and do not mischaracterize the sanitized `Color` as preserving the invalid input.
+- Verify cold and warm cache results, distinct source-space identities for visually equivalent colors, cache bypass for convertible but ineligible spaces, and unchanged aggregate-converter cache independence.
+- Run the test suite on macOS and an iOS Simulator without changing the package deployment targets.


### PR DESCRIPTION
## Summary

Fix `Color.labComponents()` so fixed colors are resolved to nonlinear sRGB before LAB conversion instead of treating raw Core Graphics component positions as sRGB. This produces correct values for grayscale, linear RGB, Display P3, and other convertible RGB inputs while preserving deterministic failure behavior.

## Changes

- Route standalone LAB extraction through `ResolvedSRGBA` and return `nil` for unavailable resolution or nonfinite conversion results.
- Preserve finite extended-range channels without clipping or gamut mapping; continue ignoring alpha in LAB math while retaining original color space and alpha in cache identity.
- Cover equivalent sRGB, grayscale, linear RGB, Display P3, extended-range, malformed, dynamic, unsupported-model, alpha, cache, and aggregate-compatibility scenarios.
- Document the gamut, appearance, alpha, source, failure, cache, and compatibility policies in the English and Spanish READMEs, API docs, DocC, the domain glossary, and a focused design note.

## Alternatives considered

Duplicating Core Graphics color-space conversion inside `labComponents()` was rejected because it would create a second resolution policy that could drift from `ResolvedSRGBA`. Clipping or rejecting out-of-sRGB-gamut channels was also rejected because LAB can represent those colors without lossy gamut mapping.

## Notes

The public optional signature, original-component cache identities, `ColorSpaceConverter.getAllColorComponents()` behavior, and iOS 14/macOS 12 deployment targets remain unchanged. Dynamic colors still require callers to supply an appearance-resolved fixed color.

## Screenshots

Not applicable; no UI changes.

## Testing

- `swift test` — 220 tests passed on macOS.
- Focused `LABResolutionTests` — 8 tests passed.
- Repository CI test matrix passed on iOS 26.5 / iPhone 17 and macOS, including parallel non-shared suites and serial shared-cache suites.
- `swiftlint lint --strict` — 0 violations.
- DocC build passed with warnings treated as errors.