### PR TITLE
fix(accessibility): calculate WCAG relative luminance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to ColorKit will be documented in this file.
 ### Added
 - Add an atomic color-comparison result that reports per-input resolution, translucency, and sRGB-gamut issues.
 - Add CIEDE2000 comparison to the preview catalog's performance benchmark.
+- Add `contrastResult(with:)`, which reports a measured contrast ratio with its relative luminance values and passing WCAG levels, or an unavailable result with independent per-input issues.
+- Add `relativeLuminanceValue()`, which returns `nil` for an unresolvable color instead of the zero that `relativeLuminance()` reports.
 
 ### Changed
 - Deprecate `compare(with:)` in favor of explicit unavailable-result handling while preserving its ColorKit 2.x fallback behavior.
@@ -14,6 +16,9 @@ All notable changes to ColorKit will be documented in this file.
 
 ### Fixed
 - Replace the normalized Euclidean RGB calculation labeled as CIEDE2000 with a reference-validated CIEDE2000 implementation over resolved D65 LAB values.
+- Calculate `relativeLuminance()` according to WCAG 2.1 by linearizing sRGB components before weighting them. The previous calculation weighted gamma-encoded components directly and under-reported contrast for mid-tone colors; `#595959` on white now measures 7.00:1 rather than 2.63:1. `contrastRatio(with:)`, `adjustedForAccessibility(with:minimumRatio:)`, and `highContrastColor` all inherit the correction. See [the migration guide](MIGRATION.md#wcag-relative-luminance).
+- Classify `isDarkColor()` at the luminance where black and white contrast equally (approximately 0.1791) instead of at 0.5, so the black-or-white fallback is always the stronger contrasting endpoint.
+- Resolve luminance inputs through the shared resolved sRGBA snapshot, so a wider-gamut color is no longer read as though its components were sRGB.
 
 ## [2.1.0] - 2026-09-02
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,7 @@ The position between an ordered pair of colors, with zero representing the start
 _Avoid_: Rounded amount
 
 **Already-compliant input**:
-A foreground color whose existing contrast against the specified background meets or exceeds the requested minimum under ColorKit's legacy contrast calculation. It needs no adjustment; this term does not independently certify WCAG compliance.
+A foreground color whose existing WCAG contrast ratio against the specified background meets or exceeds the requested minimum. It needs no adjustment. The measurement ignores opacity and does not composite a translucent foreground.
 
 **Exhausted adjustment**:
 A contrast adjustment attempt that ends without finding a color that meets the requested minimum. It does not establish that no suitable color exists.
@@ -37,6 +37,22 @@ A directional endpoint attempt whose contrast meets the requested level. It is d
 **Contrast fallback**:
 The black or white color selected when contrast adjustment is unsuccessful. It is not guaranteed to meet every requested minimum.
 _Avoid_: Guaranteed compliant color
+
+**WCAG relative luminance**:
+The perceived brightness of a color under WCAG 2.1: each nonlinear sRGB component is linearized, then weighted by 0.2126, 0.7152, and 0.0722. It is not a weighted sum of gamma-encoded components, and opacity is not part of it.
+_Avoid_: Nonlinear luma, brightness
+
+**Unavailable contrast measurement**:
+A contrast measurement ColorKit cannot establish from the supplied inputs, because an input is unresolved or outside the sRGB gamut, or the background is translucent. It is absence, not a ratio of 1 and not a failed threshold.
+_Avoid_: Zero contrast, minimum ratio
+
+**Contrast input issue**:
+The reason one contrast input is not measurable. Issues are retained independently for the foreground and the background so one does not hide the other. A translucent foreground is composited rather than diagnosed; only a background is diagnosed as translucent.
+_Avoid_: Contrast score, ordered failure priority
+
+**White-preference luminance threshold**:
+The relative luminance at which black and white contrast equally against a color, approximately 0.1791. Below it white is the stronger contrasting endpoint; above it black is. It is not the midpoint of the luminance range.
+_Avoid_: Mid gray, luminance 0.5
 
 **Best available contrasting endpoint**:
 Whichever of black or white has the greater WCAG contrast ratio against a given color. This choice may still fall short of the requested contrast level, including AAA.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,63 @@
 # Migration Guide
 
+## Unreleased
+
+### WCAG relative luminance
+
+`relativeLuminance()` now follows WCAG 2.1. It linearizes each nonlinear sRGB
+component before applying the 0.2126, 0.7152, and 0.0722 weights. The previous
+implementation applied those weights to gamma-encoded components, which
+under-reported the luminance of every color except pure black and pure white.
+
+`contrastRatio(with:)`, `isDarkColor()`, `adjustedForAccessibility(with:minimumRatio:)`,
+and the `highContrastColor` modifier are all built on that luminance, so their
+results change as well. Ratios were previously understated for mid-tone colors:
+
+| Foreground on white | Before | Now (WCAG) |
+| --- | --- | --- |
+| `#595959` | 2.63:1 | 7.00:1 |
+| `#767676` | 2.05:1 | 4.54:1 |
+| `#008000` | 2.57:1 | 5.14:1 |
+
+**What to change.** If you calibrated a `minimumRatio` against the old numbers,
+re-check it against the WCAG scale. A threshold chosen to compensate for the old
+understatement will now be stricter than you intended. Colors that already met
+their target no longer get adjusted: `#595959` on white passes AAA and is now
+returned unchanged, where it was previously replaced by the black-or-white fallback.
+
+Values from `wcagContrastRatio(with:)` and `accessibilityResult(against:targetLevel:)`
+did not change. `contrastRatio(with:)` now agrees with them for any color that
+resolves to finite, in-gamut sRGB components.
+
+### Dark color classification
+
+`isDarkColor()` now compares relative luminance against approximately 0.1791, the
+luminance at which black and white contrast equally against a color, instead of
+against 0.5. This makes the black-or-white contrast fallback always the stronger
+contrasting endpoint. Colors between the two thresholds change classification;
+mid gray `#808080` is now classified light rather than dark.
+
+### Unavailable measurements
+
+`relativeLuminance()` still returns `0` for a color it cannot resolve, which is
+indistinguishable from a measured black. Two additions report that case honestly:
+
+```swift
+// nil rather than 0 when the color cannot be resolved
+let luminance: Double? = color.relativeLuminanceValue()
+
+switch foreground.contrastResult(with: background) {
+case .available(let measurement):
+    print(measurement.ratio, measurement.passingLevels)
+case .unavailable(let issues):
+    print(issues.foreground, issues.background)
+}
+```
+
+`contrastResult(with:)` composites a translucent foreground over an opaque
+background, and reports a translucent background, an unresolvable color, or a
+wider-gamut color as an issue rather than measuring it anyway.
+
 ## ColorKit 2.0.0
 
 ColorKit 2.0.0 makes theme ownership explicit at compile time and tightens

--- a/Sources/ColorKit/Color+Adaptive.swift
+++ b/Sources/ColorKit/Color+Adaptive.swift
@@ -40,10 +40,11 @@ public extension Color {
     /// Computes the relative luminance of a color based on WCAG standards.
     ///
     /// Relative luminance represents the perceived brightness of a color, calculated
-    /// according to the WCAG 2.1 specification. The calculation uses the following weights:
-    /// - Red: 0.2126
-    /// - Green: 0.7152
-    /// - Blue: 0.0722
+    /// according to the WCAG 2.1 specification: each nonlinear sRGB component is
+    /// linearized, then weighted by 0.2126 (red), 0.7152 (green), and 0.0722 (blue).
+    ///
+    /// Opacity is not part of relative luminance. Composite a translucent color over
+    /// its background before measuring it.
     ///
     /// Example:
     /// ```swift
@@ -52,10 +53,13 @@ public extension Color {
     /// print("Relative luminance: \(luminance)") // Value between 0 and 1
     /// ```
     ///
-    /// - Returns: A `CGFloat` representing the relative luminance, ranging from 0 (darkest) to 1 (brightest).
+    /// - Returns: A `CGFloat` representing the relative luminance, ranging from 0 (darkest)
+    ///   to 1 (brightest). Returns 0 when the color cannot be resolved to finite, in-gamut
+    ///   sRGB components; use ``relativeLuminanceValue()`` to distinguish that case from
+    ///   a measured black.
     func relativeLuminance() -> CGFloat {
-        guard let components = cgColor?.components, components.count >= 3 else { return 0 }
-        return 0.2126 * components[0] + 0.7152 * components[1] + 0.0722 * components[2]
+        guard let luminance = relativeLuminanceValue() else { return 0 }
+        return CGFloat(luminance)
     }
 
     /// Determines if the color is better suited for a light or dark mode background.
@@ -78,9 +82,11 @@ public extension Color {
     /// }
     /// ```
     ///
-    /// - Returns: `true` if the color is considered dark (luminance < 0.5), `false` otherwise.
+    /// - Returns: `true` when white contrasts better than black against this color,
+    ///   `false` otherwise. An unresolvable color reports `true`, matching the luminance
+    ///   fallback of ``relativeLuminance()``.
     func isDarkColor() -> Bool {
-        return relativeLuminance() < 0.5
+        return relativeLuminance() < Color.whitePreferenceLuminanceThreshold
     }
 
     /// Adjusts color brightness to ensure it contrasts well with Light/Dark mode backgrounds.
@@ -113,6 +119,10 @@ public extension Color {
     /// the relative luminance values of both colors. The ratio ranges from 1:1 (no contrast)
     /// to 21:1 (maximum contrast).
     ///
+    /// Opacity is ignored. This method compares two colors rather than compositing a
+    /// foreground over a background; use ``contrastResult(with:)`` to measure a
+    /// translucent foreground against an opaque background.
+    ///
     /// Example:
     /// ```swift
     /// let textColor = Color.blue
@@ -122,7 +132,9 @@ public extension Color {
     /// ```
     ///
     /// - Parameter other: The color to compare contrast against.
-    /// - Returns: A `CGFloat` representing the contrast ratio (from 1 to 21).
+    /// - Returns: A `CGFloat` representing the contrast ratio (from 1 to 21). An
+    ///   unresolvable color contributes the luminance fallback of ``relativeLuminance()``;
+    ///   use ``contrastResult(with:)`` to distinguish that case from a measured ratio.
     func contrastRatio(with other: Color) -> CGFloat {
         let l1 = self.relativeLuminance() + 0.05
         let l2 = other.relativeLuminance() + 0.05
@@ -131,11 +143,12 @@ public extension Color {
 
     /// Preserves a color that already meets the requested contrast, or attempts to adjust it.
     ///
-    /// Uses the legacy `contrastRatio(with:)` calculation. If the initial ratio meets or
+    /// Uses the WCAG `contrastRatio(with:)` calculation. If the initial ratio meets or
     /// exceeds the minimum, the original color is returned unchanged, including its opacity.
     /// Otherwise, the existing greedy search adjusts HSL lightness in steps of 0.05.
     /// If adjustment is unsuccessful, the fallback is white for a background classified
-    /// as dark by `isDarkColor()`, or black otherwise. The fallback may not meet the minimum.
+    /// as dark by `isDarkColor()`, or black otherwise. That is always the stronger
+    /// contrasting endpoint, but it may still fall short of the requested minimum.
     /// If the foreground cannot be converted to HSL, the original color is returned.
     /// A NaN minimum retains the fallback behavior when foreground conversion succeeds.
     ///
@@ -158,7 +171,7 @@ public extension Color {
     ///
     /// - Parameters:
     ///   - background: The background color against which contrast should be checked.
-    ///   - minimumRatio: The requested minimum under the legacy contrast calculation.
+    ///   - minimumRatio: The requested minimum WCAG contrast ratio.
     /// - Returns: The original color on initial success or HSL conversion failure,
     ///   the first successful adjustment, or the existing black/white fallback.
     func adjustedForAccessibility(with background: Color, minimumRatio: CGFloat) -> Color {
@@ -203,9 +216,18 @@ public extension Color {
             }
         }
 
-        // Preserve the legacy fallback when adjustment does not produce a successful result.
+        // Preserve the existing fallback when adjustment does not produce a successful result.
         return background.isDarkColor() ? .white : .black
     }
+}
+
+// MARK: - Internal Constants
+extension Color {
+    /// The relative luminance at which black and white contrast equally against a color.
+    ///
+    /// Below this value white is the stronger contrasting endpoint, and above it black is.
+    /// It is the solution to `(L + 0.05) / 0.05 == 1.05 / (L + 0.05)`.
+    static let whitePreferenceLuminanceThreshold: CGFloat = 0.1791287847
 }
 
 // MARK: - Private Helpers

--- a/Sources/ColorKit/Documentation.docc/Accessibility-article.md
+++ b/Sources/ColorKit/Documentation.docc/Accessibility-article.md
@@ -19,7 +19,7 @@ let ratio = backgroundColor.contrastRatio(with: textColor)
 print("Contrast ratio: \(ratio)")
 
 // Or measure it without collapsing an unresolvable input to zero luminance
-switch backgroundColor.contrastResult(with: textColor) {
+switch textColor.contrastResult(with: backgroundColor) {
 case .available(let measurement):
     print("Contrast ratio: \(measurement.ratio)")
     print("Passing levels: \(measurement.passingLevels)")

--- a/Sources/ColorKit/Documentation.docc/Accessibility-article.md
+++ b/Sources/ColorKit/Documentation.docc/Accessibility-article.md
@@ -18,6 +18,15 @@ let textColor = Color.gray
 let ratio = backgroundColor.contrastRatio(with: textColor)
 print("Contrast ratio: \(ratio)")
 
+// Or measure it without collapsing an unresolvable input to zero luminance
+switch backgroundColor.contrastResult(with: textColor) {
+case .available(let measurement):
+    print("Contrast ratio: \(measurement.ratio)")
+    print("Passing levels: \(measurement.passingLevels)")
+case .unavailable(let issues):
+    print("Unavailable: \(issues.foreground), \(issues.background)")
+}
+
 // Check WCAG compliance
 let compliance = backgroundColor.wcagCompliance(with: textColor)
 print("AA Large Text: \(compliance.passesAALarge)")
@@ -147,11 +156,18 @@ ColorKit supports both WCAG 2.1 AA and AAA levels:
 
 ### Contrast Checking
 - `Color.contrastRatio(with:)`
+- `Color.contrastResult(with:)`
+- `Color.relativeLuminance()`
+- `Color.relativeLuminanceValue()`
 - `Color.wcagCompliance(with:)`
 - `Color.accessibilityResult(against:targetLevel:)`
 - ``WCAGContrastLevel``
 - ``WCAGComplianceResult``
 - ``ColorAccessibilityResult``
+- ``ColorContrastResult``
+- ``ContrastMeasurement``
+- ``ContrastIssues``
+- ``ContrastInputIssue``
 
 ### Color Vision Deficiency Simulation
 - ``ColorVisionDeficiency``

--- a/Sources/ColorKit/Utilities/ColorSpaceConverter.swift
+++ b/Sources/ColorKit/Utilities/ColorSpaceConverter.swift
@@ -184,7 +184,7 @@ enum SRGBColorConversion {
         return (lighter + 0.05) / (darker + 0.05)
     }
 
-    private static func wcagRelativeLuminance(
+    static func wcagRelativeLuminance(
         _ rgb: (red: Double, green: Double, blue: Double)
     ) -> Double {
         0.2126 * wcagLinearized(rgb.red)

--- a/Sources/ColorKit/WCAG/ColorContrastResult.swift
+++ b/Sources/ColorKit/WCAG/ColorContrastResult.swift
@@ -1,0 +1,173 @@
+//
+//  ColorContrastResult.swift
+//  ColorKit
+//
+//  Created by Agisilaos Tsaraboulidis on 03.09.25.
+//
+//  Description:
+//  Provides result-bearing WCAG relative luminance and contrast ratio measurements.
+//
+//  Features:
+//  - Distinguishes a measured contrast ratio from an unavailable measurement
+//  - Reports independent per-input reasons for an unavailable measurement
+//  - Reuses the shared resolved sRGBA snapshot and WCAG luminance conversion
+//
+//  License:
+//  MIT License. See LICENSE file for details.
+//
+
+import SwiftUI
+
+/// A reason that one input cannot participate in an authoritative WCAG contrast measurement.
+public enum ContrastInputIssue: Sendable, Equatable {
+    /// The color cannot be resolved to fixed, finite sRGB components.
+    case unresolved
+    /// The resolved color lies outside the standard sRGB gamut and was not clamped.
+    case outOfSRGBGamut
+    /// The background is not opaque, so the contrast depends on context not supplied here.
+    ///
+    /// A translucent foreground is composited over the background instead of reporting
+    /// this issue. Only a background can be diagnosed as translucent.
+    case translucentBackground
+}
+
+/// The independently diagnosed issues for both inputs to a contrast measurement.
+public struct ContrastIssues: Sendable, Equatable {
+    /// Issues for the color that received `Color.contrastResult(with:)`.
+    public let foreground: [ContrastInputIssue]
+    /// Issues for the background color passed to `Color.contrastResult(with:)`.
+    public let background: [ContrastInputIssue]
+}
+
+/// A measured WCAG contrast ratio and the relative luminance values behind it.
+public struct ContrastMeasurement: Sendable, Equatable {
+    /// The WCAG contrast ratio, from 1 to 21.
+    public let ratio: Double
+    /// The WCAG relative luminance of the foreground, composited over the background when translucent.
+    public let foregroundLuminance: Double
+    /// The WCAG relative luminance of the background.
+    public let backgroundLuminance: Double
+
+    /// The WCAG contrast levels this ratio meets.
+    ///
+    /// An empty array means the ratio meets no level, not that measurement failed.
+    public var passingLevels: [WCAGContrastLevel] {
+        WCAGContrastLevel.allCases.filter { ratio >= $0.minimumRatio }
+    }
+
+    init(ratio: Double, foregroundLuminance: Double, backgroundLuminance: Double) {
+        self.ratio = ratio
+        self.foregroundLuminance = foregroundLuminance
+        self.backgroundLuminance = backgroundLuminance
+    }
+}
+
+/// The result of an atomic WCAG contrast measurement between a foreground and background.
+public enum ColorContrastResult: Sendable, Equatable {
+    /// The contrast ratio was measured from both inputs.
+    case available(ContrastMeasurement)
+    /// No contrast ratio is available; the associated value explains why.
+    case unavailable(ContrastIssues)
+
+    /// The measured contrast ratio, or `nil` when measurement is unavailable.
+    ///
+    /// An unavailable measurement is absence, not a ratio of 1.
+    public var ratio: Double? {
+        guard case .available(let measurement) = self else { return nil }
+        return measurement.ratio
+    }
+}
+
+public extension Color {
+    /// Measures the WCAG relative luminance of this color.
+    ///
+    /// The calculation follows WCAG 2.1: each nonlinear sRGB component is linearized,
+    /// then weighted by 0.2126, 0.7152, and 0.0722. Opacity is not part of relative
+    /// luminance; composite a translucent color against its background first.
+    ///
+    /// Example:
+    /// ```swift
+    /// if let luminance = Color(red: 0.35, green: 0.35, blue: 0.35).relativeLuminanceValue() {
+    ///     print("Relative luminance: \(luminance)")
+    /// }
+    /// ```
+    ///
+    /// - Returns: The relative luminance from 0 to 1, or `nil` when this color cannot
+    ///   be resolved to finite, in-gamut sRGB components.
+    func relativeLuminanceValue() -> Double? {
+        guard let resolved = ResolvedSRGBA.resolve(self), resolved.isInSRGBGamut else { return nil }
+        return SRGBColorConversion.wcagRelativeLuminance(
+            (red: Double(resolved.red), green: Double(resolved.green), blue: Double(resolved.blue))
+        )
+    }
+
+    /// Measures the WCAG contrast ratio between this foreground color and a background.
+    ///
+    /// Both colors must resolve to finite, in-gamut sRGB values, and the background
+    /// must be opaque. A translucent foreground is composited over the background
+    /// before measurement. Dynamic colors, wider-gamut colors, and translucent
+    /// backgrounds produce an unavailable result rather than an invented ratio.
+    ///
+    /// Example:
+    /// ```swift
+    /// switch Color(red: 0.35, green: 0.35, blue: 0.35).contrastResult(with: .white) {
+    /// case .available(let measurement):
+    ///     print("Contrast ratio: \(measurement.ratio):1")
+    /// case .unavailable(let issues):
+    ///     print("Unavailable: \(issues.foreground), \(issues.background)")
+    /// }
+    /// ```
+    ///
+    /// - Parameter backgroundColor: The background behind this foreground color.
+    /// - Returns: A result that distinguishes a measured ratio from an unavailable measurement.
+    func contrastResult(with backgroundColor: Color) -> ColorContrastResult {
+        let foregroundResolved = ResolvedSRGBA.resolve(self)
+        let backgroundResolved = ResolvedSRGBA.resolve(backgroundColor)
+
+        var foregroundIssues: [ContrastInputIssue] = []
+        var backgroundIssues: [ContrastInputIssue] = []
+
+        if let foregroundResolved {
+            if !foregroundResolved.isInSRGBGamut { foregroundIssues.append(.outOfSRGBGamut) }
+        } else {
+            foregroundIssues.append(.unresolved)
+        }
+
+        if let backgroundResolved {
+            if !backgroundResolved.isInSRGBGamut { backgroundIssues.append(.outOfSRGBGamut) }
+            if backgroundResolved.alpha != 1 { backgroundIssues.append(.translucentBackground) }
+        } else {
+            backgroundIssues.append(.unresolved)
+        }
+
+        guard foregroundIssues.isEmpty,
+              backgroundIssues.isEmpty,
+              let foregroundResolved,
+              let backgroundResolved else {
+            return .unavailable(
+                ContrastIssues(foreground: foregroundIssues, background: backgroundIssues)
+            )
+        }
+
+        // Composite the foreground over the opaque background so opacity is measured, not ignored.
+        let inverseAlpha = 1 - foregroundResolved.alpha
+        let composited = (
+            red: Double(foregroundResolved.red * foregroundResolved.alpha + backgroundResolved.red * inverseAlpha),
+            green: Double(foregroundResolved.green * foregroundResolved.alpha + backgroundResolved.green * inverseAlpha),
+            blue: Double(foregroundResolved.blue * foregroundResolved.alpha + backgroundResolved.blue * inverseAlpha)
+        )
+        let background = (
+            red: Double(backgroundResolved.red),
+            green: Double(backgroundResolved.green),
+            blue: Double(backgroundResolved.blue)
+        )
+
+        return .available(
+            ContrastMeasurement(
+                ratio: SRGBColorConversion.wcagContrastRatio(between: composited, and: background),
+                foregroundLuminance: SRGBColorConversion.wcagRelativeLuminance(composited),
+                backgroundLuminance: SRGBColorConversion.wcagRelativeLuminance(background)
+            )
+        )
+    }
+}

--- a/Tests/ColorKitTests/AccessibilityAdjustmentTests.swift
+++ b/Tests/ColorKitTests/AccessibilityAdjustmentTests.swift
@@ -50,16 +50,27 @@ final class AccessibilityAdjustmentTests: XCTestCase {
         }
     }
 
-    func testExhaustedSearchKeepsLegacyFallbackEvenWhenBlackWouldPass() {
+    func testExhaustedSearchFallsBackToStrongerContrastingEndpoint() {
         let foreground = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
-        let background = Color(.sRGB, red: 0.4, green: 0.4, blue: 0.4)
-        XCTAssertLessThan(foreground.contrastRatio(with: background), 7)
-        XCTAssertGreaterThan(Color.black.contrastRatio(with: background), 7)
+        let backgrounds = [
+            Color(.sRGB, red: 0.4, green: 0.4, blue: 0.4),
+            Color(.sRGB, red: 0.1, green: 0.1, blue: 0.1),
+            Color(.sRGB, red: 0.9, green: 0.9, blue: 0.9)
+        ]
 
-        let adjusted = foreground.adjustedForAccessibility(with: background, minimumRatio: 7)
+        for background in backgrounds {
+            let adjusted = foreground.adjustedForAccessibility(with: background, minimumRatio: 22)
+            let blackRatio = Color.black.contrastRatio(with: background)
+            let whiteRatio = Color.white.contrastRatio(with: background)
 
-        XCTAssertEqual(adjusted, .white)
-        XCTAssertLessThan(adjusted.contrastRatio(with: background), 7)
+            // The fallback is never the weaker of the two endpoints.
+            XCTAssertEqual(adjusted, blackRatio >= whiteRatio ? .black : .white)
+            XCTAssertEqual(
+                adjusted.contrastRatio(with: background),
+                max(blackRatio, whiteRatio),
+                accuracy: 1e-9
+            )
+        }
     }
 
     func testFailedForegroundConversionReturnsOriginalColor() {

--- a/Tests/ColorKitTests/WCAG/ColorContrastResultTests.swift
+++ b/Tests/ColorKitTests/WCAG/ColorContrastResultTests.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class ColorContrastResultTests: XCTestCase {
+    // MARK: - Reference values
+
+    /// Published WCAG contrast ratios that the un-linearized calculation could not produce.
+    private static let referencePairs: [(hex: String, ratioWithWhite: Double)] = [
+        ("#000000", 21.0),
+        ("#595959", 7.0),
+        ("#767676", 4.54),
+        ("#008000", 5.14),
+        ("#0000FF", 8.59),
+        ("#FF0000", 3.998),
+        ("#FFFFFF", 1.0)
+    ]
+
+    func testContrastRatioMatchesPublishedWCAGValues() throws {
+        for (hex, expected) in Self.referencePairs {
+            let color = try XCTUnwrap(Color(hex: hex))
+
+            XCTAssertEqual(
+                Double(color.contrastRatio(with: .white)),
+                expected,
+                accuracy: 0.01,
+                "\(hex) against white"
+            )
+        }
+    }
+
+    func testRelativeLuminanceLinearizesComponents() throws {
+        // Mid gray is 0.216 in linear light, not the 0.502 a gamma-encoded sum would give.
+        let midGray = try XCTUnwrap(Color(hex: "#808080"))
+
+        XCTAssertEqual(Double(midGray.relativeLuminance()), 0.2159, accuracy: 0.001)
+    }
+
+    func testRelativeLuminanceEndpoints() {
+        XCTAssertEqual(Double(Color.black.relativeLuminance()), 0, accuracy: 1e-9)
+        XCTAssertEqual(Double(Color.white.relativeLuminance()), 1, accuracy: 1e-9)
+    }
+
+    func testBlackOnWhiteIsTwentyOne() {
+        XCTAssertEqual(Double(Color.black.contrastRatio(with: .white)), 21, accuracy: 1e-9)
+    }
+
+    func testContrastRatioIsSymmetric() throws {
+        let first = try XCTUnwrap(Color(hex: "#3366CC"))
+        let second = try XCTUnwrap(Color(hex: "#F0E68C"))
+
+        XCTAssertEqual(first.contrastRatio(with: second), second.contrastRatio(with: first))
+    }
+
+    // MARK: - Dark color classification
+
+    func testIsDarkColorUsesEqualContrastThreshold() throws {
+        // Just below the threshold white contrasts better; just above it black does.
+        let belowThreshold = try XCTUnwrap(Color(hex: "#757575"))
+        let aboveThreshold = try XCTUnwrap(Color(hex: "#767676"))
+
+        XCTAssertTrue(belowThreshold.isDarkColor())
+        XCTAssertFalse(aboveThreshold.isDarkColor())
+    }
+
+    func testIsDarkColorAgreesWithStrongerEndpoint() {
+        for step in 0...100 {
+            let value = Double(step) / 100
+            let color = Color(.sRGB, red: value, green: value, blue: value)
+            let whiteIsStronger = color.contrastRatio(with: .white) > color.contrastRatio(with: .black)
+
+            XCTAssertEqual(color.isDarkColor(), whiteIsStronger, "gray \(value)")
+        }
+    }
+
+    func testBlackAndWhiteClassification() {
+        XCTAssertTrue(Color.black.isDarkColor())
+        XCTAssertFalse(Color.white.isDarkColor())
+    }
+
+    // MARK: - Result API
+
+    func testAvailableResultReportsRatioAndLuminances() throws {
+        let foreground = try XCTUnwrap(Color(hex: "#595959"))
+
+        guard case .available(let measurement) = foreground.contrastResult(with: .white) else {
+            return XCTFail("Expected an available measurement")
+        }
+
+        XCTAssertEqual(measurement.ratio, 7.0, accuracy: 0.01)
+        XCTAssertEqual(measurement.backgroundLuminance, 1, accuracy: 1e-9)
+        XCTAssertEqual(measurement.foregroundLuminance, 0.1, accuracy: 0.01)
+    }
+
+    func testPassingLevelsReflectMeasuredRatio() throws {
+        let foreground = try XCTUnwrap(Color(hex: "#595959"))
+
+        guard case .available(let measurement) = foreground.contrastResult(with: .white) else {
+            return XCTFail("Expected an available measurement")
+        }
+
+        XCTAssertEqual(Set(measurement.passingLevels), Set(WCAGContrastLevel.allCases))
+    }
+
+    func testPassingLevelsCanBeEmptyWithoutBeingUnavailable() {
+        let result = Color.white.contrastResult(with: .white)
+
+        guard case .available(let measurement) = result else {
+            return XCTFail("Expected an available measurement")
+        }
+
+        XCTAssertEqual(measurement.ratio, 1, accuracy: 1e-9)
+        XCTAssertTrue(measurement.passingLevels.isEmpty)
+    }
+
+    func testUnresolvedForegroundIsDiagnosedIndependently() {
+        guard case .unavailable(let issues) = Color.primary.contrastResult(with: .white) else {
+            return XCTFail("Expected an unavailable measurement")
+        }
+
+        XCTAssertEqual(issues.foreground, [.unresolved])
+        XCTAssertTrue(issues.background.isEmpty)
+    }
+
+    func testUnresolvedBackgroundIsDiagnosedIndependently() {
+        guard case .unavailable(let issues) = Color.white.contrastResult(with: .primary) else {
+            return XCTFail("Expected an unavailable measurement")
+        }
+
+        XCTAssertTrue(issues.foreground.isEmpty)
+        XCTAssertEqual(issues.background, [.unresolved])
+    }
+
+    func testBothInputsAreDiagnosedWithoutHidingEachOther() {
+        guard case .unavailable(let issues) = Color.primary.contrastResult(with: .primary) else {
+            return XCTFail("Expected an unavailable measurement")
+        }
+
+        XCTAssertEqual(issues.foreground, [.unresolved])
+        XCTAssertEqual(issues.background, [.unresolved])
+    }
+
+    func testTranslucentBackgroundIsUnavailable() {
+        let background = Color(.sRGB, red: 1, green: 1, blue: 1, opacity: 0.5)
+
+        guard case .unavailable(let issues) = Color.black.contrastResult(with: background) else {
+            return XCTFail("Expected an unavailable measurement")
+        }
+
+        XCTAssertEqual(issues.background, [.translucentBackground])
+    }
+
+    func testTranslucentForegroundIsCompositedRatherThanRejected() {
+        let foreground = Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 0.5)
+
+        guard case .available(let measurement) = foreground.contrastResult(with: .white) else {
+            return XCTFail("Expected an available measurement")
+        }
+
+        // Half-strength black over white composites to 0.5 in nonlinear sRGB.
+        let composited = Color(.sRGB, red: 0.5, green: 0.5, blue: 0.5)
+        XCTAssertEqual(
+            measurement.ratio,
+            Double(composited.contrastRatio(with: .white)),
+            accuracy: 1e-9
+        )
+    }
+
+    func testOutOfGamutInputIsNotClampedIntoEligibility() {
+        let wide = Color(.displayP3, red: 1, green: 0, blue: 0)
+
+        guard case .unavailable(let issues) = wide.contrastResult(with: .white) else {
+            return XCTFail("Expected an unavailable measurement")
+        }
+
+        XCTAssertEqual(issues.foreground, [.outOfSRGBGamut])
+    }
+
+    func testUnavailableResultHasNoRatio() {
+        XCTAssertNil(Color.primary.contrastResult(with: .white).ratio)
+    }
+
+    func testAvailableResultExposesRatioAccessor() throws {
+        let result = Color.black.contrastResult(with: .white)
+
+        XCTAssertEqual(try XCTUnwrap(result.ratio), 21, accuracy: 1e-9)
+    }
+
+    // MARK: - Luminance value API
+
+    func testRelativeLuminanceValueIsNilForUnresolvableColor() {
+        XCTAssertNil(Color.primary.relativeLuminanceValue())
+    }
+
+    func testRelativeLuminanceValueDistinguishesUnavailableFromBlack() throws {
+        XCTAssertEqual(try XCTUnwrap(Color.black.relativeLuminanceValue()), 0, accuracy: 1e-9)
+        XCTAssertNil(Color.primary.relativeLuminanceValue())
+
+        // The non-optional accessor collapses both cases to zero.
+        XCTAssertEqual(Color.primary.relativeLuminance(), 0)
+        XCTAssertEqual(Color.black.relativeLuminance(), 0)
+    }
+
+    func testRelativeLuminanceValueAgreesWithNonOptionalAccessor() throws {
+        for (hex, _) in Self.referencePairs {
+            let color = try XCTUnwrap(Color(hex: hex))
+            let value = try XCTUnwrap(color.relativeLuminanceValue())
+
+            XCTAssertEqual(Double(color.relativeLuminance()), value, accuracy: 1e-12, hex)
+        }
+    }
+
+    // MARK: - Cross-API agreement
+
+    func testAgreesWithStrictAccessibilityResult() throws {
+        let pairs: [(foreground: String, background: String)] = [
+            ("#595959", "#FFFFFF"),
+            ("#767676", "#FFFFFF"),
+            ("#0000FF", "#FFFFFF"),
+            ("#FFFFFF", "#000000")
+        ]
+
+        for (foregroundHex, backgroundHex) in pairs {
+            let foreground = try XCTUnwrap(Color(hex: foregroundHex))
+            let background = try XCTUnwrap(Color(hex: backgroundHex))
+
+            let result = foreground.accessibilityResult(against: background, targetLevel: .AA)
+            let measured = try XCTUnwrap(foreground.contrastResult(with: background).ratio)
+
+            XCTAssertEqual(try XCTUnwrap(result.contrastRatio), measured, accuracy: 1e-9)
+        }
+    }
+
+    func testAgreesWithWCAGContrastRatioForResolvableColors() throws {
+        for (hex, _) in Self.referencePairs {
+            let color = try XCTUnwrap(Color(hex: hex))
+
+            XCTAssertEqual(
+                Double(color.contrastRatio(with: .white)),
+                color.wcagContrastRatio(with: .white),
+                accuracy: 1e-9,
+                hex
+            )
+        }
+    }
+}

--- a/docs/adr/0006-correct-wcag-luminance-in-place.md
+++ b/docs/adr/0006-correct-wcag-luminance-in-place.md
@@ -1,0 +1,3 @@
+# Correct WCAG relative luminance in place
+
+`relativeLuminance()` will linearize sRGB components before weighting them, changing the values it and every API built on it return, rather than preserving the previous numbers behind a deprecated adapter. The previous calculation weighted gamma-encoded components and was documented as WCAG 2.1, so callers already relied on it to mean WCAG contrast; keeping a compatibility path would preserve an understated ratio that silently fails accessibility decisions, and no caller can reasonably depend on a value that never matched the specification it named.

--- a/docs/adr/0007-classify-dark-colors-at-equal-contrast.md
+++ b/docs/adr/0007-classify-dark-colors-at-equal-contrast.md
@@ -1,0 +1,3 @@
+# Classify dark colors at the equal-contrast luminance
+
+`isDarkColor()` will compare relative luminance against the point where black and white contrast equally, approximately 0.1791, rather than the midpoint of the luminance range. The method exists to choose a contrasting endpoint, so the threshold that makes that choice correct is the one where the endpoints tie; the 0.5 midpoint has no contrast meaning under linear luminance and made the black-or-white fallback select the weaker endpoint for mid-tone backgrounds.

--- a/docs/design/wcag-luminance-correction.md
+++ b/docs/design/wcag-luminance-correction.md
@@ -1,0 +1,101 @@
+# WCAG relative luminance correction
+
+Status: implemented.
+
+## Problem
+
+`Color.relativeLuminance()` was documented as following the WCAG 2.1 specification
+but applied the 0.2126, 0.7152, and 0.0722 weights directly to gamma-encoded sRGB
+components, omitting the linearization step the specification requires. Every API
+built on it inherited the error:
+
+- `contrastRatio(with:)`, documented as producing a WCAG ratio from 1 to 21;
+- `isDarkColor()`, which chose a contrasting endpoint;
+- `adjustedForAccessibility(with:minimumRatio:)` and the `highContrastColor`
+  modifier, which searched for a color meeting a requested ratio.
+
+The result understated contrast for every color except pure black and pure white:
+
+| Foreground on white | WCAG | Previous |
+| --- | --- | --- |
+| `#595959` | 7.00:1 | 2.63:1 |
+| `#767676` | 4.54:1 | 2.05:1 |
+| `#008000` | 5.14:1 | 2.57:1 |
+
+A caller requesting 4.5:1 for `#595959` on white, a color that passes AAA, saw a
+measured 2.63:1, watched the greedy search fail, and received a black or white
+fallback in place of a color that was already compliant.
+
+The same method read `cgColor?.components` directly, so a wider-gamut color's
+components were weighted as though they were sRGB, and an unresolvable color
+returned `0`, which is indistinguishable from a measured black.
+
+A correct implementation already existed in `wcagRelativeLuminance()`, giving the
+library two divergent public contrast calculations with no stated relationship.
+
+## Approach
+
+Correct the calculation in place rather than preserving the previous numbers
+behind an adapter. See [ADR 0006](../adr/0006-correct-wcag-luminance-in-place.md).
+
+`relativeLuminance()` now delegates to the new `relativeLuminanceValue()`, which
+resolves its input through `ResolvedSRGBA` and applies
+`SRGBColorConversion.wcagRelativeLuminance`. That conversion was already the
+single linearizing implementation behind `wcagContrastRatio(with:)` and
+`accessibilityResult(against:targetLevel:)`; exposing it internally makes it the
+one luminance calculation in the library rather than adding a third.
+
+`contrastRatio(with:)` keeps its body and inherits the correction, so it now
+agrees with `wcagContrastRatio(with:)` for any color that resolves to finite,
+in-gamut sRGB components.
+
+## Dark color classification
+
+`isDarkColor()` compared luminance against 0.5. Under linear luminance that value
+has no contrast meaning: mid gray `#808080` has a relative luminance of 0.216, so
+the midpoint classified most mid-tones as dark.
+
+The threshold is now the luminance at which black and white contrast equally,
+the solution to `(L + 0.05) / 0.05 == 1.05 / (L + 0.05)`, or approximately
+0.1791. See [ADR 0007](../adr/0007-classify-dark-colors-at-equal-contrast.md).
+
+This makes `background.isDarkColor() ? .white : .black` select the stronger
+contrasting endpoint by construction. The previous behavior had a reachable case
+where the fallback was the weaker endpoint, and a test documented it; with the
+corrected threshold that case cannot occur, because any background classified
+dark caps black's ratio at 4.58:1. The test now asserts the invariant instead.
+
+## Unavailable measurements
+
+`relativeLuminance()` and `contrastRatio(with:)` keep non-optional signatures and
+an unresolvable input still contributes `0`. Two additions report that case:
+
+- `relativeLuminanceValue() -> Double?` returns `nil` rather than `0`.
+- `contrastResult(with:) -> ColorContrastResult` returns either a
+  `ContrastMeasurement` carrying the ratio, both relative luminance values, and
+  the passing WCAG levels, or `ContrastIssues` naming why each input failed.
+
+Issues are retained independently for the foreground and background so one does
+not hide the other, matching `ColorComparisonIssues`. A translucent foreground is
+composited over the background rather than rejected, because the background
+supplies the missing context; a translucent background is an issue, because it
+does not. Wider-gamut colors are reported rather than clamped into eligibility.
+
+`ContrastMeasurement.passingLevels` can be empty for a measured ratio. An empty
+array means the ratio meets no level, which is distinct from an unavailable
+measurement.
+
+## Alternatives considered
+
+- **Deprecate `contrastRatio(with:)` toward `wcagContrastRatio(with:)`.** Rejected
+  because it would leave the understated calculation reachable and still driving
+  `adjustedForAccessibility`, and because a value documented as WCAG that never
+  matched WCAG is a defect rather than a compatibility surface.
+- **Return an optional from `relativeLuminance()`.** Rejected as source-breaking
+  for every caller, including those whose colors always resolve. The optional
+  accessor is additive instead.
+- **Route `wcagRelativeLuminance()` through `ResolvedSRGBA` in this change.** It
+  fabricates black through `wcagRGBAComponents()` when resolution fails, which is
+  the same defect class. Deferred because that primitive also backs palette
+  export, LAB round-trips, and comparison, including a test that asserts a NaN
+  alpha survives it; changing its resolution semantics needs its own change.


### PR DESCRIPTION
## Summary

- Correct `relativeLuminance()` to follow WCAG 2.1 by linearizing sRGB components before weighting them, and resolve its input through the shared resolved sRGBA snapshot.
- Classify `isDarkColor()` at the luminance where black and white contrast equally, so the black-or-white fallback is always the stronger contrasting endpoint.
- Add result-bearing `contrastResult(with:)` and `relativeLuminanceValue()` so an unresolvable input is reported rather than measured as black.

## Changes

- Linearize each nonlinear sRGB component in `relativeLuminance()` before applying the 0.2126, 0.7152, and 0.0722 weights. The previous implementation applied those weights to gamma-encoded components while documenting itself as WCAG 2.1.
- Resolve luminance inputs through `ResolvedSRGBA` instead of reading `cgColor?.components` directly, so a wider-gamut color is no longer weighted as though its components were sRGB.
- Expose `SRGBColorConversion.wcagRelativeLuminance` internally and route the corrected calculation through it, making it the single linearizing luminance implementation rather than adding a third.
- Move the `isDarkColor()` threshold from 0.5 to approximately 0.1791, the solution to `(L + 0.05) / 0.05 == 1.05 / (L + 0.05)`.
- Add `ColorContrastResult`, `ContrastMeasurement`, `ContrastIssues`, and `ContrastInputIssue`, with independent per-input diagnosis so one input's issue does not hide the other's.
- Add `relativeLuminanceValue()` returning `nil` where `relativeLuminance()` returns `0`.
- Update the changelog, migration guide, `CONTEXT.md` language, DocC accessibility article, two ADRs, and an implementation design record.

## Impact

`contrastRatio(with:)`, `adjustedForAccessibility(with:minimumRatio:)`, and the `highContrastColor` modifier are all built on the corrected luminance, so their results change. Ratios were previously understated for mid tones:

| Foreground on white | Before | Now (WCAG) |
| --- | --- | --- |
| `#595959` | 2.63:1 | 7.00:1 |
| `#767676` | 2.05:1 | 4.54:1 |
| `#008000` | 2.57:1 | 5.14:1 |

The practical consequence was that `adjustedForAccessibility(with: .white, minimumRatio: 4.5)` measured `#595959` at 2.63:1, exhausted its search, and returned a black or white fallback in place of a color that already passes AAA. `contrastRatio(with:)` now agrees with `wcagContrastRatio(with:)`, whose values do not change.

## Alternatives considered

- Deprecating `contrastRatio(with:)` toward `wcagContrastRatio(with:)` was rejected because it would leave the understated calculation reachable and still driving accessibility adjustment; a value documented as WCAG that never matched WCAG is a defect rather than a compatibility surface. See ADR 0006.
- Returning an optional from `relativeLuminance()` was rejected as source-breaking for every caller, including those whose colors always resolve. The optional accessor is additive instead.
- Routing `wcagRelativeLuminance()` through `ResolvedSRGBA` in this change was deferred. It fabricates black through `wcagRGBAComponents()` when resolution fails, which is the same defect class, but that primitive also backs palette export, LAB round-trips, and comparison, including a test asserting a NaN alpha survives it. It needs its own change.

## Notes

- `testExhaustedSearchKeepsLegacyFallbackEvenWhenBlackWouldPass` asserted that black cleared 7:1 against `#666666`, which held only under the un-linearized math (9.0 against a true 3.66). With the corrected threshold the case it guarded is unreachable: any background classified dark caps black's ratio at 4.58:1. The test now asserts the invariant that the fallback is never the weaker endpoint.
- `relativeLuminance()` and `contrastRatio(with:)` keep their non-optional signatures and still report `0` for an unresolvable color; the new result APIs are where that case is distinguished.
- No demo or preview view calls the changed APIs, so the preview catalog renders unchanged. Consumers using the `highContrastColor` modifier will see changed output.

## Screenshots

Not applicable; no UI changes.

## Testing

- `swift test` — 248 tests, 0 failures
- `scripts/run_tests.sh macOS 'platform=macOS'` and `scripts/run_tests.sh iOS 'platform=iOS Simulator,name=iPhone 17 Pro'`
- Cache and theme integration suites serially on both destinations with `-parallel-testing-enabled NO`
- `swiftlint lint --strict`
- `xcodebuild docbuild -scheme ColorKit -destination generic/platform=macOS OTHER_DOCC_FLAGS=--warnings-as-errors`
- `git diff --check`
- New `ColorContrastResultTests` validates the corrected ratios against published WCAG reference values, checks `isDarkColor()` against the stronger endpoint across 101 grays, and covers each unavailable path.
