### PR TITLE
fix(ci): narrow dependency caching and retain test diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,13 @@ jobs:
       - name: Cache SPM dependencies
         uses: actions/cache@v4
         with:
-          path: .build
-          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.5-spm-${{ hashFiles('**/Package.resolved') }}
+          path: |
+            .build/checkouts
+            .build/repositories
+            .build/artifacts
+          key: ${{ runner.os }}-${{ runner.arch }}-xcode-26.5-spm-deps-v1-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-xcode-26.5-spm-
+            ${{ runner.os }}-${{ runner.arch }}-xcode-26.5-spm-deps-v1-
 
       - name: Resolve Swift Package Dependencies
         run: swift package resolve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to ColorKit will be documented in this file.
 - Resolve strict `relativeLuminanceValue()` inputs through the shared resolved sRGBA snapshot, so a wider-gamut color is reported as unavailable instead of read as though its components were sRGB. Keep `relativeLuminance()` lenient by resolving through `UIColor` or `NSColor` for the current appearance.
 
 ### Tooling
+- Retain both stdout and stderr in test-runner logs, including failed Xcode invocations.
 - Use one local/CI test matrix with the pinned iPhone 17 / iOS 26.5 destination, isolated build storage, unique raw logs and result bundles, and serialized shared-state suites.
 - Compile marked public documentation examples and actual generated theme code in CI; execute HSL, CMYK, and LAB README examples in both languages and verify their results. Test the runner's CLI contract and fail when required example coverage disappears.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to ColorKit will be documented in this file.
 - Resolve strict `relativeLuminanceValue()` inputs through the shared resolved sRGBA snapshot, so a wider-gamut color is reported as unavailable instead of read as though its components were sRGB. Keep `relativeLuminance()` lenient by resolving through `UIColor` or `NSColor` for the current appearance.
 
 ### Tooling
+- Limit the CI dependency cache to SwiftPM sources and downloaded artifacts, excluding Xcode build products and test results.
 - Retain both stdout and stderr in test-runner logs, including failed Xcode invocations.
 - Use one local/CI test matrix with the pinned iPhone 17 / iOS 26.5 destination, isolated build storage, unique raw logs and result bundles, and serialized shared-state suites.
 - Compile marked public documentation examples and actual generated theme code in CI; execute HSL, CMYK, and LAB README examples in both languages and verify their results. Test the runner's CLI contract and fail when required example coverage disappears.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ and pinned destinations in `scripts/run_tests.sh`, not in the workflow. Set
 Build storage defaults to this checkout's `.build/xcode`; override it with
 `COLORKIT_DERIVED_DATA` when needed.
 
+CI caches only SwiftPM checkouts, repositories, and downloaded artifacts. Xcode
+build products and test results stay outside that dependency cache. The cache key
+has its own scope version so older whole-`.build` archives are not restored.
+
 Each matrix invocation retains raw stdout/stderr logs and result bundles in a unique directory
 under `.build/test-results`; use `--results-dir TestResults` to choose another parent.
 For a targeted run, pass a platform label, destination, and Xcode options. Only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ and pinned destinations in `scripts/run_tests.sh`, not in the workflow. Set
 Build storage defaults to this checkout's `.build/xcode`; override it with
 `COLORKIT_DERIVED_DATA` when needed.
 
-Each matrix invocation retains raw logs and result bundles in a unique directory
+Each matrix invocation retains raw stdout/stderr logs and result bundles in a unique directory
 under `.build/test-results`; use `--results-dir TestResults` to choose another parent.
 For a targeted run, pass a platform label, destination, and Xcode options. Only
 these explicit single-destination runs use `xcpretty` when available; add

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -58,7 +58,7 @@ run_tests() {
         -destination "$destination" \
         -derivedDataPath "$derived_data" \
         -enableCodeCoverage YES \
-        "${test_options[@]}" \
+        "${test_options[@]}" 2>&1 \
         | "${output_command[@]}"; then
         printf '%s tests passed\n' "$platform"
         return 0

--- a/scripts/tests/test_run_tests.py
+++ b/scripts/tests/test_run_tests.py
@@ -27,6 +27,7 @@ class TestRunnerContract(unittest.TestCase):
             "with open(os.environ['RUNNER_CALLS'], 'a') as log:\n"
             "    log.write(json.dumps(sys.argv[1:]) + '\\n')\n"
             "print('raw xcodebuild output')\n"
+            "print('xcodebuild diagnostic', file=sys.stderr)\n"
             "sys.exit(65 if os.environ.get('RUNNER_FAIL') == '1' else 0)\n"
         )
         fake.chmod(0o755)
@@ -93,6 +94,19 @@ class TestRunnerContract(unittest.TestCase):
         result = self.run_script("macOS", "platform=macOS")
         self.assertEqual(result.returncode, 1)
 
+    def test_matrix_logs_retain_both_streams_on_success_and_failure(self):
+        for failure in ("0", "1"):
+            with self.subTest(failure=failure):
+                self.environment["RUNNER_FAIL"] = failure
+                parent = self.root / f"logs-{failure}"
+                result = self.run_script("--results-dir", str(parent))
+                self.assertEqual(result.returncode, int(failure))
+                logs = list(parent.glob("run.*/*.log"))
+                self.assertEqual(len(logs), 4)
+                for path in logs:
+                    self.assertIn("raw xcodebuild output", path.read_text())
+                    self.assertIn("xcodebuild diagnostic", path.read_text())
+
     def test_explicit_run_preserves_arguments_and_serial_override(self):
         result = self.run_script("macOS", "platform=macOS", "-parallel-testing-enabled", "NO",
                                  "-only-testing:ColorKitTests/ThemeTests")
@@ -101,6 +115,14 @@ class TestRunnerContract(unittest.TestCase):
         self.assertEqual(call.count("-parallel-testing-enabled"), 1)
         self.assertNotIn("-parallel-testing-worker-count", call)
         self.assertIn("-only-testing:ColorKitTests/ThemeTests", call)
+
+    def test_explicit_log_retains_both_streams_on_failure(self):
+        self.environment["RUNNER_FAIL"] = "1"
+        log = self.root / "explicit.log"
+        result = self.run_script("--log-file", str(log), "macOS", "platform=macOS")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("raw xcodebuild output", log.read_text())
+        self.assertIn("xcodebuild diagnostic", log.read_text())
 
     def test_destination_overrides_apply_to_both_phases(self):
         self.environment["COLORKIT_IOS_DESTINATION"] = "platform=iOS Simulator,id=chosen"


### PR DESCRIPTION
## Summary

Complete the two tooling follow-ups from #53: keep generated Xcode products out of the dependency cache and retain stderr in test logs.

## Changes

- Cache only SwiftPM checkouts, repositories, and downloaded artifacts instead of all `.build` contents.
- Version both exact and fallback cache keys so older whole-directory archives are not restored.
- Combine xcodebuild stderr with stdout before the existing output pipeline, preserving failure propagation and serialized test phases.
- Add CLI regression coverage for successful and failing matrix logs and failed explicit-log runs.
- Update contributor guidance and Unreleased tooling notes.

## Alternatives considered

- Moving DerivedData only in CI would leave an overly broad cache policy. Explicit dependency paths make the cache boundary clear.
- Separate stderr files would complicate reviewing diagnostics. Combining streams keeps the existing log and artifact workflow.

## Notes

- Follow-up to merged #53; no production API changes, release version changes, or tags.
- The new cache namespace intentionally starts cold. No existing remote caches are deleted.
- Standards and requirements reviews found no issues.

## Screenshots

Not applicable; no UI changes.

## Testing

- `python3 -m unittest discover -s scripts/tests`: 13 tests passed; rerun during PR preparation.
- Negative regression proof: stderr-retention checks failed for both successful and failed matrix runs before the redirection fix, then passed afterward.
- `scripts/run_tests.sh`: all four iOS/macOS phases passed during implementation on this unchanged code, including serialized shared-state suites.
- `bash -n scripts/run_tests.sh`: passed.
- Workflow YAML parsing and assertions for the three dependency paths and new cache-key namespace: passed during implementation.
- `swiftlint lint --strict`: passed; rerun during PR preparation.
- `git diff origin/main...HEAD --check`: passed.
