### PR TITLE
doc(release): prepare ColorKit 3.0.0 and migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-09-04
+
+### Breaking changes
+- Add `ColorAccessibilityResult.Status.invalidConfiguration`; update exhaustive switches when upgrading from 2.1.0.
+- Add the defaulted `maxPerceptualDistance` parameter to `enhancementResult` and `suggestAccessibleVariantResults`. Ordinary calls remain valid, but references to their old full method names require an updated function type or a wrapper closure. See [method-reference migration](MIGRATION.md#enhancement-method-references).
+- Enforce enhancement budgets and correct color measurement behavior as detailed below. Existing numeric thresholds, generated colors, and CVD previews may change; follow the [3.0.0 migration guide](MIGRATION.md#colorkit-300).
+
 ### Added
 - Add fixed-color CVD simulation with `ColorVisionDeficiency` and `Color.simulated(for:)` for protanopia, deuteranopia, and tritanopia. The full-severity Machado model operates in linear sRGB, preserves alpha, and returns `nil` for unsupported inputs.
 - Expose enhancement distance and budget evidence in accessibility results, including an explicit `invalidConfiguration` status.
@@ -14,8 +21,8 @@ All notable changes to ColorKit will be documented in this file.
 
 ### Changed
 - Deprecate `colorBlindnessPreview(type:)`; it now leaves arbitrary view content unchanged instead of presenting hue shifts as CVD simulation. Apply the new simulation to individual colors; see [CVD migration guidance](MIGRATION.md#color-vision-deficiency-simulation).
-- Enforce `maxPerceptualDistance` as an inclusive CIEDE2000 hard budget in enhancement and variant result APIs. Keep the default at 30 and preserve legacy color-returning behavior; result calls may now report best effort instead of an over-budget pass. Result variants use Delta E 00 for distinctness. See [the migration guide](MIGRATION.md#enhancement-distance-budgets).
-- Deprecate `compare(with:)` in favor of explicit unavailable-result handling while preserving its ColorKit 2.x fallback behavior.
+- Enforce `maxPerceptualDistance` as an inclusive CIEDE2000 hard budget in enhancement and variant result APIs. Keep the default at 30; legacy color-returning APIs still ignore the budget but inherit corrected measurements and conversions. Result calls may now report best effort instead of an over-budget pass. Result variants use Delta E 00 for distinctness. See [the migration guide](MIGRATION.md#enhancement-distance-budgets).
+- Deprecate `compare(with:)` in favor of explicit unavailable-result handling. Eligible inputs now return CIEDE2000; other inputs use the labeled legacy RGB-distance fallback. Existing numeric results are not preserved. See [comparison migration](MIGRATION.md#color-comparison-metrics).
 - Show CIEDE2000 as a raw Delta E 00 value and replace unavailable comparison metrics with actionable per-color messages.
 
 ### Fixed
@@ -29,7 +36,7 @@ All notable changes to ColorKit will be documented in this file.
 - Replace the normalized Euclidean RGB calculation labeled as CIEDE2000 with a reference-validated CIEDE2000 implementation over resolved D65 LAB values.
 - Calculate `relativeLuminance()` according to WCAG 2.1 by linearizing sRGB components before weighting them. The previous calculation weighted gamma-encoded components directly and under-reported contrast for mid-tone colors; `#595959` on white now measures 7.00:1 rather than 2.63:1. `contrastRatio(with:)`, `adjustedForAccessibility(with:minimumRatio:)`, and `highContrastColor` all inherit the correction. See [the migration guide](MIGRATION.md#wcag-relative-luminance).
 - Classify `isDarkColor()` at the luminance where black and white contrast equally (approximately 0.1791) instead of at 0.5, so the black-or-white fallback is always the stronger contrasting endpoint.
-- Resolve strict `relativeLuminanceValue()` inputs through the shared resolved sRGBA snapshot, so a wider-gamut color is reported as unavailable instead of read as though its components were sRGB. Keep `relativeLuminance()` lenient by resolving through `UIColor` or `NSColor` for the current appearance.
+- Resolve strict `relativeLuminanceValue()` inputs through the resolved sRGBA snapshot, so a wider-gamut color is reported as unavailable instead of read as though its components were sRGB. Keep `relativeLuminance()` lenient by resolving through `UIColor` or `NSColor` for the current appearance.
 
 ### Tooling
 - Limit the CI dependency cache to SwiftPM sources and downloaded artifacts, excluding Xcode build products and test results.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,78 @@
 # Migration Guide
 
-## Unreleased
+## ColorKit 3.0.0
+
+Upgrading from 2.1.0 requires handling the new accessibility status case and updating
+stored method references where applicable. Measurement and enhancement results also
+change. Swift tools 6.0, iOS 14, and macOS 12 minimum requirements remain unchanged.
+
+### Enhancement method references
+
+`enhancementResult(with:targetLevel:strategy:)` and
+`suggestAccessibleVariantResults(with:targetLevel:count:)` now include a final
+`maxPerceptualDistance` parameter with a default of 30. Ordinary calls can omit it,
+but references to the old full method names no longer compile. Default arguments
+do not preserve the old function type.
+
+Adopt the new four-argument method reference or use a closure to retain a
+three-argument callable while explicitly choosing its budget:
+
+<!-- swift-example: enhancement-references -->
+```swift
+let foreground = Color(.sRGB, red: 0.8, green: 0.8, blue: 0.8)
+let enhance: (Color, WCAGContrastLevel, AdjustmentStrategy) -> ColorAccessibilityResult = {
+    background, level, strategy in
+    foreground.enhancementResult(
+        with: background, targetLevel: level, strategy: strategy,
+        maxPerceptualDistance: 30
+    )
+}
+let variants: (Color, WCAGContrastLevel, Int) -> [ColorAccessibilityResult] = {
+    background, level, count in
+    foreground.suggestAccessibleVariantResults(
+        with: background, targetLevel: level, count: count,
+        maxPerceptualDistance: 30
+    )
+}
+let result = enhance(.white, .AA, .preserveHue)
+let suggestions = variants(.white, .AA, 3)
+```
+
+These closures preserve the call shape, not the former unbudgeted results. See
+[enhancement distance budgets](#enhancement-distance-budgets) for status handling.
+
+### Color comparison metrics
+
+In 2.1.0, `compare(with:)` reported a normalized Euclidean RGB distance under the
+CIEDE2000 label. In 3.0.0, eligible fixed, opaque, in-gamut sRGB inputs produce real
+CIEDE2000 Delta E 00 values. Existing thresholds and stored expectations must be
+recalibrated; there is no general conversion from the old score to Delta E 00.
+
+Prefer `comparisonResult(with:)`, which explicitly reports unavailable inputs:
+
+<!-- swift-example: comparison -->
+```swift
+let first = Color(.sRGB, red: 0.8, green: 0.2, blue: 0.3)
+let second = Color(.sRGB, red: 0.2, green: 0.5, blue: 0.8)
+switch first.comparisonResult(with: second) {
+case .available(let difference):
+    print("Delta E 00:", difference.perceptualDifference)
+case .unavailable(let issues):
+    print("Cannot compare:", issues.firstColor, issues.secondColor)
+}
+```
+
+The deprecated `compare(with:)` remains callable. It returns CIEDE2000 for eligible
+inputs and a legacy RGB-distance fallback otherwise. Inspect
+`perceptualDifferenceMetric` before interpreting its score; do not compare values
+from the two metrics using one threshold. Its other components and contrast results
+also inherit the corrected conversions and measurements. The human-readable
+`description` label changes with the metric; use typed properties instead of parsing it.
+
+Dynamic/unresolved colors, translucent inputs without an explicit backing color,
+and out-of-sRGB-gamut colors are unavailable to the new comparison API. Resolve or
+composite inputs explicitly when appropriate; an unavailable comparison is not zero
+difference or evidence of similarity.
 
 ### HSL resolution
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -20,6 +20,12 @@ ColorKit es compatible con **Swift Package Manager (SPM)**.
    ```
 4. Haz clic en **Add Package**.  
 
+Al actualizar de 2.x a 3.0.0, ajusta el requisito de versión del paquete y consulta
+la [guía de migración](MIGRATION.md#colorkit-300). Los switches exhaustivos sobre el
+estado de accesibilidad y las referencias guardadas a métodos de mejora requieren
+cambios. Las métricas de comparación, los límites de distancia perceptual y las
+mediciones de color pueden producir resultados distintos.
+
 ---
 
 ## **🚀 Características**  

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ ColorKit supports **Swift Package Manager (SPM)**.
    ```
 4. Click **Add Package**.  
 
+When upgrading from 2.x to 3.0.0, update your package version requirement and read
+the [migration guide](MIGRATION.md#colorkit-300). Exhaustive accessibility-status
+switches and stored enhancement-method references need updates. Comparison metrics,
+enhancement budgets, and color measurements can produce different results.
+
 ---
 
 ## **🚀 Features**  

--- a/Sources/ColorKit/ColorKit.swift
+++ b/Sources/ColorKit/ColorKit.swift
@@ -41,7 +41,7 @@ public enum ColorKit {
     /// - MAJOR version for incompatible API changes
     /// - MINOR version for added functionality in a backward compatible manner
     /// - PATCH version for backward compatible bug fixes
-    public static let version = "2.1.0"
+    public static let version = "3.0.0"
 
     /// WCAG Compliance Checker namespace.
     ///

--- a/Sources/ColorKit/Utilities/ColorComparison.swift
+++ b/Sources/ColorKit/Utilities/ColorComparison.swift
@@ -48,11 +48,11 @@ public extension Color {
         return issues
     }
 
-    /// Compares this color using the ColorKit 2.x compatibility contract.
+    /// Retains the legacy comparison call shape, but not its numeric results.
     ///
     /// Comparable colors return the same CIEDE2000 result as ``comparisonResult(with:)``.
     /// When an authoritative comparison is unavailable, this method preserves the legacy
-    /// platform-defaulting behavior and labels its value as ``PerceptualDifferenceMetric/legacyRGBDistance``.
+    /// RGB-distance fallback and labels its value as ``PerceptualDifferenceMetric/legacyRGBDistance``.
     /// Use ``comparisonResult(with:)`` to handle failures without fabricated components.
     ///
     /// - Parameter other: The second color in the comparison.

--- a/Tests/ColorKitTests/WCAG/ColorContrastResultTests.swift
+++ b/Tests/ColorKitTests/WCAG/ColorContrastResultTests.swift
@@ -197,8 +197,11 @@ final class ColorContrastResultTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(Color.black.relativeLuminanceValue()), 0, accuracy: 1e-9)
         XCTAssertNil(Color.primary.relativeLuminanceValue())
 
-        // The non-optional accessor collapses both cases to zero.
-        XCTAssertEqual(Color.primary.relativeLuminance(), 0)
+        // Primary resolves for the current appearance in the lenient accessor.
+        // Only a color that cannot resolve at all shares black's zero fallback.
+        let unresolved = unresolvableTestColor()
+        XCTAssertNil(unresolved.relativeLuminanceValue())
+        XCTAssertEqual(unresolved.relativeLuminance(), 0)
         XCTAssertEqual(Color.black.relativeLuminance(), 0)
     }
 

--- a/Tests/ColorKitTests/WCAG/NamedColorContrastTests.swift
+++ b/Tests/ColorKitTests/WCAG/NamedColorContrastTests.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 import XCTest
 
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
 @testable import ColorKit
 
 /// Covers luminance-derived behavior for named SwiftUI colors, which carry no
@@ -61,9 +67,18 @@ final class NamedColorContrastTests: XCTestCase {
         }
     }
 
-    func testOrangeMatchesItsPublishedEndpointRatios() {
-        XCTAssertEqual(Double(Color.orange.contrastRatio(with: .black)), 9.09, accuracy: 0.01)
-        XCTAssertEqual(Double(Color.orange.contrastRatio(with: .white)), 2.31, accuracy: 0.01)
+    func testOrangeMatchesItsPublishedEndpointRatios() throws {
+        // These reference values describe Light Mode; named orange changes in Dark Mode.
+        let checkRatios = {
+            XCTAssertEqual(Double(Color.orange.contrastRatio(with: .black)), 9.09, accuracy: 0.01)
+            XCTAssertEqual(Double(Color.orange.contrastRatio(with: .white)), 2.31, accuracy: 0.01)
+        }
+        #if canImport(AppKit)
+        let appearance = try XCTUnwrap(NSAppearance(named: .aqua))
+        appearance.performAsCurrentDrawingAppearance(checkRatios)
+        #elseif canImport(UIKit)
+        UITraitCollection(userInterfaceStyle: .light).performAsCurrent(checkRatios)
+        #endif
     }
 
     // MARK: - Adjustment fallback

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -19,7 +19,7 @@ EXAMPLES = {
     DOCC + "Color-Spaces-article.md": {"rgb", "hsl", "lab"},
     DOCC + "Theming-article.md": {"dynamic-theme"},
     "PERFORMANCE_IMPROVEMENTS.md": {"cache", "benchmark"},
-    "MIGRATION.md": {"cvd", "enhancement-budget"},
+    "MIGRATION.md": {"cvd", "enhancement-budget", "enhancement-references", "comparison"},
 }
 MARKER = re.compile(r"<!-- swift-example: ([a-z0-9-]+) -->")
 # Postconditions use the actual README variables, not copied example implementations.


### PR DESCRIPTION
## Summary

Prepare ColorKit 3.0.0 with explicit upgrade guidance for clients of 2.1.0. The new accessibility status case and changed enhancement method signatures break existing exhaustive switches and stored method references, so this release uses a major version.

## Changes

- Set `ColorKit.version` to `3.0.0` and move accumulated release notes under a dated 3.0.0 heading, retaining an empty Unreleased section.
- Lead with breaking changes and label the migration guide for 3.0.0.
- Add compilable wrapper examples for the changed enhancement method references.
- Explain CIEDE2000 versus the legacy RGB-distance fallback, threshold recalibration, unavailable comparisons, and changed description labels.
- Add matching English and Spanish upgrade notices and clarify the limits of legacy compatibility wording.
- Require the two new migration examples in the public-example compilation inventory.
- Correct two existing tests that assumed the host was in Light Mode: scope orange reference ratios to Light Mode and use a truly unresolvable input for the lenient zero fallback.

## Alternatives considered

A minor release would expose source incompatibilities to consumers expecting a compatible upgrade. Restoring the old API would require revisiting the approved result contracts. This release documents the accepted 3.0.0 boundary.

## Notes

- This PR prepares release metadata and documentation; tagging and GitHub release publication follow merge and `scripts/check_release.sh 3.0.0` on clean, synchronized main.
- The proposed release date is 2026-09-04; adjust it if publication occurs later.
- Swift tools 6.0, iOS 14, and macOS 12 minimum requirements remain unchanged.
- The compatibility review compiled client examples against 2.1.0 and current main: exhaustive status switches and old full method references fail only on main, while ordinary calls remain valid.

## Screenshots

Not applicable; no UI changes.

## Testing

- Full four-phase iOS/macOS test matrix, including serialized shared-state suites: passed.
- The first macOS run exposed two reproducible Dark Mode test assumptions. Both affected suites passed after correcting their fixtures; the full matrix was then rerun.
- Public documentation check: 28 examples compiled, including both new migration examples; six README conversion result checks and generated theme-code compilation passed.
- Python tooling suite: 13 tests passed.
- DocC with warnings as errors and strict SwiftLint: passed.
- Diff whitespace and release metadata checks: passed; no existing local or remote `v3.0.0` tag.
- Final main-only tagging preflight remains a post-merge step.
