### PR TITLE
fix(benchmarks): Correct preview workloads and add Release runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Test Tooling Contracts
         run: python3 -m unittest discover -s scripts/tests
 
+      - name: Test Benchmark Correctness in Release Mode
+        run: swift test --package-path Benchmarks -c release
+
       - name: Build and Test Canonical Matrix
         run: scripts/run_tests.sh --results-dir TestResults
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/Benchmarks/.build/
 /Packages
 xcuserdata/
 DerivedData/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,6 +57,8 @@ opt_in_rules:
 included:
   - Sources
   - Tests
+  - Benchmarks/Sources
+  - Benchmarks/Tests
 
 excluded:
   - .build

--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "064eca328cd5a949442be93d244125a7e76b7a44ff51a83a0b493d9af6b069a0",
+  "pins" : [
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
+        "version" : "0.58.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "ColorKitBenchmarks",
+    platforms: [.macOS(.v12)],
+    dependencies: [.package(path: "..")],
+    targets: [
+        .executableTarget(name: "ColorKitBenchmarks", dependencies: [.product(name: "ColorKit", package: "ColorKit")]),
+        .testTarget(name: "ColorKitBenchmarksTests", dependencies: ["ColorKitBenchmarks"])
+    ]
+)

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,0 +1,94 @@
+# ColorKit reference benchmarks
+
+This repository-local macOS package measures complete requests through ColorKit's
+public API in Release mode. It adds no product or dependency to the library's
+manifest. The SwiftUI preview remains an exploratory tool with uncontrolled cache
+state; gradient timings there measure value construction only.
+
+From the repository root, with Xcode selected:
+
+```sh
+swift test --package-path Benchmarks -c release
+python3 Benchmarks/run.py --output .build/benchmark-results/first
+```
+
+The output directory must be new. The command builds first, then runs seven named
+scenarios serially, using a fresh process for every scenario/cache pair in each
+of three runs. Each process performs 10 untimed warm-up requests and records 10
+samples of 100 individually timed requests. Override these modest defaults with
+`--runs`, `--samples`, and `--iterations`; keep settings equal when comparing runs.
+Run with other builds and intensive applications idle, on consistent power
+settings. The report records power information but does not control system load.
+
+## What is measured
+
+| Scenario | Complete request |
+| --- | --- |
+| `hsl-red` | Convert opaque sRGB red to HSL |
+| `lab-red` | Convert opaque sRGB red to D65 LAB |
+| `comparison-black-white` | Full comparison, including CIEDE2000, RGB/HSL deltas, contrast, and compliance |
+| `enhancement-compliant` | Assess already-compliant black against white with a distance budget of 100 |
+| `enhancement-adjusted` | Enhance sRGB 80% gray against white with a distance budget of 100 |
+| `enhancement-best-effort` | Enhance the same gray with a distance budget of 25 |
+| `palette-red-five` | Generate and assess one entire five-color palette from red against white |
+
+Enhancement explicitly uses AA, preserveHue, and preferDarker. Palette generation
+uses AA and includes black and white. Every fixture is validated before and after
+measurement; invalid outputs fail the runner. The JSON contains each scenario's
+purpose, exact inputs, settings, expected outcome, and operation unit. One palette
+request includes all internal generation attempts and all five assessments.
+
+The palette API uses internal, unseeded random hue shifts and has no public RNG
+control. Its request inputs are fixed, but candidate colors, attempt counts, and
+timings can vary. The priming request can populate different candidate entries
+from the measured request. This scenario is labeled stochastic in the JSON and
+must not be treated as a deterministic comparison of cache hits or library versions.
+
+## Cache and timing boundaries
+
+- `empty`: clear `ColorCache.shared` immediately before **each** timed request.
+- `primed`: clear, execute the same request once outside timing, then time its next execution.
+- `unused`: the operation does not use ColorKit's cache (full comparison and the
+  already-compliant enhancement path).
+
+Each enhancement or palette request retains caches populated by its own internal
+operations. Priming describes preparation, not a guaranteed hit rate. No claim is
+made about CPU or OS cache state. Public cache controls and process isolation keep
+the library's public API unchanged.
+
+The monotonic interval includes input barriers, request dispatch, the public
+operation, and consumption of its complete result. It excludes cache preparation,
+fixture validation, warm-up, sample storage, and report formatting. Each sample
+stores a sum of request intervals and its request count. The enclosing loop and
+preparation wall time are not reported as request throughput.
+
+A control uses the same timing and preparation with a precomputed result of the
+same type. It includes an extra input-consumption call and may retain/release
+values differently; it is an approximate overhead comparison, not a subtraction
+calibration. It alternates before/after each workload sample. Both raw totals are
+saved without subtraction. When the control approaches the request time, or the
+sample range is large, avoid interpreting small differences as performance changes.
+
+## Results and compiler verification
+
+`raw.json` retains all samples and run identities plus source revision, dirty-tree
+details, executable hash, hardware, OS, Swift/Xcode/SDK, power, build mode, and
+sampling settings. `complete: false` means execution stopped before all scenarios
+finished; such an artifact is not a completed baseline. `summary.md` reports the
+median and range of sample means in nanoseconds per complete request.
+
+The barriers use `@_optimize(none)` and `@inline(never)`; their presence alone does
+not prove work survived optimization. After harness or toolchain changes, inspect
+the Release executable with `xcrun llvm-objdump --disassemble --demangle` (or `otool
+-tvV`) and verify the timer/request/consume calls remain inside the request loop.
+Check each specialized result type and confirm the operation closures still call
+HSL/LAB conversion, full comparison, enhancement, and palette generation. Record
+this verification alongside baseline results. No underscored annotation is added
+to ColorKit's public API.
+
+See [initial harness verification](VERIFICATION.md) for the checked executable
+and local validation evidence.
+
+These measurements establish reference data for this machine and toolchain. They
+do not establish a speedup, a performance regression threshold, an iOS baseline,
+or rendering performance. See the [agreed design](../docs/design/benchmark-correctness.md).

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -86,7 +86,7 @@ HSL/LAB conversion, full comparison, enhancement, and palette generation. Record
 this verification alongside baseline results. No underscored annotation is added
 to ColorKit's public API.
 
-See [initial harness verification](VERIFICATION.md) for the checked executable
+See [harness verification](VERIFICATION.md) for the checked executable
 and local validation evidence.
 
 These measurements establish reference data for this machine and toolchain. They

--- a/Benchmarks/Sources/ColorKitBenchmarks/Measurement.swift
+++ b/Benchmarks/Sources/ColorKitBenchmarks/Measurement.swift
@@ -1,0 +1,161 @@
+import ColorKit
+import Foundation
+
+enum BenchmarkError: Error {
+    case invalidArguments
+    case debugBuild
+    case invalidFixture(String)
+    case invalidClock
+}
+
+enum CacheMode: String, Codable, CaseIterable {
+    case empty
+    case primed
+    case unused
+
+    func prepare(clear: () -> Void, prime: () -> Void) {
+        switch self {
+        case .empty: clear()
+        case .primed:
+            clear()
+            prime()
+        case .unused: break
+        }
+    }
+}
+
+/// An unoptimized boundary for both inputs and complete results. Verify its call
+/// sites in the Release executable when changing the harness or Swift toolchain.
+@_optimize(none)
+@inline(never)
+func opaqueInput<T>(_ value: T) -> T {
+    value
+}
+
+@_optimize(none)
+@inline(never)
+func consume(_ value: some Any) {
+    withExtendedLifetime(value) {}
+}
+
+struct Sample: Codable {
+    let requestCount: Int
+    let requestNanoseconds: UInt64
+    let controlNanoseconds: UInt64
+}
+
+struct ScenarioDescription: Codable {
+    let id: String
+    let purpose: String
+    let inputs: String
+    let settings: String
+    let expected: String
+    let unit: String
+    let modes: [CacheMode]
+}
+
+struct Scenario {
+    let description: ScenarioDescription
+    let validate: (CacheMode) throws -> Void
+    let run: (CacheMode, Int, Int) throws -> [Sample]
+
+    init<Input, Output>(
+        description: ScenarioDescription,
+        input: Input,
+        operation: @escaping (Input) -> Output,
+        validate: @escaping (Output) throws -> Void
+    ) {
+        self.description = description
+        self.validate = { mode in
+            guard description.modes.contains(mode) else { throw BenchmarkError.invalidArguments }
+            ColorCache.shared.clearCache()
+            defer { ColorCache.shared.clearCache() }
+            mode.prepare(clear: { ColorCache.shared.clearCache() }, prime: { consume(operation(input)) })
+            try validate(operation(input))
+        }
+        self.run = { mode, samples, iterations in
+            guard description.modes.contains(mode), (1 ... 1_000).contains(samples),
+                  (1 ... 100_000).contains(iterations) else { throw BenchmarkError.invalidArguments }
+            ColorCache.shared.clearCache()
+            defer { ColorCache.shared.clearCache() }
+            let reference = operation(input)
+            try validate(reference)
+            // Untimed warm-up; each timed request still receives its own cache preparation.
+            for _ in 0 ..< 10 {
+                consume(operation(opaqueInput(input)))
+            }
+            var measurements: [Sample] = []
+            for index in 0 ..< samples {
+                let request: () throws -> UInt64 = {
+                    try measureRequests(
+                        iterations: iterations,
+                        prepare: {
+                            mode.prepare(clear: { ColorCache.shared.clearCache() }, prime: {
+                                consume(operation(opaqueInput(input)))
+                            })
+                        },
+                        request: { operation(opaqueInput(input)) }
+                    )
+                }
+                let control: () throws -> UInt64 = {
+                    try measureRequests(
+                        iterations: iterations,
+                        prepare: {
+                            mode.prepare(clear: { ColorCache.shared.clearCache() }, prime: {
+                                consume(operation(opaqueInput(input)))
+                            })
+                        },
+                        request: {
+                            // Same input barrier and full result type, with a precomputed result.
+                            consume(opaqueInput(input))
+                            return reference
+                        }
+                    )
+                }
+                let requestTime: UInt64
+                let controlTime: UInt64
+                if index.isMultiple(of: 2) {
+                    requestTime = try request()
+                    controlTime = try control()
+                } else {
+                    controlTime = try control()
+                    requestTime = try request()
+                }
+                measurements.append(Sample(
+                    requestCount: iterations,
+                    requestNanoseconds: requestTime,
+                    controlNanoseconds: controlTime
+                ))
+            }
+            try validate(operation(input))
+            return measurements
+        }
+    }
+}
+
+/// Sum individually timed requests; cache preparation and sample storage are excluded.
+func measureRequests(
+    iterations: Int,
+    prepare: () -> Void,
+    now: () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+    request: () -> some Any
+) throws -> UInt64 {
+    guard iterations > 0 else { throw BenchmarkError.invalidArguments }
+    var total: UInt64 = 0
+    for _ in 0 ..< iterations {
+        prepare()
+        let start = now()
+        consume(request())
+        let end = now()
+        guard end >= start else { throw BenchmarkError.invalidClock }
+        let (next, overflow) = total.addingReportingOverflow(end - start)
+        guard !overflow else { throw BenchmarkError.invalidClock }
+        total = next
+    }
+    guard total > 0 else { throw BenchmarkError.invalidClock }
+    return total
+}
+
+func requireFixture(_ condition: Bool, _ explanation: String) throws {
+    guard condition else { throw BenchmarkError.invalidFixture(explanation) }
+}

--- a/Benchmarks/Sources/ColorKitBenchmarks/Measurement.swift
+++ b/Benchmarks/Sources/ColorKitBenchmarks/Measurement.swift
@@ -84,27 +84,24 @@ struct Scenario {
             for _ in 0 ..< 10 {
                 consume(operation(opaqueInput(input)))
             }
+            let prepare = {
+                mode.prepare(clear: { ColorCache.shared.clearCache() }, prime: {
+                    consume(operation(opaqueInput(input)))
+                })
+            }
             var measurements: [Sample] = []
             for index in 0 ..< samples {
                 let request: () throws -> UInt64 = {
                     try measureRequests(
                         iterations: iterations,
-                        prepare: {
-                            mode.prepare(clear: { ColorCache.shared.clearCache() }, prime: {
-                                consume(operation(opaqueInput(input)))
-                            })
-                        },
+                        prepare: prepare,
                         request: { operation(opaqueInput(input)) }
                     )
                 }
                 let control: () throws -> UInt64 = {
                     try measureRequests(
                         iterations: iterations,
-                        prepare: {
-                            mode.prepare(clear: { ColorCache.shared.clearCache() }, prime: {
-                                consume(operation(opaqueInput(input)))
-                            })
-                        },
+                        prepare: prepare,
                         request: {
                             // Same input barrier and full result type, with a precomputed result.
                             consume(opaqueInput(input))

--- a/Benchmarks/Sources/ColorKitBenchmarks/Runner.swift
+++ b/Benchmarks/Sources/ColorKitBenchmarks/Runner.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+@main
+enum Runner {
+    struct Result: Codable {
+        let scenario: ScenarioDescription
+        let cacheMode: CacheMode
+        let samples: [Sample]
+    }
+
+    static func main() throws {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data: Data
+        if arguments == ["--list"] {
+            data = try encoder.encode(scenarios().map(\.description))
+        } else {
+            #if DEBUG
+                throw BenchmarkError.debugBuild
+            #else
+                guard arguments.count == 4,
+                      let scenario = scenarios().first(where: { $0.description.id == arguments[0] }),
+                      let mode = CacheMode(rawValue: arguments[1]),
+                      let samples = Int(arguments[2]), let iterations = Int(arguments[3])
+                else {
+                    throw BenchmarkError.invalidArguments
+                }
+                data = try encoder.encode(Result(
+                    scenario: scenario.description,
+                    cacheMode: mode,
+                    samples: scenario.run(mode, samples, iterations)
+                ))
+            #endif
+        }
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data([10]))
+    }
+}

--- a/Benchmarks/Sources/ColorKitBenchmarks/Scenarios.swift
+++ b/Benchmarks/Sources/ColorKitBenchmarks/Scenarios.swift
@@ -79,10 +79,10 @@ func scenarios() -> [Scenario] {
         )
     ]
 
-    for (id, original, budget, expected) in [
-        ("enhancement-compliant", black, 100.0, ColorAccessibilityResult.Status.meetsTarget),
-        ("enhancement-adjusted", gray, 100.0, .meetsTarget),
-        ("enhancement-best-effort", gray, 25.0, .bestEffort)
+    for (id, original, budget, expected, isAlreadyCompliant) in [
+        ("enhancement-compliant", black, 100.0, ColorAccessibilityResult.Status.meetsTarget, true),
+        ("enhancement-adjusted", gray, 100.0, .meetsTarget, false),
+        ("enhancement-best-effort", gray, 25.0, .bestEffort, false)
     ] {
         let enhancer = AccessibilityEnhancer(configuration: .init(
             targetLevel: .AA, strategy: .preserveHue, maxPerceptualDistance: budget, preferDarker: true
@@ -91,11 +91,11 @@ func scenarios() -> [Scenario] {
             description: ScenarioDescription(
                 id: id,
                 purpose: "Budgeted enhancement: \(id.replacingOccurrences(of: "enhancement-", with: ""))",
-                inputs: "sRGB RGBA foreground \(id == "enhancement-compliant" ? "(0, 0, 0, 1)" : "(0.8, 0.8, 0.8, 1)"), background (1, 1, 1, 1)",
+                inputs: "sRGB RGBA foreground \(isAlreadyCompliant ? "(0, 0, 0, 1)" : "(0.8, 0.8, 0.8, 1)"), background (1, 1, 1, 1)",
                 settings: "AA, preserveHue, preferDarker true, distance budget \(budget)",
                 expected: "\(expected); distance <= \(budget); best effort improves contrast; compliant preserves input",
                 unit: "enhancement",
-                modes: id == "enhancement-compliant" ? [.unused] : [.empty, .primed]
+                modes: isAlreadyCompliant ? [.unused] : [.empty, .primed]
             ),
             input: (original, white),
             operation: { enhancer.enhanceColorResult($0.0, against: $0.1) },
@@ -112,7 +112,7 @@ func scenarios() -> [Scenario] {
                         && actual.contrastRatio == value.contrastRatio && contrast.isFinite,
                     "Incorrect enhancement evidence"
                 )
-                if id == "enhancement-compliant" {
+                if isAlreadyCompliant {
                     try requireFixture(value.color == original && distance == 0, "Changed compliant input")
                 } else if expected == .bestEffort {
                     try requireFixture(abs(contrast - 3.976653) < 0.00001, "Incorrect best effort")

--- a/Benchmarks/Sources/ColorKitBenchmarks/Scenarios.swift
+++ b/Benchmarks/Sources/ColorKitBenchmarks/Scenarios.swift
@@ -1,0 +1,152 @@
+import ColorKit
+import SwiftUI
+
+func scenarios() -> [Scenario] {
+    let red = Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)
+    let black = Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 1)
+    let white = Color(.sRGB, red: 1, green: 1, blue: 1, opacity: 1)
+    let gray = Color(.sRGB, red: 0.8, green: 0.8, blue: 0.8, opacity: 1)
+    var cases = [
+        Scenario(
+            description: ScenarioDescription(
+                id: "hsl-red",
+                purpose: "Convert fixed red to HSL components",
+                inputs: "sRGB RGBA (1, 0, 0, 1)",
+                settings: "hslComponents()",
+                expected: "HSL (0, 1, 0.5), tolerance 0.001",
+                unit: "conversion",
+                modes: [.empty, .primed]
+            ),
+            input: red,
+            operation: { $0.hslComponents() },
+            validate: { value in
+                guard let value else { throw BenchmarkError.invalidFixture("Missing HSL") }
+                try requireFixture(
+                    abs(value.hue) < 0.001 && abs(value.saturation - 1) < 0.001
+                        && abs(value.lightness - 0.5) < 0.001,
+                    "Incorrect HSL red"
+                )
+            }
+        ),
+        Scenario(
+            description: ScenarioDescription(
+                id: "lab-red",
+                purpose: "Convert fixed red to D65 LAB components",
+                inputs: "sRGB RGBA (1, 0, 0, 1)",
+                settings: "labComponents()",
+                expected: "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+                unit: "conversion",
+                modes: [.empty, .primed]
+            ),
+            input: red,
+            operation: { $0.labComponents() },
+            validate: { value in
+                guard let value else { throw BenchmarkError.invalidFixture("Missing LAB") }
+                try requireFixture(
+                    abs(value.L - 53.2408) < 0.001 && abs(value.a - 80.0925) < 0.001
+                        && abs(value.b - 67.2032) < 0.001,
+                    "Incorrect LAB red"
+                )
+            }
+        ),
+        Scenario(
+            description: ScenarioDescription(
+                id: "comparison-black-white",
+                purpose: "Compute all public color-comparison metrics",
+                inputs: "sRGB RGBA first (0, 0, 0, 1), second (1, 1, 1, 1)",
+                settings: "comparisonResult(with:)",
+                expected: "Available CIEDE2000 100 and contrast 21",
+                unit: "comparison",
+                modes: [.unused]
+            ),
+            input: (black, white),
+            operation: { $0.0.comparisonResult(with: $0.1) },
+            validate: { value in
+                guard case let .available(difference) = value else {
+                    throw BenchmarkError.invalidFixture("Unavailable comparison")
+                }
+                try requireFixture(
+                    difference.perceptualDifferenceMetric == .ciede2000
+                        && abs(difference.perceptualDifference - 100) < 0.001
+                        && abs(difference.contrastRatio - 21) < 0.001
+                        && difference.rgbDifference.red == 1 && difference.rgbDifference.green == 1
+                        && difference.rgbDifference.blue == 1 && difference.hslDifference.hue == 0
+                        && difference.hslDifference.saturation == 0 && difference.hslDifference.lightness == 100
+                        && difference.wcagComplianceLevels.count == WCAGContrastLevel.allCases.count,
+                    "Incorrect full comparison"
+                )
+            }
+        )
+    ]
+
+    for (id, original, budget, expected) in [
+        ("enhancement-compliant", black, 100.0, ColorAccessibilityResult.Status.meetsTarget),
+        ("enhancement-adjusted", gray, 100.0, .meetsTarget),
+        ("enhancement-best-effort", gray, 25.0, .bestEffort)
+    ] {
+        let enhancer = AccessibilityEnhancer(configuration: .init(
+            targetLevel: .AA, strategy: .preserveHue, maxPerceptualDistance: budget, preferDarker: true
+        ))
+        cases.append(Scenario(
+            description: ScenarioDescription(
+                id: id,
+                purpose: "Budgeted enhancement: \(id.replacingOccurrences(of: "enhancement-", with: ""))",
+                inputs: "sRGB RGBA foreground \(id == "enhancement-compliant" ? "(0, 0, 0, 1)" : "(0.8, 0.8, 0.8, 1)"), background (1, 1, 1, 1)",
+                settings: "AA, preserveHue, preferDarker true, distance budget \(budget)",
+                expected: "\(expected); distance <= \(budget); best effort improves contrast; compliant preserves input",
+                unit: "enhancement",
+                modes: id == "enhancement-compliant" ? [.unused] : [.empty, .primed]
+            ),
+            input: (original, white),
+            operation: { enhancer.enhanceColorResult($0.0, against: $0.1) },
+            validate: { value in
+                let actual = value.color.accessibilityResult(against: white)
+                guard case let .available(difference) = original.comparisonResult(with: value.color),
+                      let contrast = value.contrastRatio, let distance = value.perceptualDistance
+                else {
+                    throw BenchmarkError.invalidFixture("Missing enhancement evidence")
+                }
+                try requireFixture(
+                    value.status == expected && value.isWithinPerceptualDistanceBudget == true
+                        && distance <= budget && abs(distance - difference.perceptualDifference) < 0.001
+                        && actual.contrastRatio == value.contrastRatio && contrast.isFinite,
+                    "Incorrect enhancement evidence"
+                )
+                if id == "enhancement-compliant" {
+                    try requireFixture(value.color == original && distance == 0, "Changed compliant input")
+                } else if expected == .bestEffort {
+                    try requireFixture(abs(contrast - 3.976653) < 0.00001, "Incorrect best effort")
+                }
+            }
+        ))
+    }
+
+    let generator = AccessiblePaletteGenerator(configuration: .init(
+        targetLevel: .AA, paletteSize: 5, includeBlackAndWhite: true
+    ))
+    cases.append(Scenario(
+        description: ScenarioDescription(
+            id: "palette-red-five",
+            purpose: "Generate and assess one five-color palette (stochastic candidate search)",
+            inputs: "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+            settings: "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+            expected: "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+            unit: "palette",
+            modes: [.empty, .primed]
+        ),
+        input: (red, white),
+        operation: { generator.generateAssessedPalette(from: $0.0, against: $0.1) },
+        validate: { values in
+            try requireFixture(values.count == 5 && values.first?.color == red, "Incorrect palette size or seed")
+            for value in values {
+                let assessment = value.color.accessibilityResult(against: white)
+                try requireFixture(
+                    value.contrastRatio != nil && value.contrastRatio == assessment.contrastRatio
+                        && value.status == assessment.status && value.targetLevel == .AA,
+                    "Incorrect palette assessment"
+                )
+            }
+        }
+    ))
+    return cases
+}

--- a/Benchmarks/Tests/ColorKitBenchmarksTests/MeasurementTests.swift
+++ b/Benchmarks/Tests/ColorKitBenchmarksTests/MeasurementTests.swift
@@ -1,0 +1,68 @@
+@testable import ColorKitBenchmarks
+import Testing
+
+struct MeasurementTests {
+    @Test("Preparation precedes each individually timed request")
+    func timingBoundaries() throws {
+        var events: [String] = []
+        var tick: UInt64 = 0
+        let duration = try measureRequests(
+            iterations: 3,
+            prepare: { events.append("prepare") },
+            now: {
+                events.append("clock")
+                tick += 7
+                return tick
+            },
+            request: { events.append("request") }
+        )
+        #expect(duration == 21)
+        #expect(events == Array(repeating: ["prepare", "clock", "request", "clock"], count: 3).flatMap(\.self))
+    }
+
+    @Test("Cache modes apply exactly the documented preparation", arguments: CacheMode.allCases)
+    func preparation(mode: CacheMode) {
+        var events: [String] = []
+        mode.prepare(clear: { events.append("clear") }, prime: { events.append("prime") })
+        switch mode {
+        case .empty: #expect(events == ["clear"])
+        case .primed: #expect(events == ["clear", "prime"])
+        case .unused: #expect(events.isEmpty)
+        }
+    }
+
+    @Test("Invalid clocks and iteration counts cannot produce timings")
+    func invalidMeasurements() {
+        #expect(throws: BenchmarkError.self) {
+            try measureRequests(iterations: 1, prepare: {}, now: { 0 }, request: { 1 })
+        }
+        #expect(throws: BenchmarkError.self) {
+            try measureRequests(iterations: 0, prepare: {}, request: { 1 })
+        }
+    }
+}
+
+/// Own the shared cache for the entire suite. These are fixture correctness checks,
+/// not duration assertions or performance regression gates.
+@Suite(.serialized)
+struct ScenarioTests {
+    @Test("Every named fixture validates in all supported cache modes")
+    func fixtures() throws {
+        let cases = scenarios()
+        #expect(cases.count == 7)
+        #expect(Set(cases.map(\.description.id)).count == cases.count)
+        for scenario in cases {
+            for mode in scenario.description.modes {
+                try scenario.validate(mode)
+            }
+        }
+    }
+
+    @Test("Invalid counts and unsupported cache modes are rejected")
+    func invalidArguments() throws {
+        let comparison = try #require(scenarios().first { $0.description.id == "comparison-black-white" })
+        #expect(throws: BenchmarkError.self) { try comparison.run(.empty, 1, 1) }
+        #expect(throws: BenchmarkError.self) { try comparison.run(.unused, 0, 1) }
+        #expect(throws: BenchmarkError.self) { try comparison.run(.unused, 1, -1) }
+    }
+}

--- a/Benchmarks/VERIFICATION.md
+++ b/Benchmarks/VERIFICATION.md
@@ -1,0 +1,64 @@
+# Initial harness verification — 2026-09-07
+
+The initial local validation completed successfully on an Apple M4 Pro, macOS
+26.6.2, Xcode 26.5 (17F42), and Swift 6.3.2. This was a dirty-worktree validation
+based on `b54ca5adfc80290003c543a23483503d1c5f4d4b`, not a clean-revision published
+baseline. Capture a fresh baseline after committing and reviewing the harness.
+
+## Runtime evidence
+
+`python3 Benchmarks/run.py --output .build/benchmark-results/validation` completed
+all 36 isolated processes: three runs of 12 scenario/cache pairs, with 10 samples
+of 100 requests each. The local `raw.json` has `complete: true` and 360 samples;
+it retains the dirty-tree details and environment. Its companion `summary.md`
+reports sample means and control overhead without subtraction. Both files are
+local ignored artifacts, not committed reference results.
+
+The five-color palette workload remains stochastic. Small conversion and
+comparison timings also showed variation between samples; these observations do
+not establish speedups or regression thresholds.
+
+## Optimized workload execution
+
+Inspected the actual Release executable with:
+
+```sh
+xcrun llvm-objdump --disassemble --demangle \
+  Benchmarks/.build/arm64-apple-macosx/release/ColorKitBenchmarks
+```
+
+Executable SHA-256:
+`097ef5a84c400879b1a92305e090ff00e078a5b61efd857600cef4dd6b191f3b`.
+
+The specialized request loops retain the opaque input call, operation dispatch,
+and complete-result consumption between the clock reads. Cache preparation
+precedes the timed interval on each back edge. The following instruction
+addresses identify the checked calls in this executable only:
+
+| Result type | Input barrier | Operation dispatch | Result sink | Loop back edge |
+| --- | --- | --- | --- | --- |
+| HSL/LAB optional triple | `0x1000b5cac` | `0x1000b5cbc` | `0x1000b5cd8` | `0x1000b5d10` |
+| Full comparison | `0x1000b5a4c` | `0x1000b5a5c` | `0x1000b5a7c` | `0x1000b5abc` |
+| Enhancement result | `0x1000b57b8` | `0x1000b57c8` | `0x1000b57e8` | `0x1000b5828` |
+| Assessed palette array | `0x1000b5518` | `0x1000b5528` | `0x1000b5558` | `0x1000b5598` |
+
+The supplied operation closures still invoke HSL/LAB conversion, full
+`comparisonResult(with:)`, the enhancer method, and `generateAssessedPalette`.
+The tuple closures share a conversion trampoline; comparison stores its full
+result, and palette consumption receives the complete returned array. This
+inspection is evidence for the identified compiler and executable, not a promise
+about future compiler behavior. Repeat it after harness or toolchain changes.
+
+## Regression checks
+
+- Full `scripts/run_tests.sh` iOS/macOS and serialized shared-state matrix: PASS.
+- `swift test --package-path Benchmarks -c release`: PASS, five tests in two suites.
+- Python tooling tests: PASS, 15 tests.
+- Strict SwiftLint: PASS, no violations in 116 files.
+- DocC warnings-as-errors build and executable documentation examples: PASS.
+- `git diff --check`: PASS.
+
+The test matrix's local logs and result bundles are under
+`.build/test-results/run.ZUlj9O/`. These checks preserve the ColorKit 3.0.0 public
+contract; they do not replace the separate committed-branch review or publication
+steps.

--- a/Benchmarks/VERIFICATION.md
+++ b/Benchmarks/VERIFICATION.md
@@ -1,16 +1,16 @@
-# Initial harness verification — 2026-09-07
+# Harness verification — 2026-09-07
 
-The initial local validation completed successfully on an Apple M4 Pro, macOS
-26.6.2, Xcode 26.5 (17F42), and Swift 6.3.2. This was a dirty-worktree validation
-based on `b54ca5adfc80290003c543a23483503d1c5f4d4b`, not a clean-revision published
-baseline. Capture a fresh baseline after committing and reviewing the harness.
+Local validation completed successfully on an Apple M4 Pro, macOS 26.6.2,
+Xcode 26.5 (17F42), and Swift 6.3.2. The final run used clean source revision
+`5918b1ac50c3dcc3209785e87ea2b10c1cd96b56`; both tracked changes and untracked
+files were empty in the recorded metadata.
 
 ## Runtime evidence
 
-`python3 Benchmarks/run.py --output .build/benchmark-results/validation` completed
+`python3 Benchmarks/run.py --output .build/benchmark-results/5918b1a` completed
 all 36 isolated processes: three runs of 12 scenario/cache pairs, with 10 samples
 of 100 requests each. The local `raw.json` has `complete: true` and 360 samples;
-it retains the dirty-tree details and environment. Its companion `summary.md`
+it retains the source revision and environment. Its companion `summary.md`
 reports sample means and control overhead without subtraction. Both files are
 local ignored artifacts, not committed reference results.
 
@@ -28,7 +28,9 @@ xcrun llvm-objdump --disassemble --demangle \
 ```
 
 Executable SHA-256:
-`097ef5a84c400879b1a92305e090ff00e078a5b61efd857600cef4dd6b191f3b`.
+`caedfa6e7082f2c6fa5b61cec8279d21ffe4f7cfb68e8eec1b5f135d8c24fb30`.
+
+Its disassembly was identical to the initially inspected validation executable.
 
 The specialized request loops retain the opaque input call, operation dispatch,
 and complete-result consumption between the clock reads. Cache preparation

--- a/Benchmarks/run.py
+++ b/Benchmarks/run.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Build and run the macOS Release baseline, preserving raw repeated samples."""
+
+import argparse
+import datetime
+import hashlib
+import json
+import pathlib
+import platform
+import statistics
+import subprocess
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "Benchmarks"
+
+
+def command(*args):
+    return subprocess.check_output(args, cwd=ROOT, text=True).strip()
+
+
+def positive_int(value):
+    result = int(value)
+    if result < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return result
+
+
+def summarize(records):
+    lines = [
+        "# ColorKit macOS Release baseline", "",
+        "Times include input barriers, clock reads, dispatch, and result consumption. "
+        "The control substitutes a precomputed result and is an overhead estimate; "
+        "it is reported without subtraction. Cache preparation is outside timing.", "",
+        "| Scenario | Cache preparation | Median ns/request | Sample range | Median control ns/request |",
+        "| --- | --- | ---: | ---: | ---: |",
+    ]
+    groups = {}
+    for record in records:
+        key = (record["scenario"]["id"], record["cacheMode"])
+        groups.setdefault(key, []).extend(record["samples"])
+    for (name, mode), samples in groups.items():
+        times = [s["requestNanoseconds"] / s["requestCount"] for s in samples]
+        controls = [s["controlNanoseconds"] / s["requestCount"] for s in samples]
+        lines.append(
+            f"| {name} | {mode} | {statistics.median(times):,.1f} | "
+            f"{min(times):,.1f}–{max(times):,.1f} | {statistics.median(controls):,.1f} |"
+        )
+    lines.extend([
+        "", "Each sample is the mean of individually timed complete requests. The table's median "
+        "and range describe those sample means across runs, not individual-request latency percentiles.",
+        "", "Read raw.json for every sample, fixture description, run identity, and environment. "
+        "Large ranges or a control close to the request time limit useful comparisons. "
+        "These are reference measurements, not speedup claims, CI thresholds, or iOS results.", "",
+    ])
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=pathlib.Path, required=True, help="new directory for raw.json and summary.md")
+    parser.add_argument("--runs", type=positive_int, default=3, help="independent processes per scenario/cache pair (default: 3)")
+    parser.add_argument("--samples", type=positive_int, default=10, help="samples per process (default: 10; max: 1000)")
+    parser.add_argument("--iterations", type=positive_int, default=100, help="requests per sample (default: 100; max: 100000)")
+    args = parser.parse_args()
+    if platform.system() != "Darwin":
+        parser.error("the baseline requires macOS")
+    if args.samples > 1000 or args.iterations > 100000:
+        parser.error("samples must be <= 1000 and iterations <= 100000")
+    if args.output.exists():
+        parser.error("output directory already exists; choose a new directory")
+
+    # Build before sampling. Do not mix build time with runtime measurements.
+    subprocess.run(["swift", "build", "--package-path", str(PACKAGE), "-c", "release"], cwd=ROOT, check=True)
+    binary = pathlib.Path(command("swift", "build", "--package-path", str(PACKAGE), "-c", "release", "--show-bin-path")) / "ColorKitBenchmarks"
+    descriptions = json.loads(command(str(binary), "--list"))
+    pairs = [(s["id"], mode) for s in descriptions for mode in s["modes"]]
+    metadata = {
+        "timestampUTC": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "revision": command("git", "rev-parse", "HEAD"),
+        "trackedChanges": command("git", "diff", "HEAD", "--stat"),
+        "untrackedFiles": command("git", "ls-files", "--others", "--exclude-standard"),
+        "binarySHA256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+        "configuration": "release",
+        "buildCommand": "swift build --package-path Benchmarks -c release",
+        "swift": command("swift", "--version"),
+        "xcode": command("xcodebuild", "-version"),
+        "sdk": command("xcrun", "--show-sdk-version"),
+        "os": command("sw_vers"),
+        "architecture": platform.machine(),
+        "hardwareModel": command("sysctl", "-n", "hw.model"),
+        "cpu": command("sysctl", "-n", "machdep.cpu.brand_string"),
+        "memoryBytes": int(command("sysctl", "-n", "hw.memsize")),
+        "power": command("pmset", "-g", "batt"),
+        "runs": args.runs, "samplesPerRun": args.samples, "requestsPerSample": args.iterations,
+        "warmupRequests": 10,
+        "clock": "DispatchTime.uptimeNanoseconds",
+        "sampling": "Sum individually timed requests; preparation excluded; alternating request/control sample order",
+    }
+    # Reserve a new output directory; preserve completed records if a later process fails.
+    args.output.mkdir(parents=True)
+    records = []
+    artifact = {"schemaVersion": 1, "complete": False, "environment": metadata, "records": records}
+
+    def save():
+        (args.output / "raw.json").write_text(json.dumps(artifact, indent=2) + "\n")
+
+    save()
+    for run in range(args.runs):
+        # Reverse the fixed scenario order on alternate runs to expose order drift.
+        for name, mode in (pairs if run % 2 == 0 else list(reversed(pairs))):
+            print(f"Run {run + 1}/{args.runs}: {name} ({mode})", file=sys.stderr, flush=True)
+            record = json.loads(command(str(binary), name, mode, str(args.samples), str(args.iterations)))
+            record["run"] = run + 1
+            records.append(record)
+            save()
+    artifact["complete"] = True
+    save()
+    summary = summarize(records)
+    (args.output / "summary.md").write_text(summary)
+    print(summary)
+    print(f"Artifacts: {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add a repository-local macOS Release benchmark runner with explicit conversion, comparison, enhancement, and assessed-palette fixtures, cache preparation, raw repeated samples, and machine/toolchain metadata. Replace unsupported historical speedup claims with reproducible measurement guidance.
+
 ### Fixed
 - Measure real HSL/LAB conversion in the performance preview, consume every request's result, and label gradient timings as value construction. Preview measurements remain exploratory with uncontrolled cache state; no color API or conversion behavior changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Measure real HSL/LAB conversion in the performance preview, consume every request's result, and label gradient timings as value construction. Preview measurements remain exploratory with uncontrolled cache state; no color API or conversion behavior changes.
+
 ## [3.0.0] - 2026-09-04
 
 ### Breaking changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,11 @@ python3 -m unittest discover -s scripts/tests
 python3 scripts/check_documentation.py
 ```
 
+For benchmark changes, also run `swift test --package-path Benchmarks -c release`
+and the [macOS Release runner](Benchmarks/README.md). Its correctness tests do not
+assert machine-specific duration thresholds. Record actual performance samples
+separately with other builds idle.
+
 The zero-argument runner is the canonical CI matrix: parallel iOS and macOS tests,
 then serialized shared-state suites on each platform. Change the shared-suite list
 and pinned destinations in `scripts/run_tests.sh`, not in the workflow. Set

--- a/PERFORMANCE_IMPROVEMENTS.md
+++ b/PERFORMANCE_IMPROVEMENTS.md
@@ -1,14 +1,16 @@
-# ColorKit Performance Improvements
+# ColorKit Performance Measurement
 
 ## Overview
 
-ColorKit 1.4.0 introduces significant performance optimizations through a high-performance caching system. This document explains the improvements and how they benefit your applications.
+ColorKit caches selected repeated color operations. The repository's macOS Release
+runner provides reproducible reference measurements; actual costs depend on the
+operation, inputs, cache preparation, machine, and toolchain.
 
 ## Key Performance Enhancements
 
 ### Caching System
 
-ColorKit now includes a thread-safe caching system that dramatically improves performance for repeated color operations. The caching system:
+ColorKit includes a thread-safe caching system for repeated color operations. The caching system:
 
 - Uses `NSCache` for automatic memory management
 - Is thread-safe for use in concurrent environments
@@ -17,24 +19,14 @@ ColorKit now includes a thread-safe caching system that dramatically improves pe
 
 ### Performance Metrics
 
-Based on our benchmarks, the following performance improvements can be expected:
+The historical speedup ratios previously listed here did not include reproducible
+supporting measurements and should not be used as expectations. The new baseline
+measures complete public conversion, comparison, enhancement, and palette requests.
+It does not establish rendering, battery-life, or application-level improvements.
 
-| Operation | Performance Improvement | Notes |
-|-----------|-------------------------|-------|
-| LAB Color Conversion | Up to 10x faster | Most significant for repeated conversions |
-| HSL Color Conversion | Up to 8x faster | Especially beneficial for UI with many color calculations |
-| WCAG Calculations | Up to 12x faster | Critical for accessibility checks |
-| Color Blending | Up to 5x faster | Important for complex UIs with blended colors |
-| Gradient Generation | Up to 7x faster | Significant for animations and transitions |
-
-## Real-World Benefits
-
-These performance improvements translate to:
-
-1. **Reduced CPU Usage**: Less processing power required for color operations
-2. **Better Battery Life**: More efficient processing means less power consumption
-3. **Smoother UI**: Faster color calculations lead to more responsive interfaces
-4. **Improved Scalability**: Better handling of complex UIs with many color operations
+See [the benchmark runner](Benchmarks/README.md) for fixtures, cache preparation,
+result-consumption overhead, raw samples, and reproduction commands. Treat empty
+and primed cache timings as different workloads, not a before/after library speedup.
 
 ## Implementation Details
 
@@ -71,10 +63,14 @@ ColorCache.shared.clearContrastCache()
 
 ## Benchmarking
 
-Open the public `PerformanceBenchmark` SwiftUI view and use its Run Benchmarks
-button to measure operations on your hardware. There is no public programmatic
-`runAllBenchmarks()` API. Results depend on the device, build configuration,
-inputs, and cache state; they are not a guarantee of the historical ratios above.
+For reference data, run `python3 Benchmarks/run.py --output .build/benchmark-results/first`
+from the repository root. It builds the separate macOS runner in Release mode and
+saves repeated timings and environment metadata in a new output directory.
+
+Open the public `PerformanceBenchmark` SwiftUI view and use its Run Benchmark
+button for exploratory timings. Conversion runs actual HSL and LAB requests with
+uncontrolled cache state. Gradient cases construct SwiftUI values; they do not
+render pixels. There is no public programmatic `runAllBenchmarks()` API.
 
 <!-- swift-example: benchmark -->
 ```swift
@@ -87,7 +83,3 @@ struct ContentView: View {
     }
 }
 ```
-
-## Conclusion
-
-The performance improvements in ColorKit 1.4.0 provide significant benefits with zero configuration required. Your applications will automatically take advantage of these optimizations simply by updating to the latest version.

--- a/Sources/ColorKit/PreviewCatalog/BenchmarkMeasurement.swift
+++ b/Sources/ColorKit/PreviewCatalog/BenchmarkMeasurement.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Internal preview workloads; the repository's Release runner owns baseline measurements.
+enum BenchmarkConversion: String, CaseIterable {
+    case hsl = "HSL Components (uncontrolled cache)"
+    case lab = "LAB Components (uncontrolled cache)"
+
+    func components(for color: Color) -> (CGFloat, CGFloat, CGFloat)? {
+        switch self {
+        case .hsl: color.hslComponents()
+        case .lab: color.labComponents()
+        }
+    }
+}
+
+enum BenchmarkMeasurement {
+    // Keep these barriers unoptimized: retaining only the final result permits
+    // the compiler to eliminate earlier requests or hoist invariant work.
+    @_optimize(none)
+    @inline(never)
+    static func input<T>(_ value: T) -> T { value }
+
+    @_optimize(none)
+    @inline(never)
+    static func consume<T>(_ value: T) {
+        withExtendedLifetime(value) {}
+    }
+
+    static func measure<T>(name: String, iterations: Int, operation: () -> T) -> BenchmarkResult {
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations {
+            consume(operation())
+        }
+        let duration = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
+        return BenchmarkResult(
+            name: name,
+            duration: duration,
+            operationsPerSecond: Double(iterations) / duration
+        )
+    }
+}

--- a/Sources/ColorKit/PreviewCatalog/PerformanceBenchmark.swift
+++ b/Sources/ColorKit/PreviewCatalog/PerformanceBenchmark.swift
@@ -101,6 +101,10 @@ public struct PerformanceBenchmark: View {
             Text("Results")
                 .font(.headline)
 
+            Text("Exploratory timings include measurement overhead and uncontrolled cache state. Gradients measure value construction only.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
             if benchmarkResults.isEmpty {
                 Text("Run a benchmark to see results")
                     .foregroundColor(.secondary)
@@ -140,7 +144,8 @@ public struct PerformanceBenchmark: View {
         operation: BenchmarkOperation,
         iterations: Int
     ) -> [BenchmarkResult] {
-        switch operation {
+        guard iterations > 0 else { return [] }
+        return switch operation {
         case .blending:
             benchmarkBlending(iterations: iterations)
         case .conversion:
@@ -155,157 +160,67 @@ public struct PerformanceBenchmark: View {
     }
 
     nonisolated private static func benchmarkBlending(iterations: Int) -> [BenchmarkResult] {
-        let color1 = Color.blue
-        let color2 = Color.red
-        var results: [BenchmarkResult] = []
-
-        // Test each blend mode
+        let first = Color(.sRGB, red: 0, green: 0, blue: 1, opacity: 1)
+        let second = Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)
         let blendModes: [BlendMode] = [
             .normal, .multiply, .screen, .overlay,
             .darken, .lighten, .colorDodge, .colorBurn,
             .softLight, .hardLight, .difference, .exclusion
         ]
-
-        for mode in blendModes {
-            let start = CFAbsoluteTimeGetCurrent()
-
-            for _ in 0..<iterations {
-                _ = color1.blended(with: color2, mode: mode)
+        return blendModes.map { mode in
+            BenchmarkMeasurement.measure(name: "Blend Mode: \(mode)", iterations: iterations) {
+                BenchmarkMeasurement.input(first).blended(with: second, mode: mode)
             }
-
-            let end = CFAbsoluteTimeGetCurrent()
-            let duration = end - start
-
-            results.append(BenchmarkResult(
-                name: "Blend Mode: \(String(describing: mode))",
-                duration: duration,
-                operationsPerSecond: Double(iterations) / duration
-            ))
         }
-
-        return results
     }
 
     nonisolated private static func benchmarkConversion(iterations: Int) -> [BenchmarkResult] {
-        let color = Color.blue
-        var results: [BenchmarkResult] = []
-
-        // Color Space Conversion
-        do {
-            let start = CFAbsoluteTimeGetCurrent()
-
-            for _ in 0..<iterations {
-                _ = color.opacity(1.0) // Simple color operation
+        let color = Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)
+        return BenchmarkConversion.allCases.map { conversion in
+            BenchmarkMeasurement.measure(name: conversion.rawValue, iterations: iterations) {
+                conversion.components(for: BenchmarkMeasurement.input(color))
             }
-
-            let end = CFAbsoluteTimeGetCurrent()
-            let duration = end - start
-
-            results.append(BenchmarkResult(
-                name: "Color Space Conversion",
-                duration: duration,
-                operationsPerSecond: Double(iterations) / duration
-            ))
         }
-
-        return results
     }
 
     nonisolated private static func benchmarkGradient(iterations: Int) -> [BenchmarkResult] {
-        let colors = [Color.blue, Color.purple, Color.red]
-        var results: [BenchmarkResult] = []
-
-        // Linear Gradient
-        do {
-            let start = CFAbsoluteTimeGetCurrent()
-
-            for _ in 0..<iterations {
-                _ = LinearGradient(
-                    colors: colors,
+        let colors = [
+            Color(.sRGB, red: 0, green: 0, blue: 1, opacity: 1),
+            Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)
+        ]
+        return [
+            BenchmarkMeasurement.measure(name: "Linear Gradient Construction", iterations: iterations) {
+                LinearGradient(
+                    colors: BenchmarkMeasurement.input(colors),
                     startPoint: .leading,
                     endPoint: .trailing
                 )
-            }
-
-            let end = CFAbsoluteTimeGetCurrent()
-            let duration = end - start
-
-            results.append(BenchmarkResult(
-                name: "Linear Gradient",
-                duration: duration,
-                operationsPerSecond: Double(iterations) / duration
-            ))
-        }
-
-        // Radial Gradient
-        do {
-            let start = CFAbsoluteTimeGetCurrent()
-
-            for _ in 0..<iterations {
-                _ = RadialGradient(
-                    colors: colors,
+            },
+            BenchmarkMeasurement.measure(name: "Radial Gradient Construction", iterations: iterations) {
+                RadialGradient(
+                    colors: BenchmarkMeasurement.input(colors),
                     center: .center,
                     startRadius: 0,
                     endRadius: 100
                 )
             }
-
-            let end = CFAbsoluteTimeGetCurrent()
-            let duration = end - start
-
-            results.append(BenchmarkResult(
-                name: "Radial Gradient",
-                duration: duration,
-                operationsPerSecond: Double(iterations) / duration
-            ))
-        }
-
-        return results
+        ]
     }
 
     nonisolated private static func benchmarkAccessibility(iterations: Int) -> [BenchmarkResult] {
-        let color1 = Color.white
-        let color2 = Color.black
-        var results: [BenchmarkResult] = []
-
-        // Contrast Ratio
-        do {
-            let start = CFAbsoluteTimeGetCurrent()
-
-            for _ in 0..<iterations {
-                _ = color1.contrastRatio(with: color2)
-            }
-
-            let end = CFAbsoluteTimeGetCurrent()
-            let duration = end - start
-
-            results.append(BenchmarkResult(
-                name: "Contrast Ratio",
-                duration: duration,
-                operationsPerSecond: Double(iterations) / duration
-            ))
-        }
-
-        return results
+        let first = Color(.sRGB, red: 1, green: 1, blue: 1, opacity: 1)
+        let second = Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 1)
+        return [BenchmarkMeasurement.measure(name: "Contrast Ratio", iterations: iterations) {
+            BenchmarkMeasurement.input(first).contrastRatio(with: second)
+        }]
     }
 
     nonisolated private static func benchmarkComparison(iterations: Int) -> [BenchmarkResult] {
         let first = Color(.sRGB, red: 0.85, green: 0.2, blue: 0.35, opacity: 1)
         let second = Color(.sRGB, red: 0.15, green: 0.55, blue: 0.8, opacity: 1)
-        var lastResult: ColorComparisonResult?
-        let start = CFAbsoluteTimeGetCurrent()
-
-        for _ in 0..<iterations {
-            lastResult = first.comparisonResult(with: second)
-        }
-
-        withExtendedLifetime(lastResult) {}
-        let duration = CFAbsoluteTimeGetCurrent() - start
-        return [BenchmarkResult(
-            name: "CIEDE2000 Color Comparison",
-            duration: duration,
-            operationsPerSecond: Double(iterations) / duration
-        )]
+        return [BenchmarkMeasurement.measure(name: "CIEDE2000 Color Comparison", iterations: iterations) {
+            BenchmarkMeasurement.input(first).comparisonResult(with: second)
+        }]
     }
 }
 

--- a/Tests/ColorKitTests/BenchmarkMeasurementTests.swift
+++ b/Tests/ColorKitTests/BenchmarkMeasurementTests.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import Testing
+
+@testable import ColorKit
+
+struct BenchmarkMeasurementTests {
+    @Test("Preview conversion workloads produce HSL and D65 LAB coordinates")
+    func convertsFixedRed() throws {
+        let red = Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)
+        let hsl = try #require(BenchmarkConversion.hsl.components(for: red))
+        #expect(abs(hsl.0) < 0.001)
+        #expect(abs(hsl.1 - 1) < 0.001)
+        #expect(abs(hsl.2 - 0.5) < 0.001)
+        let lab = try #require(BenchmarkConversion.lab.components(for: red))
+        #expect(abs(lab.0 - 53.2408) < 0.001)
+        #expect(abs(lab.1 - 80.0925) < 0.001)
+        #expect(abs(lab.2 - 67.2032) < 0.001)
+    }
+
+    @Test("Preview measurement executes every requested operation")
+    func executesEveryRequest() {
+        var requests = 0
+        _ = BenchmarkMeasurement.measure(name: "Counter", iterations: 17) {
+            requests += 1
+            return requests
+        }
+        #expect(requests == 17)
+    }
+
+    @Test("Nonpositive iteration counts produce no preview measurements", arguments: [0, -1])
+    func rejectsInvalidIterations(iterations: Int) {
+        #expect(PerformanceBenchmark.benchmark(operation: .conversion, iterations: iterations).isEmpty)
+    }
+}

--- a/Tests/ColorKitTests/PerformanceBenchmarkTests.swift
+++ b/Tests/ColorKitTests/PerformanceBenchmarkTests.swift
@@ -43,7 +43,7 @@ final class PerformanceBenchmarkTests: XCTestCase {
 
         let results = await benchmark(.conversion, iterations: iterations)
 
-        XCTAssertEqual(results.map(\.name), ["Color Space Conversion"])
+        XCTAssertEqual(results.map(\.name), ["HSL Components (uncontrolled cache)", "LAB Components (uncontrolled cache)"])
         assertValidMeasurements(results, iterations: iterations)
     }
 
@@ -52,7 +52,7 @@ final class PerformanceBenchmarkTests: XCTestCase {
 
         let results = await benchmark(.gradient, iterations: iterations)
 
-        XCTAssertEqual(results.map(\.name), ["Linear Gradient", "Radial Gradient"])
+        XCTAssertEqual(results.map(\.name), ["Linear Gradient Construction", "Radial Gradient Construction"])
         assertValidMeasurements(results, iterations: iterations)
     }
 

--- a/docs/design/benchmark-correctness.md
+++ b/docs/design/benchmark-correctness.md
@@ -1,0 +1,149 @@
+# Benchmark correctness and performance baseline
+
+Status: reduced milestone implemented. This note supersedes the broader workload
+and acceptance-framework proposals discussed earlier. See [the runner guide](../../Benchmarks/README.md)
+for the chosen fixtures, repetition counts, timing boundaries, and reproduction commands.
+
+## Agreed scope
+
+Preserve ColorKit 3.0.0's public API and documented behavior throughout this work.
+Correct the preview's conversion workload and gradient labels, then establish a
+small, reproducible performance baseline for conversion, comparison, enhancement,
+and assessed palette generation. No measured bottleneck or speedup has been
+established.
+
+Defer exhaustive input coverage, all-blend-mode and gradient-construction baseline
+suites, formal measurement-status classifications, and automated regression
+thresholds. Gradient rendering and speculative product optimizations remain out
+of scope. Consumer SwiftLint dependency/build-cost evaluation, a separate
+preserved-3.0.0 client compatibility gate, and release/version selection remain
+follow-up work.
+
+## Agreed harness
+
+The authoritative baseline runner will be a repository-local command-line package
+under `Benchmarks/`, importing ColorKit through its existing public API and running
+in Release mode. macOS is the initial reference platform; recorded results must
+identify that platform and cannot establish iOS performance.
+
+This arrangement supports repeatable invocations, fresh processes for cache
+experiments, and machine-readable results while exercising operations available
+to library consumers. Private conversion kernels are outside this harness's
+reach. The SwiftUI performance preview retains its public API and receives the
+workload corrections agreed during this design session.
+
+## Agreed workload families
+
+The first baseline covers these four families, with cases reported separately:
+
+| Family | Operations |
+| --- | --- |
+| Conversion | Real public conversion requests, starting with HSL and LAB components |
+| Comparison | Full `comparisonResult(with:)`, including all its metrics |
+| Enhancement | Budgeted enhancement, separating already-compliant inputs from inputs requiring adjustment |
+| Palette | Assessed palette generation with fixed seeds and configuration |
+
+The preview's gradient cases must explicitly describe value construction. That
+label correction does not require adding gradient cases to the baseline runner.
+
+## Agreed fixture policy
+
+Use a small, checked-in set of named scenarios with explicit color components and
+configurations. Report each scenario separately so changes in the workload mix
+cannot conceal a regression. Validate expected outcomes before timing.
+
+Clarity is part of this contract: every scenario has a stable identifier, a
+plain-language purpose, exact inputs (including color space and opacity), explicit
+operation settings, and an expected outcome. Include those details with the timing
+results so readers can understand what was measured without reading source code.
+
+Enhancement scenarios include an already-compliant black foreground against white,
+and sRGB `(0.8, 0.8, 0.8)` against white with distance budgets of 100 and 25 to
+exercise a passing adjustment and budget-constrained best effort respectively.
+Pin the strategy, direction preference, and target level for these fixtures and
+verify their expected outcomes before accepting measurements. Start with a small
+set of explicit sRGB fixtures; exhaustive color-space and edge-case coverage is
+deferred.
+
+Choose and document the compact fixture inventory and exact settings during
+implementation, using existing correctness tests where applicable.
+
+Implementation inspection found that the public palette generator uses internal,
+unseeded random hue shifts. Its seed color and configuration are fixed, but its
+candidate search is stochastic. Retain the representative five-color request and
+disclose that variability, including priming with different candidates, rather
+than modifying the library to control its RNG. Validate palette invariants instead
+of exact generated colors; do not interpret this case as a deterministic cache-hit
+or version comparison.
+
+## Agreed operation unit
+
+One operation is one complete request through the selected API:
+
+- Conversion: convert one color using the selected API.
+- Comparison: process one color pair.
+- Enhancement: process one foreground/background request.
+- Palette: generate and assess one entire palette.
+
+A five-color assessed palette counts as one palette request. All internal
+candidate searches and per-entry assessments are part of that request. Results
+use explicit units such as nanoseconds per comparison and palettes per second.
+Input preparation and report formatting happen outside the timed work. The cost
+of result consumption is included as described below.
+
+## Agreed result consumption
+
+Pass every complete result to a small benchmark sink designed to keep the result
+observable to the optimizer. The timed measurement includes both the request and
+its sink call. Validate correctness outside the timed section.
+
+Measure loop and sink overhead separately and disclose it without subtracting it
+from the reported request measurements. Explain when harness overhead prevents a
+useful measurement of a cheap operation.
+Detailed per-iteration checksums are not the chosen consumption mechanism because
+their cost could dominate small workloads.
+
+During implementation, inspect optimized code to verify that workload calls remain
+inside the loop. A sink's presence alone is not evidence that repeated work survives
+optimization. The sink implementation and verification must cover every result
+type used by the harness.
+
+Reference: [Swift benchmarking guidance](https://www.swift.org/blog/benchmarks/)
+demonstrates consuming results with `blackHole`.
+
+## Agreed cache protocol
+
+Define cache preparation at the start of each complete request:
+
+| Mode | Preparation outside timing |
+| --- | --- |
+| Empty ColorKit cache | Clear `ColorCache.shared` immediately before the measured request. |
+| Primed ColorKit cache | Clear `ColorCache.shared`, execute the same scenario once outside timing, then measure its next execution. |
+
+Cache entries created during an enhancement or palette request remain available
+to its internal operations. The request includes that natural cache behavior.
+Clearing once before a loop does not qualify the entire loop as empty-cache work;
+each measured request must receive the stated preparation.
+
+Run scenarios serially in isolated runner processes. These labels describe only
+ColorKit cache preparation, not CPU or operating-system cache state. Priming does
+not guarantee that every internal lookup hits. Operations that never use ColorKit's
+cache have a single measurement mode.
+
+## Baseline deliverable
+
+Save repeated timings and raw samples with a concise human-readable summary of
+typical request time, variation, and measurement limitations. Record the source
+revision, fixture settings, cache preparation, Release build configuration,
+hardware, OS, and Swift/Xcode versions so results can be reproduced.
+
+Choose and document a modest repetition count during implementation. Check fixture
+correctness, valid timing arithmetic, and optimized workload execution. Explain
+noisy or overhead-dominated measurements directly; this milestone does not require
+a formal classification system, statistical acceptance thresholds, or CI slowdown
+gates. Do not interpret a shorter duration as an improvement if the expected
+workload result is wrong.
+
+The deliverable is corrected preview measurements and useful reference data for
+future profiling decisions. Broaden the suite only when a concrete performance
+question justifies the additional maintenance.

--- a/docs/design/benchmark-correctness.md
+++ b/docs/design/benchmark-correctness.md
@@ -21,7 +21,7 @@ follow-up work.
 
 ## Agreed harness
 
-The authoritative baseline runner will be a repository-local command-line package
+The authoritative baseline runner is a repository-local command-line package
 under `Benchmarks/`, importing ColorKit through its existing public API and running
 in Release mode. macOS is the initial reference platform; recorded results must
 identify that platform and cannot establish iOS performance.
@@ -65,8 +65,8 @@ verify their expected outcomes before accepting measurements. Start with a small
 set of explicit sRGB fixtures; exhaustive color-space and edge-case coverage is
 deferred.
 
-Choose and document the compact fixture inventory and exact settings during
-implementation, using existing correctness tests where applicable.
+The [runner guide](../../Benchmarks/README.md) records the compact fixture inventory
+and exact settings, checked against existing correctness expectations.
 
 Implementation inspection found that the public palette generator uses internal,
 unseeded random hue shifts. Its seed color and configuration are fixed, but its
@@ -137,9 +137,9 @@ typical request time, variation, and measurement limitations. Record the source
 revision, fixture settings, cache preparation, Release build configuration,
 hardware, OS, and Swift/Xcode versions so results can be reproduced.
 
-Choose and document a modest repetition count during implementation. Check fixture
-correctness, valid timing arithmetic, and optimized workload execution. Explain
-noisy or overhead-dominated measurements directly; this milestone does not require
+The runner defaults to three independent runs, each with ten samples of 100
+requests. Check fixture correctness, valid timing arithmetic, and optimized workload
+execution. Explain noisy or overhead-dominated measurements directly; this milestone does not require
 a formal classification system, statistical acceptance thresholds, or CI slowdown
 gates. Do not interpret a shorter duration as an improvement if the expected
 workload result is wrong.

--- a/scripts/tests/test_benchmark_report.py
+++ b/scripts/tests/test_benchmark_report.py
@@ -1,0 +1,38 @@
+"""Keep report units and aggregation honest without asserting machine speed."""
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_report", pathlib.Path(__file__).resolve().parents[2] / "Benchmarks" / "run.py"
+)
+REPORT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REPORT)
+
+
+class BenchmarkReportTests(unittest.TestCase):
+    def test_sample_totals_are_normalized_before_combining_runs(self):
+        records = [
+            {"scenario": {"id": "palette"}, "cacheMode": "empty", "run": 1, "samples": [
+                {"requestCount": 10, "requestNanoseconds": 1000, "controlNanoseconds": 100}
+            ]},
+            {"scenario": {"id": "palette"}, "cacheMode": "empty", "run": 2, "samples": [
+                {"requestCount": 20, "requestNanoseconds": 6000, "controlNanoseconds": 600}
+            ]},
+        ]
+        summary = REPORT.summarize(records)
+        self.assertIn("| palette | empty | 200.0 | 100.0–300.0 | 20.0 |", summary)
+        self.assertIn("not individual-request latency percentiles", summary)
+
+    def test_cache_modes_remain_separate(self):
+        records = [
+            {"scenario": {"id": "hsl"}, "cacheMode": mode, "samples": [
+                {"requestCount": 1, "requestNanoseconds": duration, "controlNanoseconds": 10}
+            ]}
+            for mode, duration in [("empty", 200), ("primed", 100)]
+        ]
+        summary = REPORT.summarize(records)
+        self.assertIn("| hsl | empty | 200.0 |", summary)
+        self.assertIn("| hsl | primed | 100.0 |", summary)


### PR DESCRIPTION
## Summary

Correct misleading performance-preview measurements and add a small, reproducible macOS Release benchmark runner. Preserve ColorKit 3.0.0's public API and library algorithms; establish measurement evidence without claiming a speedup.

## Changes

- Replace the preview's opacity placeholder with real HSL/LAB conversion, consume every result, and label gradient timings as value construction with uncontrolled cache state.
- Add seven public-API scenarios covering conversion, full comparison, budgeted enhancement, and assessed palette generation.
- Prepare empty or primed ColorKit cache state before each complete request; isolate scenario/cache pairs in fresh processes.
- Retain repeated raw timings, unsubtracted control measurements, fixture descriptions, and machine/toolchain metadata.
- Add Release harness and report tests, CI correctness checks, and reproduction/verification documentation; remove unsupported historical speedup claims.
- Share cache preparation between workload/control paths and make enhancement fixture behavior explicit instead of deriving it from identifiers.

## Alternatives considered

- The exploratory SwiftUI preview cannot provide isolated cache state or enforce Release configuration, so reference measurements use a separate repository-local package.
- Retaining only the final result risks elimination of repeated work; every complete result passes through an optimizer-resistant sink, with optimized-code inspection for all result shapes.
- Exhaustive workload matrices, a general benchmarking framework, and CI timing thresholds were deferred until a concrete profiling question justifies them.
- The public palette API offers no RNG control. Its representative five-color request is retained with explicit stochastic-workload caveats rather than changing library behavior.

## Notes

- Final independent Standards and Spec reviews of `b54ca5a...13cc17e` both reported zero findings.
- No gradient rendering, speculative product optimizations, new public APIs, or migration requirements.
- Empty and primed cache results are different request preparations, not before/after library speedup claims. Palette candidates can differ between priming and measurement.
- Raw runs remain local ignored artifacts. `Benchmarks/VERIFICATION.md` identifies the clean `5918b1a` run; both subsequent refactors were separately revalidated with full runs and optimized-code checks.
- The five branch commits are unsigned by explicit maintainer authorization; persistent signing configuration was not changed.

## Screenshots

Captured from the actual library preview in a temporary host on iPhone 17 Pro / iOS 26.2. These Debug UI timings demonstrate the labels and behavior, not the Release reference baseline.

![HSL and LAB conversion results with uncontrolled-cache labels and measurement caveat](https://github.com/user-attachments/assets/795407ce-e8f1-48e3-9b57-59d56e2170c9)

![Linear and radial gradient construction results with measurement caveat](https://github.com/user-attachments/assets/c38c673c-c740-455f-8b7d-1739ee44d678)

## Testing

- PASS: canonical `scripts/run_tests.sh` iOS/macOS matrix, including serialized shared-state suites, for the unchanged library source revision.
- PASS: `swift test --package-path Benchmarks -c release`, refreshed at final HEAD; five tests cover preparation order, timing boundaries, invalid inputs, and every fixture/cache mode.
- PASS: `python3 -m unittest discover -s scripts/tests`, 15 tests including report normalization and cache-mode separation.
- PASS: `swiftlint lint --strict`, no violations in 116 files.
- PASS: DocC warnings-as-errors build and executable public documentation examples for the unchanged library/documentation examples.
- PASS: complete 36-process, 360-sample benchmark runs after each final refactor; scenario descriptions remained byte-for-byte identical.
- PASS: optimized executable inspection confirmed input barriers, public operation dispatch, complete-result consumption, and clock reads remain inside request loops for every result shape.
- PASS: temporary iOS preview-host build/run on iPhone 17 Pro / iOS 26.2; ran conversion and gradient workloads and visually verified both result screens and the measurement caveat.
- PASS: `git diff b54ca5a...HEAD --check`; clean worktree and remote HEAD verified.

Reproduce the reference measurements on macOS with:

```sh
swift test --package-path Benchmarks -c release
python3 Benchmarks/run.py --output .build/benchmark-results/review
```

Choose a new output directory and keep other intensive workloads idle. These measurements do not establish iOS performance or automatic regression thresholds.
