### PR TITLE
doc(api): Clarify accessibility and component contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to ColorKit will be documented in this file.
 - Add a repository-local macOS Release benchmark runner with explicit conversion, comparison, enhancement, and assessed-palette fixtures, cache preparation, raw repeated samples, and machine/toolchain metadata. Replace unsupported historical speedup claims with reproducible measurement guidance.
 
 ### Fixed
+- Clarify existing accessibility, palette assessment, component conversion, similarity, and contrast-role contracts in API comments and documentation. Lead new callers to measured outcomes and compile the revised examples; no signatures or runtime behavior change.
 - Measure real HSL/LAB conversion in the performance preview, consume every request's result, and label gradient timings as value construction. Preview measurements remain exploratory with uncontrolled cache state; no color API or conversion behavior changes.
 
 ## [3.0.0] - 2026-09-04

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -171,22 +171,18 @@ Rectangle()
 ### **1️⃣1️⃣ Generación automática de paletas de colores accesibles**  
 <!-- swift-example: accessible-palette -->
 ```swift
-// Generar una paleta accesible a partir de un color base
-let seedColor = Color.blue
-let palette = seedColor.generateAccessiblePalette(
-    targetLevel: .AA,  // Nivel de cumplimiento WCAG
-    paletteSize: 5,    // Número de colores a generar
-    includeBlackAndWhite: true
-)
+let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let generator = AccessiblePaletteGenerator(configuration: .init(targetLevel: .AA))
+let results = generator.generateAssessedPalette(from: seedColor, against: backgroundColor)
+for result in results {
+    if result.meetsTarget {
+        Text("WCAG AA").foregroundColor(result.color).background(backgroundColor)
+    } else {
+        print(result.status)
+    }
+}
 
-// Generar un tema accesible a partir de un color base
-let theme = seedColor.generateAccessibleTheme(
-    name: "Accessible Blue Theme",
-    targetLevel: .AA
-)
-
-// Encontrar el extremo blanco o negro con mayor contraste e inspeccionar el resultado
-let backgroundColor = Color(.sRGB, red: 0.5, green: 0.2, blue: 0.7)
 let textResult = backgroundColor.accessibleContrastingColorResult(for: .AA)
 let textColor = textResult.color
 
@@ -210,6 +206,13 @@ struct ContentView: View {
     }
 }
 ```
+
+Para código nuevo, comprueba `meetsTarget` o `status` antes de usar un candidato.
+La paleta evaluada conserva todos los resultados; no aplica un límite de mejora ni
+certifica el contraste entre entradas. Las paletas heredadas devuelven candidatos;
+los temas solo establecen una pareja de texto/fondo blanco y negro.
+`accessibleContrastingColor(for:)` y `suggestedColor(for:)` ignoran el nivel solicitado,
+usan heurísticas distintas y no garantizan ese nivel.
 
 ### **1️⃣2️⃣ Exportar y compartir paletas de colores**  
 ```swift
@@ -286,7 +289,7 @@ Para más detalles sobre las mejoras de rendimiento, consulta [PERFORMANCE_IMPRO
 ### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
 <!-- swift-example: enhancement -->
 ```swift
-// Generar un candidato preservando la identidad de marca e inspeccionar su resultado
+// Generar un candidato dentro de un límite de distancia e inspeccionar su resultado
 let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
 let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
 let targetLevel = WCAGContrastLevel.AA
@@ -397,6 +400,12 @@ print(components.description)
 ColorSpaceInspectorView(color: myColor)
 ```
 
+`rgbaComponents()` resuelve la apariencia actual: UIKit conserva sRGB extendido;
+AppKit convierte a sRGB acotado. Un fallo devuelve `(0, 0, 0, 0)`, indistinguible del
+negro transparente. Los componentes agregados heredan esa política, sustituyen fallos
+HSL/CMYK por ceros, extraen HSB sin indicar éxito y derivan LAB/XYZ de RGB incluso
+si es una sustitución. Usa conversiones opcionales cuando importe la disponibilidad.
+
 ### **Comparación de colores**  
 
 Compara colores sRGB fijos, opacos y dentro de gama mediante diferencias de componentes, métricas WCAG y CIEDE2000:
@@ -419,16 +428,26 @@ ColorComparisonView(color1: color1, color2: color2)
 
 Los colores dinámicos, translúcidos, no finitos o fuera de la gama sRGB devuelven problemas explícitos en vez de mediciones inventadas.
 
+`isPerceptuallySimilar(to:threshold:)` usa CIE76 en LAB D65 y `distancia < umbral`
+sin validar el umbral. La igualdad o una conversión LAB no disponible devuelven `false`.
+Ignora alfa sin componer sobre un fondo y admite sRGB extendido si LAB está disponible.
+CIEDE2000 requiere colores opacos dentro de gama; los umbrales no son intercambiables.
+
 ### **Depuración de accesibilidad WCAG**  
 
 Valida y mejora la accesibilidad de los colores:
+
+En `foreground.contrastResult(with: background)`, el receptor es el primer plano.
+Un primer plano translúcido se compone sobre el fondo opaco; un fondo translúcido
+no está disponible. Invertir los argumentos puede cambiar el resultado.
 
 <!-- swift-example: budget -->
 ```swift
 // Verificar cumplimiento WCAG
 let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
 let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let compliance = backgroundColor.wcagCompliance(with: textColor)
+let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
+print(assessment.status)
 
 // Obtener candidatos dentro del límite con resultados explícitos y evidencia de medición
 let suggestions = textColor.suggestAccessibleVariantResults(
@@ -442,7 +461,7 @@ Las APIs de mejora que devuelven resultados aplican un límite inclusivo CIEDE20
 Delta E 00 respecto al primer plano original (finito, en `0...100`, predeterminado: `30`).
 Si ningún candidato examinado alcanza el objetivo, devuelven el mejor esfuerzo dentro
 del límite, o un resultado explícito `invalidConfiguration` o `unavailable`.
-Las APIs heredadas que devuelven solo colores siguen ignorando el límite.
+Las mejoras heredadas que devuelven solo colores ignoran el límite y no garantizan el objetivo.
 Consulta la [guía de migración de mejoras](MIGRATION.md#enhancement-distance-budgets).
 
 Consulta la [Documentación de depuración de colores](Sources/ColorKit/Utilities/DOCUMENTATION.md) para más detalles.

--- a/README.md
+++ b/README.md
@@ -168,22 +168,18 @@ Rectangle()
 ### **1️⃣1️⃣ Auto-Generate Accessible Color Palettes**  
 <!-- swift-example: accessible-palette -->
 ```swift
-// Generate an accessible palette from a seed color
-let seedColor = Color.blue
-let palette = seedColor.generateAccessiblePalette(
-    targetLevel: .AA,  // WCAG compliance level
-    paletteSize: 5,    // Number of colors to generate
-    includeBlackAndWhite: true
-)
+let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let generator = AccessiblePaletteGenerator(configuration: .init(targetLevel: .AA))
+let results = generator.generateAssessedPalette(from: seedColor, against: backgroundColor)
+for result in results {
+    if result.meetsTarget {
+        Text("WCAG AA").foregroundColor(result.color).background(backgroundColor)
+    } else {
+        print(result.status)
+    }
+}
 
-// Generate an accessible theme from a seed color
-let theme = seedColor.generateAccessibleTheme(
-    name: "Accessible Blue Theme",
-    targetLevel: .AA
-)
-
-// Find the stronger black-or-white endpoint and inspect its measured outcome
-let backgroundColor = Color(.sRGB, red: 0.5, green: 0.2, blue: 0.7)
 let textResult = backgroundColor.accessibleContrastingColorResult(for: .AA)
 let textColor = textResult.color
 
@@ -207,6 +203,13 @@ struct ContentView: View {
     }
 }
 ```
+
+For new callers, check `meetsTarget` or `status` before using a candidate.
+Assessed palettes retain every outcome; they impose no enhancement budget and do
+not certify contrast between entries. Legacy palettes return candidates; themes
+only establish a black-and-white text/background pair.
+`accessibleContrastingColor(for:)` and `suggestedColor(for:)` ignore the requested
+level, use different heuristics, and do not guarantee that level.
 
 ### **1️⃣2️⃣ Export & Share Color Palettes**  
 ```swift
@@ -283,7 +286,7 @@ For more details on performance improvements, see [PERFORMANCE_IMPROVEMENTS.md](
 ### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
 <!-- swift-example: enhancement -->
 ```swift
-// Generate a candidate while preserving brand identity, then inspect its outcome
+// Generate a candidate within a distance budget, then inspect its outcome
 let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
 let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
 let targetLevel = WCAGContrastLevel.AA
@@ -394,6 +397,12 @@ print(components.description)
 ColorSpaceInspectorView(color: myColor)
 ```
 
+`rgbaComponents()` resolves the current appearance: UIKit preserves extended sRGB;
+AppKit converts to bounded sRGB. Failure returns `(0, 0, 0, 0)`, indistinguishable
+from transparent black. Aggregate components inherit that policy, substitute zeros
+for failed HSL/CMYK, extract HSB without a success flag, and derive LAB/XYZ from RGB
+even on failure. Use optional conversions when availability matters.
+
 ### **Color Comparison**  
 
 Compare fixed, opaque, in-gamut sRGB colors using component differences, WCAG metrics, and CIEDE2000:
@@ -416,16 +425,26 @@ ColorComparisonView(color1: color1, color2: color2)
 
 Dynamic, translucent, nonfinite, and out-of-sRGB inputs return explicit issues instead of fabricated measurements.
 
+`isPerceptuallySimilar(to:threshold:)` uses CIE76 in D65 LAB and `distance < threshold`
+without validating the threshold. Equality or unavailable LAB returns `false`.
+It ignores alpha without compositing and accepts extended sRGB when LAB is available.
+CIEDE2000 requires opaque, in-gamut inputs; thresholds are not interchangeable.
+
 ### **WCAG Accessibility Debugging**  
 
 Validate and improve color accessibility:
+
+In `foreground.contrastResult(with: background)`, the receiver is the foreground.
+A translucent foreground composites over the opaque background; a translucent
+background is unavailable. Reversing the arguments can change the result.
 
 <!-- swift-example: budget -->
 ```swift
 // Check WCAG compliance
 let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
 let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let compliance = backgroundColor.wcagCompliance(with: textColor)
+let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
+print(assessment.status)
 
 // Get budgeted candidates with explicit outcomes and measurement evidence
 let suggestions = textColor.suggestAccessibleVariantResults(
@@ -438,7 +457,7 @@ let suggestions = textColor.suggestAccessibleVariantResults(
 Result-bearing enhancement enforces an inclusive CIEDE2000 Delta E 00 budget
 from the original foreground (finite `0...100`, default `30`). It returns in-budget
 best effort when no examined candidate passes, or an explicit `invalidConfiguration`
-or `unavailable` outcome. Legacy color-returning enhancement still ignores the budget.
+or `unavailable` outcome. Legacy color-returning enhancement ignores the budget and does not guarantee the target.
 See [enhancement migration guidance](MIGRATION.md#enhancement-distance-budgets).
 
 See [Color Debugging Documentation](Sources/ColorKit/Utilities/DOCUMENTATION.md) for more details.

--- a/Sources/ColorKit/Documentation.docc/Accessibility-article.md
+++ b/Sources/ColorKit/Documentation.docc/Accessibility-article.md
@@ -4,64 +4,53 @@ Learn how to create accessible color combinations and ensure your app meets WCAG
 
 ## Overview
 
-ColorKit provides comprehensive tools for ensuring your app's colors meet accessibility standards, particularly the Web Content Accessibility Guidelines (WCAG).
+For new callers, use result-bearing APIs and check `meetsTarget` or `status` before
+using a candidate. Legacy color-returning methods do not guarantee the requested
+target; legacy enhancement also ignores distance budgets.
 
 ### Contrast Checking
 
 Check if your color combinations meet WCAG contrast requirements:
 
+The receiver of `foreground.contrastResult(with: background)` is the foreground.
+A translucent foreground composites over the opaque background; a translucent
+background is unavailable. Reversing the arguments can change the result.
+
+<!-- swift-example: contrast -->
 ```swift
-let backgroundColor = Color.white
-let textColor = Color.gray
-
-// Check contrast ratio
-let ratio = backgroundColor.contrastRatio(with: textColor)
-print("Contrast ratio: \(ratio)")
-
-// Or measure it without collapsing an unresolvable input to zero luminance
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let textColor = Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 0.7)
 switch textColor.contrastResult(with: backgroundColor) {
 case .available(let measurement):
-    print("Contrast ratio: \(measurement.ratio)")
-    print("Passing levels: \(measurement.passingLevels)")
+    print(measurement.ratio, measurement.passingLevels)
 case .unavailable(let issues):
-    print("Unavailable: \(issues.foreground), \(issues.background)")
+    print(issues.foreground, issues.background)
 }
-
-// Both colors must be opaque. A translucent color reports a ratio of 1, meaning it
-// was not measured; compose it against a background with contrastResult(with:).
-
-// Check WCAG compliance
-let compliance = backgroundColor.wcagCompliance(with: textColor)
-print("AA Large Text: \(compliance.passesAALarge)")
-print("AA Normal Text: \(compliance.passesAA)")
-print("AAA Large Text: \(compliance.passesAAALarge)")
-print("AAA Normal Text: \(compliance.passesAAA)")
 ```
 
-### Accessible Color Generation
+### Assessed Palettes
 
-Generate accessible color variations that maintain your brand identity:
+Assessment retains every outcome without imposing an enhancement budget or
+certifying contrast between entries. Legacy palettes return candidates; themes
+establish a black-and-white text/background pair. Assess other role combinations.
 
+<!-- swift-example: assessed-palette -->
 ```swift
-// Find an accessible color that meets AA standards
-let enhancedColor = textColor.enhanced(
-    with: backgroundColor,
-    targetLevel: .AA
-)
-
-// Generate an accessible color palette
-let palette = seedColor.generateAccessiblePalette(
-    targetLevel: .AA,
-    paletteSize: 5,
-    includeBlackAndWhite: true
-)
-
-// Create an accessible theme
-let theme = seedColor.generateAccessibleTheme(
-    name: "Accessible Theme",
-    targetLevel: .AA
-)
+let seed = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let background = Color(.sRGB, red: 1, green: 1, blue: 1)
+let results = AccessiblePaletteGenerator().generateAssessedPalette(from: seed, against: background)
+for result in results {
+    if result.meetsTarget {
+        Text("WCAG AA").foregroundColor(result.color).background(background)
+    } else {
+        print(result.status)
+    }
+}
 ```
+
+`accessibleContrastingColor(for:)` and `suggestedColor(for:)` ignore the requested
+level and use different endpoint heuristics. Prefer `accessibleContrastingColorResult(for:)`
+and inspect its outcome; even the stronger black-or-white endpoint may miss the target.
 
 ### Verifiable Results
 
@@ -70,7 +59,10 @@ on knowing the outcome, use the assessed interfaces. They distinguish a measured
 a measurable best effort below the target, and a result that cannot be measured from
 the supplied colors.
 
+<!-- swift-example: enhancement -->
 ```swift
+let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
 let result = textColor.enhancementResult(
     with: backgroundColor,
     targetLevel: .AAA
@@ -205,10 +197,10 @@ ColorKit supports both WCAG 2.1 AA and AAA levels:
 
 ### Color Enhancement
 - `Color.enhanced(with:targetLevel:)`
-- `Color.enhancementResult(with:targetLevel:strategy:)`
+- `Color.enhancementResult(with:targetLevel:strategy:maxPerceptualDistance:)`
 - ``AccessibilityEnhancer``
 - `Color.suggestedAccessibleColors(for:level:)`
-- `Color.suggestAccessibleVariantResults(with:targetLevel:count:)`
+- `Color.suggestAccessibleVariantResults(with:targetLevel:count:maxPerceptualDistance:)`
 - `Color.accessibleContrastingColorResult(for:)`
 
 ### Palette Generation

--- a/Sources/ColorKit/Documentation.docc/Utilities-article.md
+++ b/Sources/ColorKit/Documentation.docc/Utilities-article.md
@@ -28,6 +28,25 @@ CIEDE2000 uses the reference weighting factors set to one and is validated again
 
 ![A comparison of system blue and indigo showing raw CIEDE2000, component, contrast, and WCAG results.](ciede2000-comparison.jpg)
 
+### Similarity and Components
+
+`isPerceptuallySimilar(to:threshold:)` uses CIE76 in D65 LAB and `distance < threshold`
+without validating the threshold. Equality or unavailable LAB returns `false`.
+It ignores alpha without compositing and accepts extended sRGB when LAB is available.
+CIEDE2000 requires opaque, in-gamut inputs; thresholds are not interchangeable.
+
+<!-- swift-example: similarity -->
+```swift
+let color = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+print(color.isPerceptuallySimilar(to: color, threshold: 0)) // false: equality
+print(color.isPerceptuallySimilar(to: Color.primary)) // false: unavailable LAB
+```
+
+`rgbaComponents()` resolves the current appearance, preserving extended sRGB on UIKit
+and converting to bounded sRGB on AppKit. Failure returns `(0, 0, 0, 0)`, indistinguishable
+from transparent black. ``ColorSpaceConverter/getAllColorComponents()`` documents the
+aggregate API's additional substitutions; use optional conversions when availability matters.
+
 ### Color Cache
 
 Improve performance by caching expensive color operations:

--- a/Sources/ColorKit/Utilities/Color+ColorSpaceComponents.swift
+++ b/Sources/ColorKit/Utilities/Color+ColorSpaceComponents.swift
@@ -16,8 +16,10 @@
 import SwiftUI
 
 public extension Color {
-    /// Get color components in all available color spaces
-    /// - Returns: A ColorComponents structure with all color space representations
+    /// Returns aggregate components without per-conversion availability.
+    ///
+    /// See ``ColorSpaceConverter/getAllColorComponents()`` for appearance resolution
+    /// and failure substitutions; zero components do not establish conversion success.
     func colorSpaceComponents() -> ColorComponents {
         let converter = ColorSpaceConverter(color: self)
         return converter.getAllColorComponents()

--- a/Sources/ColorKit/Utilities/ColorComponents.swift
+++ b/Sources/ColorKit/Utilities/ColorComponents.swift
@@ -18,7 +18,10 @@
 //  License:
 //  MIT License. See LICENSE file for details.
 
-/// A structure that represents color components in various color spaces
+/// Aggregate color representations without per-conversion availability.
+///
+/// Values from ``ColorSpaceConverter/getAllColorComponents()`` may contain compatibility
+/// substitutions. Zero components do not establish that conversion succeeded.
 public struct ColorComponents: Sendable {
     /// RGB color components
     public let rgb: (red: Double, green: Double, blue: Double, alpha: Double)

--- a/Sources/ColorKit/Utilities/ColorSpaceConverter.swift
+++ b/Sources/ColorKit/Utilities/ColorSpaceConverter.swift
@@ -49,13 +49,21 @@ public struct ColorSpaceConverter {
         self.color = color
     }
 
-    /// Get all color components in various color spaces.
+    /// Returns aggregate color components, including compatibility substitutions.
     ///
     /// This method converts the color to all supported color spaces and returns their components
     /// in a single structure. This is useful when you need to analyze or compare a color across
     /// different color spaces.
-    /// LAB and XYZ share the D65 conversion used by `Color.labComponents()`.
-    /// XYZ uses a relative scale where the reference white has Y = 100.
+    /// RGB uses `Color.rgbaComponents()`, including appearance resolution, platform gamut
+    /// handling, and the all-zero failure tuple. Failed HSL and CMYK conversions each
+    /// substitute zero tuples. HSB uses platform hue extraction into zero-initialized
+    /// components without exposing conversion success.
+    ///
+    /// LAB and XYZ are derived from the RGB tuple, even when that tuple is a fallback;
+    /// they do not call the optional `Color.labComponents()`. They share its D65 formula,
+    /// but not its resolution or failure policy. XYZ uses reference-white Y = 100.
+    /// No field identifies substitutions. Use individual optional conversions when
+    /// their availability matters; a zero coordinate alone is not evidence of success.
     ///
     /// Example:
     /// ```swift

--- a/Sources/ColorKit/WCAG/AccessibilityEnhancer.swift
+++ b/Sources/ColorKit/WCAG/AccessibilityEnhancer.swift
@@ -90,7 +90,8 @@ public enum AdjustmentStrategy: String, CaseIterable, Identifiable {
 /// for color adjustment and can suggest alternative colors that maintain harmony with
 /// the original design.
 ///
-/// Example usage:
+/// For new callers, prefer `enhanceColorResult(_:against:)` and inspect `meetsTarget`.
+/// Legacy candidate examples:
 /// ```swift
 /// // Create an enhancer targeting WCAG AA compliance
 /// let config = AccessibilityEnhancer.Configuration(
@@ -105,7 +106,7 @@ public enum AdjustmentStrategy: String, CaseIterable, Identifiable {
 ///     against: .white
 /// )
 ///
-/// // Get multiple accessible variants
+/// // Get legacy variant candidates
 /// let variants = enhancer.suggestAccessibleVariants(
 ///     for: .blue,
 ///     against: .white,
@@ -185,7 +186,7 @@ public class AccessibilityEnhancer {
 
     /// Attempts to enhance a color for a requested accessibility target.
     ///
-    /// This compatibility method preserves the original color-returning behavior and ignores the distance budget.
+    /// This compatibility method does not guarantee the requested target and ignores the distance budget.
     /// Use ``enhanceColorResult(_:against:)`` when the caller needs to distinguish
     /// a passing candidate from best effort or unavailable measurement.
     ///
@@ -195,7 +196,7 @@ public class AccessibilityEnhancer {
     /// let textColor = Color.blue
     /// let backgroundColor = Color.white
     ///
-    /// // Get an accessible version of the text color
+    /// // Get a legacy candidate without a target or budget guarantee
     /// let accessibleColor = enhancer.enhanceColor(
     ///     textColor,
     ///     against: backgroundColor
@@ -223,6 +224,9 @@ public class AccessibilityEnhancer {
 
     /// Enhances and assesses a color against the configured WCAG target.
     ///
+    /// Prefer this result-bearing method for new callers; check `meetsTarget` before using
+    /// the candidate as a passing color.
+    ///
     /// Enforces the inclusive configured Delta E 00 budget. The original is examined
     /// first, then the first passing eligible strategy candidate wins. Minimum-change
     /// candidates are ordered by distance; other strategies retain their existing order.
@@ -246,8 +250,8 @@ public class AccessibilityEnhancer {
 
     /// Suggests multiple color variants that target the configured contrast level.
     ///
-    /// This compatibility method generates alternative candidates while maintaining
-    /// different aspects of the original color's character. Use
+    /// This compatibility method neither guarantees the requested target nor enforces
+    /// the configured distance budget. Use
     /// ``suggestAccessibleVariantResults(for:against:count:)`` to inspect the measured
     /// outcome for each candidate.
     ///
@@ -257,7 +261,7 @@ public class AccessibilityEnhancer {
     /// let brandColor = Color.blue
     /// let backgroundColor = Color.white
     ///
-    /// // Get three accessible variants
+    /// // Request up to three legacy candidates
     /// let variants = enhancer.suggestAccessibleVariants(
     ///     for: brandColor,
     ///     against: backgroundColor,
@@ -377,7 +381,10 @@ public class AccessibilityEnhancer {
 // MARK: - Color Extensions
 
 public extension Color {
-    /// Enhances and assesses this color against a background and WCAG target.
+    /// Enhances and assesses this foreground against a background and WCAG target.
+    ///
+    /// Prefer this method for new callers. Check `meetsTarget` or `status` before using
+    /// `color` as a passing candidate; diagnostic contrast alone does not establish success.
     ///
     /// - Parameters:
     ///   - backgroundColor: The background against which the candidate is assessed.
@@ -400,6 +407,10 @@ public extension Color {
     }
 
     /// Attempts to enhance this color for a requested accessibility target.
+    ///
+    /// This legacy method neither guarantees the target nor enforces an enhancement
+    /// distance budget. Prefer ``enhancementResult(with:targetLevel:strategy:maxPerceptualDistance:)``.
+    ///
     /// - Parameters:
     ///   - backgroundColor: The background color to check against
     ///   - targetLevel: The WCAG level to target (default: .AA)
@@ -418,7 +429,11 @@ public extension Color {
         return enhancer.enhanceColor(self, against: backgroundColor)
     }
 
-    /// Suggests color variants that target a contrast level while maintaining harmony.
+    /// Suggests color candidates for a requested contrast level.
+    ///
+    /// This legacy method neither guarantees the target nor enforces an enhancement budget.
+    /// Prefer ``suggestAccessibleVariantResults(with:targetLevel:count:maxPerceptualDistance:)``.
+    ///
     /// - Parameters:
     ///   - backgroundColor: The background color to check against
     ///   - targetLevel: The WCAG level to target (default: .AA)
@@ -462,11 +477,21 @@ public extension Color {
         )
     }
 
-    /// Determines if this color is perceptually similar to another color
+    /// Returns whether the CIE76 distance between two D65 LAB colors is strictly below a threshold.
+    ///
+    /// Uses Euclidean LAB distance (`Delta E ab`) from `labComponents()`. Alpha does not
+    /// affect the coordinates and no background compositing occurs. Finite extended-sRGB
+    /// channels can participate; unresolved inputs or unavailable LAB conversions return `false`.
+    /// Equality with the threshold returns `false`, including identical colors at threshold zero.
+    ///
+    /// This is not CIEDE2000. Use `comparisonResult(with:)` for Delta E 00 and explicit
+    /// unavailable-input diagnostics; that API additionally requires opaque, in-gamut inputs.
+    /// Thresholds are not interchangeable between the two metrics.
+    ///
     /// - Parameters:
-    ///   - color: The color to compare with
-    ///   - threshold: The threshold for similarity (0-100, lower means more similar)
-    /// - Returns: Whether the colors are perceptually similar
+    ///   - color: The color whose LAB coordinates are compared with this color's.
+    ///   - threshold: The exclusive CIE76 distance limit (default: 10), used without clamping or validation.
+    /// - Returns: `true` only when both LAB conversions succeed and `distance < threshold`.
     func isPerceptuallySimilar(to color: Color, threshold: Double = 10) -> Bool {
         guard let lab1 = self.labComponents(),
               let lab2 = color.labComponents() else {

--- a/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.md
+++ b/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.md
@@ -18,6 +18,10 @@ The Accessible Palette Generator helps you create candidate palettes around a se
 
 ## Usage Examples
 
+For new callers, use `generateAssessedPalette(from:against:)` and inspect each
+result. See the [compiled README examples](../../../README.md). Assessment retains
+all outcomes without imposing an enhancement budget or certifying pairwise contrast.
+
 ### Generating an Accessible Palette
 
 ```swift

--- a/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.swift
+++ b/Sources/ColorKit/WCAG/AccessiblePaletteGenerator.swift
@@ -31,7 +31,8 @@ import SwiftUI
 /// - Customize palette size and accessibility requirements
 /// - Support for different WCAG compliance levels
 ///
-/// Example usage:
+/// For new callers, prefer `generateAssessedPalette(from:against:)` and inspect each outcome.
+/// Legacy candidate examples:
 /// ```swift
 /// // Create a generator with custom configuration
 /// let config = AccessiblePaletteGenerator.Configuration(
@@ -45,7 +46,7 @@ import SwiftUI
 /// let seedColor = Color.blue
 /// let palette = generator.generatePalette(from: seedColor)
 ///
-/// // Create an accessible theme
+/// // Create a theme candidate
 /// let theme = generator.generateAccessibleTheme(
 ///     from: seedColor,
 ///     name: "Ocean Theme"
@@ -142,7 +143,10 @@ public struct AccessiblePaletteGenerator {
         self.configuration = configuration
     }
 
-    /// Generates an accessible color palette based on a seed color.
+    /// Generates palette candidates based on a seed color.
+    ///
+    /// Prefer ``generateAssessedPalette(from:against:)`` for new callers that need
+    /// measured outcomes against an explicit background.
     ///
     /// This method creates a palette that:
     /// - Targets the specified WCAG contrast for generated candidates against the seed
@@ -172,7 +176,7 @@ public struct AccessiblePaletteGenerator {
     /// ```
     ///
     /// - Parameter seedColor: The color to base the palette on
-    /// - Returns: An array of colors that form an accessible palette
+    /// - Returns: An array of candidates without per-entry or pairwise compliance guarantees.
     public func generatePalette(from seedColor: Color) -> [Color] {
         var palette: [Color] = []
 
@@ -220,6 +224,8 @@ public struct AccessiblePaletteGenerator {
 
     /// Generates the existing palette and assesses every entry against a background.
     ///
+    /// Prefer this method for new callers and inspect each result's `meetsTarget` or `status`.
+    /// Assessment does not adjust candidates or impose an enhancement distance budget.
     /// Ordering and candidate generation are identical to ``generatePalette(from:)``.
     /// Results are not filtered, so callers retain evidence for passing, best-effort,
     /// and unavailable entries. This method does not imply pairwise contrast between
@@ -241,7 +247,7 @@ public struct AccessiblePaletteGenerator {
         }
     }
 
-    /// Generates a theme from a seed color with accessible color combinations.
+    /// Generates a theme with a black-and-white text/background pair from a seed color.
     ///
     /// This method creates a color theme that:
     /// - Uses a black-and-white text and background pairing
@@ -274,7 +280,7 @@ public struct AccessiblePaletteGenerator {
     /// - Parameters:
     ///   - seedColor: The primary color to base the theme on
     ///   - name: The name for the theme
-    /// - Returns: A ColorTheme with accessible color combinations
+    /// - Returns: A theme with a black-and-white text/background pair; assess other role combinations before use.
     public func generateAccessibleTheme(from seedColor: Color, name: String) -> ColorTheme {
         // Use simpler, more deterministic approach for theme generation
 

--- a/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
+++ b/Sources/ColorKit/WCAG/Color+AccessiblePalette.swift
@@ -27,17 +27,18 @@ import SwiftUI
 /// - Creating themes with a high-contrast text and background pairing
 /// - Finding the stronger black-or-white contrasting endpoint
 ///
-/// Example usage:
+/// For new callers, prefer `AccessiblePaletteGenerator.generateAssessedPalette(from:against:)`.
+/// Legacy candidate examples:
 /// ```swift
 /// let brandColor = Color.blue
 ///
-/// // Generate an accessible palette
+/// // Generate palette candidates
 /// let palette = brandColor.generateAccessiblePalette(
 ///     targetLevel: .AA,
 ///     paletteSize: 5
 /// )
 ///
-/// // Create an accessible theme
+/// // Create a theme candidate
 /// let theme = brandColor.generateAccessibleTheme(
 ///     name: "Brand Theme"
 /// )
@@ -46,8 +47,10 @@ import SwiftUI
 /// let textColor = brandColor.accessibleContrastingColor()
 /// ```
 public extension Color {
-    /// Generates an accessible color palette based on this color.
+    /// Generates palette candidates based on this color.
     ///
+    /// For new callers, prefer `AccessiblePaletteGenerator.generateAssessedPalette(from:against:)`
+    /// to retain each candidate's outcome against its intended background.
     /// Generated candidates target the requested contrast level against the base color.
     /// The base color, optional black and white entries, and fallback colors are not
     /// pairwise certified. Validate combinations in the context where they will be used.
@@ -58,7 +61,7 @@ public extension Color {
     ///
     /// // Generate a palette with custom settings
     /// let palette = brandColor.generateAccessiblePalette(
-    ///     targetLevel: .AAA,      // Highest accessibility
+    ///     targetLevel: .AAA,      // Requested target, not a guarantee
     ///     paletteSize: 7,         // 7 colors
     ///     includeBlackAndWhite: true
     /// )
@@ -75,7 +78,7 @@ public extension Color {
     ///   - targetLevel: The WCAG level to target (default: .AA)
     ///   - paletteSize: The number of colors to generate (default: 5)
     ///   - includeBlackAndWhite: Whether to include black and white (default: true)
-    /// - Returns: An array of colors that form an accessible palette
+    /// - Returns: An array of candidates without per-entry or pairwise compliance guarantees.
     func generateAccessiblePalette(
         targetLevel: WCAGContrastLevel = .AA,
         paletteSize: Int = 5,
@@ -91,7 +94,7 @@ public extension Color {
         return generator.generatePalette(from: self)
     }
 
-    /// Generates an accessible theme based on this color.
+    /// Generates a theme with a black-and-white text/background pair based on this color.
     ///
     /// This method creates a complete color theme with a black-and-white text and
     /// background pairing. Other role combinations are not certified against the
@@ -121,7 +124,7 @@ public extension Color {
     /// - Parameters:
     ///   - name: The name for the theme
     ///   - targetLevel: The WCAG level to target (default: .AA)
-    /// - Returns: A ColorTheme with accessible color combinations
+    /// - Returns: A theme with a black-and-white text/background pair; assess other role combinations before use.
     func generateAccessibleTheme(
         name: String,
         targetLevel: WCAGContrastLevel = .AA
@@ -141,6 +144,9 @@ public extension Color {
     /// Compares both endpoints using `wcagContrastRatio(with:)` and returns the one
     /// with the higher ratio. Exact ties return black.
     ///
+    /// For new callers, prefer ``accessibleContrastingColorResult(for:)`` and check
+    /// `meetsTarget` before using the endpoint as a passing foreground.
+    ///
     /// The result is independent of the requested level: the stronger endpoint is
     /// returned even when neither meets the target. In particular, AAA may be
     /// unattainable. Color resolution follows the existing WCAG calculation.
@@ -151,11 +157,11 @@ public extension Color {
     ///
     /// // Get a contrasting color for text
     /// let textColor = backgroundColor.accessibleContrastingColor(
-    ///     for: .AAA  // Highest contrast requirement
+    ///     for: .AAA  // Requested level does not change selection
     /// )
     ///
     /// // Use in SwiftUI
-    /// Text("Accessible Text")
+    /// Text("Candidate text")
     ///     .foregroundColor(textColor)
     ///     .background(backgroundColor)
     /// ```

--- a/Sources/ColorKit/WCAG/Color+WCAG.swift
+++ b/Sources/ColorKit/WCAG/Color+WCAG.swift
@@ -36,7 +36,7 @@ extension Color {
     /// print("Alpha: \(components.alpha)")
     /// ```
     ///
-    /// - Returns: A tuple containing normalized (0.0-1.0) RGBA components. A color the
+    /// - Returns: A tuple of appearance-resolved sRGBA components; UIKit RGB may extend beyond `0...1`. A color the
     ///   platform cannot resolve, such as a pattern color, reports all zeros, which is
     ///   indistinguishable from transparent black.
     func wcagRGBAComponents() -> (red: Double, green: Double, blue: Double, alpha: Double) {

--- a/Sources/ColorKit/WCAG/Color+WCAGCompliance.swift
+++ b/Sources/ColorKit/WCAG/Color+WCAGCompliance.swift
@@ -23,7 +23,8 @@ import SwiftUI
 /// - Checking WCAG compliance levels
 /// - Suggesting accessible color alternatives
 ///
-/// Example usage:
+/// For new callers, prefer `accessibilityResult(against:targetLevel:)` and inspect `meetsTarget`.
+/// Legacy candidate examples:
 /// ```swift
 /// let textColor = Color.blue
 /// let backgroundColor = Color.white
@@ -38,14 +39,17 @@ import SwiftUI
 ///     print("Safe for normal text")
 /// }
 ///
-/// // Get suggested accessible color
+/// // Get a legacy color candidate
 /// let accessibleColor = backgroundColor.suggestedColor(for: .AA)
 /// ```
 public extension Color {
-    /// Returns the RGBA components of a color.
+    /// Returns appearance-resolved sRGBA components with a zero-tuple compatibility fallback.
     ///
-    /// This method provides access to the raw color components in the sRGB color space.
-    /// Values are normalized to the range 0.0-1.0.
+    /// Named and dynamic colors resolve through the platform color types for the appearance
+    /// in effect. UIKit preserves extended sRGB channels, which can fall outside `0...1`;
+    /// AppKit converts to bounded sRGB. Alpha is separate and unpremultiplied.
+    /// If conversion fails, the method returns `(0, 0, 0, 0)`, indistinguishable from
+    /// transparent black. The tuple carries no indication of conversion success.
     ///
     /// Example:
     /// ```swift
@@ -57,7 +61,7 @@ public extension Color {
     /// print("Alpha: \(components.alpha)")
     /// ```
     ///
-    /// - Returns: A tuple containing red, green, blue, and alpha components as Double values (0.0-1.0)
+    /// - Returns: Red, green, blue, and alpha as `Double` values, or all zeros if conversion fails.
     func rgbaComponents() -> (red: Double, green: Double, blue: Double, alpha: Double) {
         return wcagRGBAComponents()
     }
@@ -198,21 +202,21 @@ public extension Color {
 
     /// Suggests a black-or-white color to pair with this color.
     ///
-    /// This method provides a simple suggestion for an accessible color by recommending
-    /// either black or white based on the current color's luminance. For more
-    /// sophisticated color suggestions that preserve brand identity, use
-    /// ``AccessibilityEnhancer``.
+    /// The requested level does not affect this legacy luminance heuristic, and the candidate
+    /// is not guaranteed to meet it. This heuristic differs from the stronger-endpoint
+    /// selection in ``accessibleContrastingColor(for:)``. For new callers, prefer
+    /// ``accessibleContrastingColorResult(for:)`` and inspect `meetsTarget` before use.
     ///
     /// Example:
     /// ```swift
     /// let backgroundColor = Color.blue
     /// let textColor = backgroundColor.suggestedColor(for: .AA)
-    /// Text("Accessible Text")
+    /// Text("Candidate text")
     ///     .foregroundColor(textColor)
     ///     .background(backgroundColor)
     /// ```
     ///
-    /// - Parameter level: The WCAG compliance level to target
+    /// - Parameter level: The requested WCAG level, retained for compatibility and ignored.
     /// - Returns: A black-or-white candidate selected from this color's legacy luminance.
     func suggestedColor(for level: WCAGContrastLevel) -> Color {
         let luminance = self.wcagRelativeLuminance()

--- a/Sources/ColorKit/WCAG/ColorContrastResult.swift
+++ b/Sources/ColorKit/WCAG/ColorContrastResult.swift
@@ -101,6 +101,8 @@ public extension Color {
 
     /// Measures the WCAG contrast ratio between this foreground color and a background.
     ///
+    /// The receiver is the foreground; the `with:` argument is the background. Reversing
+    /// them can change availability and the measurement when opacity is involved.
     /// Both colors must resolve to finite, in-gamut sRGB values, and the background
     /// must be opaque. A translucent foreground is composited over the background
     /// before measurement. Dynamic colors, wider-gamut colors, and translucent

--- a/Sources/ColorKit/WCAG/README.md
+++ b/Sources/ColorKit/WCAG/README.md
@@ -14,6 +14,10 @@ The WCAG (Web Content Accessibility Guidelines) Compliance Checker is a powerful
 
 ## Usage
 
+For new callers, start with the [result-bearing examples](../../../README.md).
+Check outcomes before using candidates; legacy color-returning helpers do not
+guarantee the target, and legacy enhancement ignores distance budgets.
+
 ### Basic Usage
 
 ```swift

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -18,6 +18,8 @@ EXAMPLES = {
     "README.es-ES.md": README_EXAMPLES,
     DOCC + "Color-Spaces-article.md": {"rgb", "hsl", "lab"},
     DOCC + "Theming-article.md": {"dynamic-theme"},
+    DOCC + "Accessibility-article.md": {"contrast", "enhancement", "assessed-palette"},
+    DOCC + "Utilities-article.md": {"similarity"},
     "PERFORMANCE_IMPROVEMENTS.md": {"cache", "benchmark"},
     "MIGRATION.md": {"cvd", "enhancement-budget", "enhancement-references", "comparison"},
 }


### PR DESCRIPTION
## Summary

Color-returning accessibility helpers and component accessors can appear to provide stronger guarantees than their implementations support. Clarify their existing contracts and lead new callers to result-bearing accessibility and assessed-palette APIs.

## Changes

- Explain legacy target and enhancement-budget limitations, RGBA appearance/gamut behavior and zero fallback, aggregate conversion substitutions, CIE76 similarity boundaries, and contrast foreground/background roles.
- Align API comments, DocC, English and Spanish README examples, focused guides, and the changelog.
- Compile the actual DocC contrast, enhancement, assessed-palette, and similarity examples through the existing public-client checker.

## Alternatives considered

Changing algorithms, signatures, defaults, eligibility, or fallbacks would alter released contracts. This change documents existing behavior without aliases or deprecations. Broader guide rewrites and repeated examples were omitted to keep the diff focused.

## Notes

All nine changed library Swift files differ only in documentation-comment lines. No runtime behavior or UI changes; no migration is required.

The branch starts at `3f12211`, the origin/main revision fetched when the isolated worktree was created. Current main's subsequent consumer-build tooling changes merge cleanly in a `git merge-tree --write-tree` check; validation below was run on this branch, not a merged checkout. Full test-matrix coverage and a dedicated ABI comparison were not run; this baseline has no dedicated API compatibility command.

## Screenshots

Not applicable; no UI changes.

## Testing

- `xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' -derivedDataPath /tmp/ColorKitAPIClarityDocumentation -skipPackagePluginValidation -skipMacroValidation 'OTHER_DOCC_FLAGS=--warnings-as-errors'`: passed.
- `python3 scripts/check_documentation.py --derived-data /tmp/ColorKitAPIClarityDocumentation`: 32 public examples compiled; six actual README conversion examples verified; generated theme output compiled for named, translucent, Display P3, and grayscale inputs.
- `swiftlint lint --strict`: zero violations.
- `python3 -m unittest discover -s scripts/tests`: 15 tests passed.
- Repository `scripts/run_tests.sh` targeted runs on macOS arm64 and iPhone 17 / iOS 26.5, with parallel testing disabled: 69 XCTest tests and 22 Swift Testing tests passed per platform. Suites: AccessibleContrastingColorTests, EnhancementDistanceBudgetTests, ColorContrastResultTests, AccessiblePaletteGeneratorTests, HSLResolutionTests, LABResolutionTests, and ResolvedSRGBATests. Includes unattainable targets, legacy budget compatibility, unavailable inputs, contrast opacity roles, and platform conversion contracts.
- `git diff --check`: passed; comparison excluding documentation-comment lines confirmed unchanged executable library source.
