### PR TITLE
perf(enhancement): Reuse the original color snapshot

### DIFF
--- a/Sources/ColorKit/Utilities/ColorComparison.swift
+++ b/Sources/ColorKit/Utilities/ColorComparison.swift
@@ -21,8 +21,11 @@ public extension Color {
     /// - Parameter other: The second color in the comparison.
     /// - Returns: A complete color difference or the issues that prevent measurement.
     func comparisonResult(with other: Color) -> ColorComparisonResult {
-        let first = ResolvedSRGBA.resolve(self)
-        let second = ResolvedSRGBA.resolve(other)
+        Self.comparisonResult(first: ResolvedSRGBA.resolve(self), second: ResolvedSRGBA.resolve(other))
+    }
+
+    /// Shares comparison validation and calculations with request-local resolved inputs.
+    internal static func comparisonResult(first: ResolvedSRGBA?, second: ResolvedSRGBA?) -> ColorComparisonResult {
         let issues = ColorComparisonIssues(
             firstColor: Self.comparisonIssues(for: first),
             secondColor: Self.comparisonIssues(for: second)

--- a/Sources/ColorKit/WCAG/BudgetedEnhancement.swift
+++ b/Sources/ColorKit/WCAG/BudgetedEnhancement.swift
@@ -10,16 +10,17 @@ struct BudgetedEnhancement {
         guard AccessibilityEnhancer.Configuration.isValidDistanceBudget(budget) else {
             return result(color: original, contrast: originalContrast, distance: nil)
         }
+        let resolvedOriginal = ResolvedSRGBA.resolve(original)
         let originalResult = result(
             color: original,
             contrast: originalContrast,
-            distance: distance(from: original, to: original)
+            distance: distance(from: resolvedOriginal, to: original)
         )
         guard originalResult.status == .bestEffort, budget > 0 else { return originalResult }
 
         var candidates: [ColorAccessibilityResult] = []
         func examine(_ candidate: Color) {
-            guard let distance = distance(from: original, to: candidate), distance <= budget,
+            guard let distance = distance(from: resolvedOriginal, to: candidate), distance <= budget,
                   let contrast = StrictWCAGContrast.measure(foreground: candidate, background: background).ratio
             else { return }
             candidates.append(result(color: candidate, contrast: contrast, distance: distance))
@@ -59,8 +60,8 @@ struct BudgetedEnhancement {
         return best
     }
 
-    private func distance(from original: Color, to candidate: Color) -> Double? {
-        guard case let .available(difference) = original.comparisonResult(with: candidate) else { return nil }
+    private func distance(from original: ResolvedSRGBA?, to candidate: Color) -> Double? {
+        guard case let .available(difference) = Color.comparisonResult(first: original, second: ResolvedSRGBA.resolve(candidate)) else { return nil }
         return difference.perceptualDifference
     }
 


### PR DESCRIPTION
## Summary

Reuse the original color's strict resolved snapshot across budgeted enhancement comparisons. The preserveHue searching fixtures perform 22 full comparisons; this avoids 21 repeated original-color resolutions per request.

## Changes

- Add an internal comparison entry point accepting resolved inputs, shared by the public comparison and budgeted enhancement.
- Resolve the original once for comparison use within each enhancement request.
- Preserve full comparison calculations, candidate order, fallback examination, tie-breaking, availability checks, and budget boundaries. Contrast assessment retains its existing resolution path.

## Alternatives considered

A broader assessment context could also reuse background/candidate snapshots but requires more machinery. A distance-only calculator changes more calculation paths. This patch keeps the optimization limited to original-snapshot reuse.

## Notes

Alternating uninstrumented Release runs on an M4 Pro, macOS 26.6.2, Xcode 26.5 / Swift 6.3.2 measured:

| Enhancement | Cache preparation | Baseline µs/request | Updated µs/request | Reduction |
| --- | --- | ---: | ---: | ---: |
| Adjusted | empty | 32.320 | 29.155 | 9.8% |
| Adjusted | primed | 28.857 | 23.876 | 17.3% |
| Best effort | empty | 26.744 | 21.544 | 19.4% |
| Best effort | primed | 22.171 | 18.811 | 15.2% |

Three rounds, ten samples of 1,000 requests per process, with alternating binary order and 72 fresh processes across all existing scenario/cache pairs. All four searching cases improved in each round. Controls are retained without subtraction. These local measurements do not establish iOS or general application speedups; the palette remains stochastic.

Baseline revision: `3f122111681538db5bd71a01891b7619fba00ba9`. Raw samples, metadata, executable hashes, source patch, disassembly, profiles, and the temporary differential test are retained in ignored local `.build/enhancement-profile/` artifacts. No benchmark semantics, compatibility fixtures, or public API changed.

## Screenshots

Not applicable; no UI changes.

## Testing

- macOS and iOS 26.5 / iPhone 17 Release: 43 selected tests passed per platform, including a temporary differential suite with 4,352 exact old/new enhancement comparisons per platform.
- Differential checks covered all strategies, both direction preferences, AA/AAA, invalid and boundary budgets, unavailable/translucent/extended-gamut inputs, and selected color/status/contrast/distance equivalence. The prior implementation was copied from the baseline revision; the diagnostic test was removed from the product tree after validation.
- Fresh pre-commit macOS check: `swift test -c release --filter 'EnhancementDistanceBudgetTests|ColorComparisonResultTests|AccessibilityEnhancerTests'` passed.
- iOS checks used `scripts/run_tests.sh` with Release, `ENABLE_TESTABILITY=YES`, and the four selected suites.
- Unchanged official benchmark runner completed all 36 default processes and fixture checks; the alternating comparison completed all 72 processes.
- Follow-up Time Profiler capture corroborated reduced resolution cost; inspected optimized request loops retained workload dispatch and complete-result consumption.
- `swiftlint lint --strict --quiet` and `git diff --check` passed.
