### PR TITLE
feat(conversion): Add independent component conversion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add `Color.componentConversionResults()` with independent results for sRGBA, HSL, HSB, CMYK, XYZ, LAB, and Hex from one fixed color. Preserve extended sRGBA and finite D65 XYZ/LAB; report unavailable bounded representations without clipping. Include typed diagnostics, explicit alpha/appearance limits, and signed extended-sRGB decoding with exact LAB constants. Existing conversion APIs and legacy calculations remain unchanged, with no deprecations.
+
 ## [3.0.1] - 2026-09-07
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,10 @@ _Avoid_: Clamped RGB, color identity
 **Unavailable inspector conversion**:
 A color representation or contrast ratio that cannot be obtained from the current color inputs. It is neither a zero value nor a failed contrast threshold, and says nothing about earlier inputs.
 
+**Unavailable component representation**:
+A representation that cannot be obtained from a color under the conversion's stated contract. Its absence does not invalidate other representations successfully obtained from that input.
+_Avoid_: Zero components, wholly unconvertible color
+
 **Color identity**:
 The original color space and complete component values, including opacity, that distinguish a color input. Equal component values in different color spaces do not establish the same color identity.
 _Avoid_: Visual equivalence

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,28 @@
 # Migration Guide
 
+## Unreleased additions for ColorKit 3.1
+
+### Component conversion results
+
+`Color.componentConversionResults()` is additive; no existing calls need migration
+and nothing is deprecated. Adopt it when each representation's availability matters.
+It returns per-field Swift `Result` values, rather than the zero substitutions of
+`colorSpaceComponents()` and `ColorSpaceConverter.getAllColorComponents()`.
+
+The new API requires a fixed RGB or grayscale color. Resolve named/dynamic colors
+explicitly before calling it; even `.blue` can lack fixed components. All fields
+derive from one extended-sRGBA snapshot, with valid alpha and no compositing.
+Out-of-sRGB-gamut inputs retain sRGBA and finite XYZ/LAB but report unavailable
+HSL/HSB/CMYK/Hex, including tiny endpoint overshoots. This differs deliberately from
+legacy HSL clipping and ambient appearance resolution.
+
+Signed decoding corrects negative extended-sRGB channels in the new XYZ/LAB path,
+and exact LAB constants replace rounded constants in that path only. New values can
+differ from legacy results for negative channels or near the LAB breakpoint. Existing
+calculations, caches, formatters, nil/zero fallbacks, and deployment targets remain
+unchanged. Do not treat the new method as a numerically identical wrapper around
+every old accessor; see the [component contract](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results).
+
 ## ColorKit 3.0.0
 
 Upgrading from 2.1.0 requires handling the new accessibility status case and updating

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -52,6 +52,35 @@ mediciones de color pueden producir resultados distintos.
 
 ## **🎨 Uso**  
 
+### Resultados de conversión de componentes
+
+Usa `componentConversionResults()` cuando importe la disponibilidad. Cada campo
+devuelve su valor o un problema, de modo que un fallo de Hex no descarta LAB disponible.
+
+<!-- swift-example: component-results -->
+```swift
+let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
+if case .success(let lab) = conversions.lab {
+    print(lab.lightness, lab.a, lab.b)
+}
+switch conversions.hex {
+case .success(let hex): print(hex)
+case .failure(let issue): print("Hex no disponible:", issue)
+}
+```
+
+Los siete campos describen un único color fijo, sin composición con un fondo:
+`srgba`, `hsl`, `hsb`, `cmyk`, `xyz`, `lab` y `hex`. El llamador debe resolver
+explícitamente los colores con nombre o dinámicos que no tengan componentes fijos.
+Se conservan sRGBA extendido y XYZ/LAB D65 finitos; HSL, HSB, CMYK y Hex rechazan
+RGB fuera de `0...1`, sin recorte ni tolerancia en los extremos. Alfa se conserva
+en sRGBA y en Hex de ocho dígitos `#RRGGBBAA`; las demás coordenadas lo omiten.
+El tono se expresa en vueltas, las fracciones HSL/HSB/CMYK están en `0...1` y XYZ
+usa Y = 100 para el blanco de referencia. CMYK es una aproximación algebraica,
+no un perfil de impresión. Las API existentes no cambian ni se marcan como obsoletas.
+Consulta el [contrato de conversión](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
+y las [notas de adopción](MIGRATION.md#component-conversion-results).
+
 ### **1️⃣ Conversión HEX <-> RGB**  
 ```swift
 let color = Color(hex: "#FF5733")

--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ enhancement budgets, and color measurements can produce different results.
 
 ## **🎨 Usage**  
 
+### Component conversion results
+
+Use `componentConversionResults()` when availability matters. Each field reports its
+own value or issue, so a failed Hex conversion does not discard available LAB.
+
+<!-- swift-example: component-results -->
+```swift
+let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
+if case .success(let lab) = conversions.lab {
+    print(lab.lightness, lab.a, lab.b)
+}
+switch conversions.hex {
+case .success(let hex): print(hex)
+case .failure(let issue): print("Hex unavailable:", issue)
+}
+```
+
+All seven fields describe one fixed, uncomposited color: `srgba`, `hsl`, `hsb`,
+`cmyk`, `xyz`, `lab`, and `hex`. Named or dynamic colors without fixed components
+must be resolved explicitly by the caller. Extended sRGBA and finite D65 XYZ/LAB
+are preserved; HSL, HSB, CMYK, and Hex reject RGB outside `0...1` without clipping
+or endpoint tolerance. Alpha is retained in sRGBA and eight-digit `#RRGGBBAA` Hex;
+other coordinates omit it. Hues are turns, HSL/HSB/CMYK fractions are `0...1`, and
+XYZ uses reference-white Y = 100. CMYK is an algebraic approximation, not a printer
+profile. Existing APIs remain unchanged and are not deprecated. See the
+[conversion contract](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
+and [adoption notes](MIGRATION.md#component-conversion-results).
+
 ### **1️⃣ HEX <-> RGB Conversion**  
 ```swift
 let color = Color(hex: "#FF5733")

--- a/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
+++ b/Sources/ColorKit/Documentation.docc/Color-Spaces-article.md
@@ -6,6 +6,69 @@ Learn about the different color spaces supported by ColorKit and how to convert 
 
 ColorKit supports multiple color spaces to give you flexibility in how you work with colors. Each color space has its own unique characteristics and use cases.
 
+### Component conversion results
+
+Use `Color.componentConversionResults()` for independent availability
+without fallback coordinates. Every success derives from the same fixed sRGBA
+snapshot; a failed bounded representation does not discard finite extended coordinates.
+
+<!-- swift-example: component-results -->
+```swift
+let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
+if case .success(let xyz) = conversions.xyz {
+    print(xyz.x, xyz.y, xyz.z)
+}
+switch conversions.hex {
+case .success(let hex): print(hex)
+case .failure(.outOfSRGBGamut): print("Hex would require clipping")
+case .failure(let issue): print(issue)
+}
+```
+
+| Field | Meaning and units | Limits |
+| --- | --- | --- |
+| `srgba` | Nonlinear extended sRGB, separate unpremultiplied alpha | Finite RGB, possibly outside 0–1; alpha 0–1 |
+| `hsl` | Hue in turns `[0,1)`, saturation/lightness fractions 0–1 | In-gamut sRGB only; achromatic hue is zero |
+| `hsb` | HSV coordinates, named HSB; hue in turns `[0,1)`, saturation/brightness 0–1 | In-gamut sRGB only; brightness is max(R,G,B), achromatic hue is zero |
+| `cmyk` | Algebraic complements in 0–1, black K = 1 − max(R,G,B) | In-gamut sRGB only; no ink/printer profile or print-fidelity claim |
+| `xyz` | CIE XYZ, D65, reference-white Y = 100 | Finite output, not percentages or bounded to 100 |
+| `lab` | CIE L*a*b*, D65 white (95.047,100,108.883) | Finite output; no forced L*/a*/b* bounds for extended inputs |
+| `hex` | Uppercase `#RRGGBBAA`, nearest-byte rounding, ties upward | In-gamut sRGB only; at most 0.5/255 quantization error per channel |
+
+Alpha never premultiplies RGB, even at zero, and no background is assumed. Numeric
+fields other than sRGBA omit alpha; keep it alongside the coordinates when needed.
+HSL/HSB hue can be multiplied by 360 for degrees and fractions by 100 for percentages.
+LAB lightness conventionally ranges from 0 to 100 for ordinary surface colors;
+extended values are algebraic coordinates, not HDR luminance measurements.
+
+Fixed RGB and grayscale inputs are converted through their source color space to
+extended sRGB with relative-colorimetric intent. No gamut mapping, clipping, or
+endpoint tolerance is applied, so a tiny platform overshoot can make a bounded
+representation unavailable. Equivalent profiles may introduce numerical differences;
+results do not promise bitwise equality across OS versions. Legacy caches are not used.
+
+Named and dynamic colors without fixed `cgColor` components report `unresolvedInput`.
+The caller must choose and capture an appearance before conversion. For UIKit,
+capture `Color(UIColor(color).resolvedColor(with: traits).cgColor)` using the relevant
+trait collection. For AppKit, inside the chosen appearance's
+`performAsCurrentDrawingAppearance` block, obtain
+`NSColor(color).usingColorSpace(.extendedSRGB)?.cgColor` and construct a `Color` from
+the non-nil value. Capture failure is still possible. ColorKit does not infer the
+missing appearance or retain it after capture.
+
+``ColorConversionIssue`` records the first observable blocker: missing fixed input,
+unsupported model, invalid source components, or failed platform conversion affects
+all fields. Gamut rejection affects bounded fields; nonfinite XYZ also makes LAB
+unavailable. A missing fixed input does not prove that appearance resolution will fix
+it. Components sanitized by platform construction are judged as received.
+
+Signed extended-sRGB decoding and exact LAB constants can yield different XYZ/LAB
+results from legacy accessors for negative channels or near the LAB breakpoint.
+Existing APIs, including ambient appearance resolution and clamping where documented,
+remain unchanged and are not deprecated. Successful component conversion does not
+establish WCAG contrast or perceptual similarity. Legacy color initializers can clamp
+their inputs and are not general inverses of extended coordinates.
+
 ### RGB
 
 The RGB color space is the most common color space used in digital displays. It represents colors using red, green, and blue components.

--- a/Sources/ColorKit/Utilities/ColorComponentConversionResults.swift
+++ b/Sources/ColorKit/Utilities/ColorComponentConversionResults.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+/// The first observable blocker for one component conversion.
+public enum ColorConversionIssue: Error, Sendable, Equatable {
+    /// No fixed color is available; this does not establish whether appearance resolution would help.
+    case unresolvedInput
+    /// The source has no color space or uses a model other than RGB or grayscale.
+    case unsupportedColorModel
+    /// Source components are malformed or nonfinite, or alpha is outside 0–1.
+    case invalidComponents
+    /// The platform could not produce a valid extended-sRGB snapshot.
+    case colorSpaceConversionFailed
+    /// A bounded representation would require clipping a channel outside 0–1.
+    case outOfSRGBGamut
+    /// Conversion arithmetic or a required XYZ dependency produced nonfinite coordinates.
+    case nonfiniteResult
+}
+
+/// Finite nonlinear extended-sRGB components with separate, unpremultiplied alpha.
+public struct SRGBAComponents: Sendable, Equatable {
+    /// The red channel, which may be below zero or above one.
+    public let red: Double
+    /// The green channel, which may be below zero or above one.
+    public let green: Double
+    /// The blue channel, which may be below zero or above one.
+    public let blue: Double
+    /// Opacity in 0–1; zero does not erase the RGB channels.
+    public let alpha: Double
+}
+
+/// Bounded-sRGB HSL coordinates, independent of opacity.
+public struct HSLComponents: Sendable, Equatable {
+    /// Hue in turns, from zero up to but excluding one; achromatic colors use zero.
+    public let hue: Double
+    /// Saturation in 0–1.
+    public let saturation: Double
+    /// Lightness in 0–1.
+    public let lightness: Double
+}
+
+/// Bounded-sRGB HSV coordinates, named HSB for consistency with SwiftUI.
+public struct HSBComponents: Sendable, Equatable {
+    /// Hue in turns, from zero up to but excluding one; achromatic colors use zero.
+    public let hue: Double
+    /// Saturation in 0–1, independent of opacity.
+    public let saturation: Double
+    /// The maximum RGB channel in 0–1, independent of opacity.
+    public let brightness: Double
+}
+
+/// Algebraic sRGB complements in 0–1, independent of opacity.
+///
+/// These coordinates use no printer or ink profile and do not predict printed appearance.
+public struct CMYKComponents: Sendable, Equatable {
+    /// The cyan fraction.
+    public let cyan: Double
+    /// The magenta fraction.
+    public let magenta: Double
+    /// The yellow fraction.
+    public let yellow: Double
+    /// The black fraction; black uses C = M = Y = 0 and K = 1.
+    public let key: Double
+}
+
+/// Finite D65 XYZ coordinates on the reference-white Y = 100 scale, independent of opacity.
+///
+/// Coordinates are not percentages and are not bounded to 0–100.
+public struct XYZComponents: Sendable, Equatable {
+    /// The X tristimulus coordinate.
+    public let x: Double
+    /// The Y tristimulus coordinate.
+    public let y: Double
+    /// The Z tristimulus coordinate.
+    public let z: Double
+}
+
+/// Finite CIE L*a*b* coordinates relative to D65 white (95.047, 100, 108.883).
+///
+/// Opacity does not affect these coordinates. Extended inputs are not clamped to conventional LAB ranges.
+public struct LABComponents: Sendable, Equatable {
+    /// L*, conventionally 0–100 for ordinary surface colors, but unbounded for extended inputs.
+    public let lightness: Double
+    /// The a* green–red coordinate, without an imposed range.
+    public let a: Double
+    /// The b* blue–yellow coordinate, without an imposed range.
+    public let b: Double
+}
+
+/// Independent component conversions derived from one fixed, uncomposited sRGBA snapshot.
+///
+/// A failed representation does not discard successful ones. Results do not consult legacy caches
+/// or change with appearance. Numeric representations other than sRGBA omit alpha; retrieve it
+/// from ``srgba``. A successful conversion makes no claim about contrast or displayed appearance.
+public struct ColorComponentConversionResults: Sendable {
+    /// Extended sRGBA, available whenever fixed resolution succeeds.
+    public let srgba: Result<SRGBAComponents, ColorConversionIssue>
+    /// HSL, unavailable outside the sRGB gamut.
+    public let hsl: Result<HSLComponents, ColorConversionIssue>
+    /// HSB, unavailable outside the sRGB gamut.
+    public let hsb: Result<HSBComponents, ColorConversionIssue>
+    /// Algebraic CMYK, unavailable outside the sRGB gamut.
+    public let cmyk: Result<CMYKComponents, ColorConversionIssue>
+    /// D65 XYZ, unavailable when its calculation produces nonfinite coordinates.
+    public let xyz: Result<XYZComponents, ColorConversionIssue>
+    /// D65 LAB, unavailable when XYZ or LAB cannot be calculated finitely.
+    public let lab: Result<LABComponents, ColorConversionIssue>
+    /// Uppercase #RRGGBBAA, with nearest-byte rounding (ties upward), unavailable outside sRGB.
+    ///
+    /// Quantization loses at most 0.5/255 per channel, including alpha; no gamut mapping occurs.
+    public let hex: Result<String, ColorConversionIssue>
+}
+
+public extension Color {
+    /// Returns independent component conversions of this fixed color.
+    ///
+    /// RGB and grayscale sources convert to extended nonlinear sRGB once. Inputs without fixed
+    /// components, including named and dynamic colors, require caller-side resolution first.
+    /// No ambient appearance, clipping, endpoint tolerance, or background compositing is used.
+    /// Alpha must be finite and in 0–1, even for representations that omit it.
+    ///
+    /// Extended sRGBA and finite XYZ/LAB remain available when HSL, HSB, CMYK, and Hex cannot
+    /// represent an out-of-gamut color. Signed extended-sRGB decoding and exact LAB constants
+    /// can yield different XYZ/LAB coordinates from legacy accessors, which remain unchanged.
+    ///
+    /// ```swift
+    /// let color = Color(.displayP3, red: 1, green: 0, blue: 0)
+    /// let conversions = color.componentConversionResults()
+    /// if case .success(let lab) = conversions.lab { print(lab.lightness) }
+    /// if case .failure(let issue) = conversions.hex { print(issue) }
+    /// ```
+    ///
+    /// - Returns: Seven independent results, with a shared issue when fixed resolution fails.
+    func componentConversionResults() -> ColorComponentConversionResults {
+        let resolved = ResolvedSRGBA.resolveResult(self)
+        let bounded = resolved.flatMap { snapshot -> Result<BoundedColorConversion, ColorConversionIssue> in
+            snapshot.isInSRGBGamut ? .success(BoundedColorConversion(snapshot)) : .failure(.outOfSRGBGamut)
+        }
+        let xyz = resolved.flatMap(ComponentConversion.xyz)
+        return ColorComponentConversionResults(
+            srgba: resolved.map {
+                SRGBAComponents(red: Double($0.red), green: Double($0.green), blue: Double($0.blue), alpha: Double($0.alpha))
+            },
+            hsl: bounded.map(\.hsl),
+            hsb: bounded.map(\.hsb),
+            cmyk: bounded.map(\.cmyk),
+            xyz: xyz,
+            lab: xyz.flatMap(ComponentConversion.lab),
+            hex: bounded.map(\.hex)
+        )
+    }
+}
+
+/// The four bounded representations, calculated together from one in-gamut snapshot.
+private struct BoundedColorConversion {
+    let hsl: HSLComponents
+    let hsb: HSBComponents
+    let cmyk: CMYKComponents
+    let hex: String
+
+    init(_ rgb: ResolvedSRGBA) {
+        let r = Double(rgb.red)
+        let g = Double(rgb.green)
+        let b = Double(rgb.blue)
+        let maximum = max(r, g, b)
+        let minimum = min(r, g, b)
+        let chroma = maximum - minimum
+        let lightness = (maximum + minimum) / 2
+        let hue: Double
+        if chroma == 0 {
+            hue = 0
+        } else {
+            let sector: Double
+            if maximum == r {
+                sector = (g - b) / chroma + (g < b ? 6 : 0)
+            } else if maximum == g {
+                sector = (b - r) / chroma + 2
+            } else {
+                sector = (r - g) / chroma + 4
+            }
+            // Rounding near red can reach exactly one turn; zero is the same hue.
+            hue = (sector / 6).truncatingRemainder(dividingBy: 1)
+        }
+        // Subtract before adding near white to avoid rounding the denominator to zero.
+        let denominator = lightness > 0.5 ? (1 - maximum) + (1 - minimum) : maximum + minimum
+        hsl = HSLComponents(hue: hue, saturation: chroma == 0 ? 0 : chroma / denominator, lightness: lightness)
+        hsb = HSBComponents(hue: hue, saturation: maximum == 0 ? 0 : chroma / maximum, brightness: maximum)
+        // Divide by maximum directly: 1 - K can round to zero near black.
+        cmyk = CMYKComponents(
+            cyan: maximum == 0 ? 0 : (maximum - r) / maximum,
+            magenta: maximum == 0 ? 0 : (maximum - g) / maximum,
+            yellow: maximum == 0 ? 0 : (maximum - b) / maximum,
+            key: 1 - maximum
+        )
+        hex = String(
+            format: "#%02X%02X%02X%02X",
+            Int((r * 255).rounded()),
+            Int((g * 255).rounded()),
+            Int((b * 255).rounded()),
+            Int((rgb.alpha * 255).rounded())
+        )
+    }
+}
+
+/// New result arithmetic; legacy XYZ/LAB formulas intentionally remain separate.
+private enum ComponentConversion {
+    static func xyz(_ rgb: ResolvedSRGBA) -> Result<XYZComponents, ColorConversionIssue> {
+        func linearize(_ channel: CGFloat) -> Double {
+            let value = Double(channel)
+            let magnitude = abs(value)
+            return magnitude <= 0.04045 ? value / 12.92
+                : (value < 0 ? -1 : 1) * pow((magnitude + 0.055) / 1.055, 2.4)
+        }
+        let r = linearize(rgb.red)
+        let g = linearize(rgb.green)
+        let b = linearize(rgb.blue)
+        let xyz = XYZComponents(
+            x: (r * 0.4124564 + g * 0.3575761 + b * 0.1804375) * 100,
+            y: (r * 0.2126729 + g * 0.7151522 + b * 0.0721750) * 100,
+            z: (r * 0.0193339 + g * 0.1191920 + b * 0.9503041) * 100
+        )
+        guard xyz.x.isFinite, xyz.y.isFinite, xyz.z.isFinite else { return .failure(.nonfiniteResult) }
+        return .success(xyz)
+    }
+
+    static func lab(_ xyz: XYZComponents) -> Result<LABComponents, ColorConversionIssue> {
+        func transform(_ value: Double) -> Double {
+            value > 216.0 / 24_389 ? cbrt(value) : ((24_389.0 / 27) * value + 16) / 116
+        }
+        let x = transform(xyz.x / 95.047)
+        let y = transform(xyz.y / 100)
+        let z = transform(xyz.z / 108.883)
+        let lab = LABComponents(lightness: 116 * y - 16, a: 500 * (x - y), b: 200 * (y - z))
+        guard lab.lightness.isFinite, lab.a.isFinite, lab.b.isFinite else { return .failure(.nonfiniteResult) }
+        return .success(lab)
+    }
+}

--- a/Sources/ColorKit/Utilities/ResolvedSRGBA.swift
+++ b/Sources/ColorKit/Utilities/ResolvedSRGBA.swift
@@ -31,16 +31,25 @@ struct ResolvedSRGBA {
 
     /// Resolves fixed RGB or grayscale inputs without consulting appearance or caches.
     static func resolve(_ color: Color) -> Self? {
-        guard let source = color.cgColor,
-              let space = source.colorSpace,
-              space.model == .rgb || space.model == .monochrome,
-              let components = source.components,
+        try? resolveResult(color).get()
+    }
+
+    /// Uses the same fixed resolution policy while retaining its first observable blocker.
+    static func resolveResult(_ color: Color) -> Result<Self, ColorConversionIssue> {
+        guard let source = color.cgColor else { return .failure(.unresolvedInput) }
+        guard let space = source.colorSpace,
+              space.model == .rgb || space.model == .monochrome else {
+            return .failure(.unsupportedColorModel)
+        }
+        guard let components = source.components,
               components.count == space.numberOfComponents + 1,
               components.allSatisfy({ $0.isFinite }),
               let alpha = components.last,
-              (0...1).contains(alpha),
-              let sRGB = CGColorSpace(name: CGColorSpace.sRGB),
-              let extendedSRGB = CGColorSpace(name: CGColorSpace.extendedSRGB) else { return nil }
+              (0...1).contains(alpha) else { return .failure(.invalidComponents) }
+        guard let sRGB = CGColorSpace(name: CGColorSpace.sRGB),
+              let extendedSRGB = CGColorSpace(name: CGColorSpace.extendedSRGB) else {
+            return .failure(.colorSpaceConversionFailed)
+        }
 
         let resolved: [CGFloat]
         if CFEqual(space, sRGB) || CFEqual(space, extendedSRGB) {
@@ -48,11 +57,16 @@ struct ResolvedSRGBA {
             resolved = components
         } else {
             guard let converted = source.converted(to: extendedSRGB, intent: .relativeColorimetric, options: nil),
-                  let convertedComponents = converted.components else { return nil }
+                  let convertedComponents = converted.components else {
+                return .failure(.colorSpaceConversionFailed)
+            }
             resolved = convertedComponents
         }
 
-        return Self(sRGBComponents: resolved)
+        guard let snapshot = Self(sRGBComponents: resolved) else {
+            return .failure(.colorSpaceConversionFailed)
+        }
+        return .success(snapshot)
     }
 }
 

--- a/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorCacheIntegrationTests.swift
@@ -15,6 +15,20 @@ final class ColorCacheIntegrationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testComponentResultsIgnoreAndDoNotReplaceLegacyCacheEntries() throws {
+        let color = try fixedTestColor(components: [1, 0, 0, 1])
+        ColorCache.shared.cacheHSLComponents(for: color, hue: 0.4, saturation: 0.2, lightness: 0.3)
+        ColorCache.shared.cacheLABComponents(for: color, L: 12, a: 34, b: 56)
+
+        let result = color.componentConversionResults()
+        XCTAssertEqual(try result.hsl.get(), HSLComponents(hue: 0, saturation: 1, lightness: 0.5))
+        XCTAssertEqual(try result.lab.get().lightness, 53.2407941413, accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(color.hslComponents()).hue, 0.4)
+        XCTAssertEqual(try XCTUnwrap(color.labComponents()).L, 12)
+        ColorCache.shared.clearCache()
+        XCTAssertEqual(try result.lab.get(), try color.componentConversionResults().lab.get())
+    }
+
     func testNearbyInterpolationAmountsMatchColdResultsInBothCallOrders() throws {
         let first = try fixedTestColor(components: [0.8, 0.1, 0.2, 1])
         let second = try fixedTestColor(components: [0.1, 0.6, 0.9, 1])

--- a/Tests/ColorKitTests/Utilities/ColorComponentConversionResultsTests.swift
+++ b/Tests/ColorKitTests/Utilities/ColorComponentConversionResultsTests.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+final class ColorComponentConversionResultsTests: XCTestCase {
+    func testPrimaryAndSecondaryBoundedCoordinates() throws {
+        let samples: [(rgb: [CGFloat], hue: Double, cmyk: CMYKComponents)] = [
+            ([1, 0, 0, 1], 0, CMYKComponents(cyan: 0, magenta: 1, yellow: 1, key: 0)),
+            ([1, 1, 0, 1], 1.0 / 6, CMYKComponents(cyan: 0, magenta: 0, yellow: 1, key: 0)),
+            ([0, 1, 0, 1], 1.0 / 3, CMYKComponents(cyan: 1, magenta: 0, yellow: 1, key: 0)),
+            ([0, 1, 1, 1], 0.5, CMYKComponents(cyan: 1, magenta: 0, yellow: 0, key: 0)),
+            ([0, 0, 1, 1], 2.0 / 3, CMYKComponents(cyan: 1, magenta: 1, yellow: 0, key: 0)),
+            ([1, 0, 1, 1], 5.0 / 6, CMYKComponents(cyan: 0, magenta: 1, yellow: 0, key: 0))
+        ]
+        for sample in samples {
+            let result = try fixedTestColor(components: sample.rgb).componentConversionResults()
+            XCTAssertEqual(try result.hsl.get(), HSLComponents(hue: sample.hue, saturation: 1, lightness: 0.5))
+            XCTAssertEqual(try result.hsb.get(), HSBComponents(hue: sample.hue, saturation: 1, brightness: 1))
+            XCTAssertEqual(try result.cmyk.get(), sample.cmyk)
+        }
+    }
+
+    func testFixedSRGBReferenceCoordinates() throws {
+        // Independent reference calculations, using the documented D65 matrix and exact LAB constants.
+        // Values are pinned here, not obtained from either production conversion helper.
+        let samples: [(rgb: [CGFloat], xyz: [Double], lab: [Double])] = [
+            ([1, 0, 0, 1], [41.24564, 21.26729, 1.93339], [53.2407941413, 80.0924595964, 67.2031965159]),
+            ([0.2, 0.4, 0.6, 1], [11.8642593355, 12.5052672891, 31.9193194523], [42.0081455965, -0.1517081972, -32.8460361881]),
+            ([-0.5, 0, 0, 1], [-8.8282638255, -4.5520750066, -0.4138250006], [-41.1187249389, -184.4063430255, -64.9752096631]),
+            ([-0.5, 0.2, 0.7, 1], [0.4388744237, 1.0487760246, 42.5532798427], [9.3913371873, -22.5017887795, -102.4466144904])
+        ]
+        for sample in samples {
+            let color = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: sample.rgb)
+            let result = color.componentConversionResults()
+            let xyz = try result.xyz.get()
+            let lab = try result.lab.get()
+            for (actual, expected) in zip([xyz.x, xyz.y, xyz.z], sample.xyz) {
+                XCTAssertEqual(actual, expected, accuracy: 1e-9)
+            }
+            for (actual, expected) in zip([lab.lightness, lab.a, lab.b], sample.lab) {
+                XCTAssertEqual(actual, expected, accuracy: 1e-9)
+            }
+        }
+    }
+
+    func testSuccessfulZeroCoordinatesAndWhiteScale() throws {
+        for value: CGFloat in [0, 0.5, 1] {
+            let result = try fixedTestColor(components: [value, value, value, 1]).componentConversionResults()
+            XCTAssertEqual(try result.hsl.get(), HSLComponents(hue: 0, saturation: 0, lightness: Double(value)))
+            XCTAssertEqual(try result.hsb.get(), HSBComponents(hue: 0, saturation: 0, brightness: Double(value)))
+            XCTAssertEqual(try result.cmyk.get(), CMYKComponents(cyan: 0, magenta: 0, yellow: 0, key: Double(1 - value)))
+            XCTAssertEqual(try result.srgba.get().alpha, 1)
+            XCTAssertNoThrow(try result.hex.get())
+            XCTAssertNoThrow(try result.lab.get())
+            if value == 1 {
+                XCTAssertEqual(try result.xyz.get().z, 108.883, accuracy: 1e-9)
+            } else if value == 0 {
+                XCTAssertEqual(try result.lab.get(), LABComponents(lightness: 0, a: 0, b: 0))
+            }
+        }
+    }
+
+    func testAlphaIsPreservedWithoutCompositing() throws {
+        let reference = try fixedTestColor(components: [1, 0, 0, 1]).componentConversionResults()
+        for (alpha, suffix): (CGFloat, String) in [(0, "00"), (0.5, "80"), (1, "FF")] {
+            let result = try fixedTestColor(components: [1, 0, 0, alpha]).componentConversionResults()
+            XCTAssertEqual(try result.srgba.get(), SRGBAComponents(red: 1, green: 0, blue: 0, alpha: Double(alpha)))
+            XCTAssertEqual(try result.hex.get(), "#FF0000" + suffix)
+            XCTAssertEqual(try result.hsl.get(), try reference.hsl.get())
+            XCTAssertEqual(try result.hsb.get(), try reference.hsb.get())
+            XCTAssertEqual(try result.cmyk.get(), try reference.cmyk.get())
+            XCTAssertEqual(try result.xyz.get(), try reference.xyz.get())
+            XCTAssertEqual(try result.lab.get(), try reference.lab.get())
+        }
+    }
+
+    func testEquivalentProfiledInputsAndGrayscale() throws {
+        let original = try fixedTestColor(components: [0.2, 0.4, 0.6, 0.5])
+        let source = try XCTUnwrap(original.cgColor)
+        let reference = original.componentConversionResults()
+        for name in [CGColorSpace.linearSRGB, CGColorSpace.displayP3, CGColorSpace.adobeRGB1998] {
+            let space = try XCTUnwrap(CGColorSpace(name: name))
+            let converted = try XCTUnwrap(source.converted(to: space, intent: .relativeColorimetric, options: nil))
+            let result = Color(converted).componentConversionResults()
+            XCTAssertEqual(try result.srgba.get().red, try reference.srgba.get().red, accuracy: 1e-5)
+            XCTAssertEqual(try result.lab.get().lightness, try reference.lab.get().lightness, accuracy: 0.001)
+            XCTAssertEqual(try result.lab.get().a, try reference.lab.get().a, accuracy: 0.001)
+            XCTAssertEqual(try result.lab.get().b, try reference.lab.get().b, accuracy: 0.001)
+            XCTAssertEqual(try result.hex.get(), "#33669980")
+            XCTAssertNoThrow(try result.cmyk.get())
+            XCTAssertNoThrow(try result.hsl.get())
+            XCTAssertNoThrow(try result.hsb.get())
+        }
+        let gray = try fixedTestColor(space: CGColorSpace.linearGray, components: [0.25, 0.5]).componentConversionResults()
+        XCTAssertEqual(try gray.srgba.get().red, 0.5370987304831942, accuracy: 1e-6)
+        XCTAssertEqual(try gray.hsl.get().saturation, 0)
+        XCTAssertEqual(try gray.hex.get(), "#89898980")
+    }
+
+    func testWideGamutAndOverflowPreserveIndependentSuccesses() throws {
+        let p3 = try fixedTestColor(space: CGColorSpace.displayP3, components: [1, 0, 0, 0.5])
+        let result = p3.componentConversionResults()
+        XCTAssertGreaterThan(try result.srgba.get().red, 1)
+        XCTAssertLessThan(try result.srgba.get().green, 0)
+        assertBoundedUnavailable(result)
+        // Independent Display P3 red XYZ from its primaries, allowing platform/matrix rounding.
+        let xyz = try result.xyz.get()
+        XCTAssertEqual(xyz.x, 48.657095, accuracy: 0.02)
+        XCTAssertEqual(xyz.y, 22.897456, accuracy: 0.02)
+        XCTAssertEqual(xyz.z, 0, accuracy: 0.02)
+        XCTAssertNoThrow(try result.lab.get())
+
+        let extreme = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: [.greatestFiniteMagnitude, 0.4, 0.6, 1])
+        let overflow = extreme.componentConversionResults()
+        XCTAssertEqual(try overflow.srgba.get().red, Double.greatestFiniteMagnitude)
+        assertBoundedUnavailable(overflow)
+        assertFailure(overflow.xyz, .nonfiniteResult)
+        assertFailure(overflow.lab, .nonfiniteResult)
+    }
+
+    func testStrictEndpointsAndStableBoundedArithmetic() throws {
+        for red: CGFloat in [-.leastNonzeroMagnitude, CGFloat(1).nextUp] {
+            let result = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: [red, 0.4, 0.6, 1]).componentConversionResults()
+            assertBoundedUnavailable(result)
+        }
+        let nearWhite = try fixedTestColor(components: [1, CGFloat(1).nextDown, CGFloat(1).nextDown, 1]).componentConversionResults()
+        XCTAssertEqual(try nearWhite.hsl.get().saturation, 1)
+        let nearBlack = try fixedTestColor(components: [.leastNonzeroMagnitude, 0, 0, 1]).componentConversionResults()
+        XCTAssertEqual(try nearBlack.cmyk.get(), CMYKComponents(cyan: 0, magenta: 1, yellow: 1, key: 1))
+        let nearRed = try fixedTestColor(components: [1, 0, .leastNonzeroMagnitude, 1]).componentConversionResults()
+        XCTAssertEqual(try nearRed.hsl.get().hue, 0)
+        XCTAssertEqual(try nearRed.hsb.get().hue, 0)
+        let rounded = try fixedTestColor(components: [0.5, 0.25, 0.125, 0.5]).componentConversionResults()
+        XCTAssertEqual(try rounded.hex.get(), "#80402080")
+    }
+
+    func testObservableResolutionIssuesPropagateToEveryField() throws {
+        for color in [Color.blue, .primary, .secondary] {
+            XCTAssertNil(color.cgColor)
+            assertAllUnavailable(color.componentConversionResults(), .unresolvedInput)
+        }
+        assertAllUnavailable(try patternTestColor().componentConversionResults(), .unsupportedColorModel)
+        let cmyk = try fixedTestColor(space: CGColorSpaceCreateDeviceCMYK(), components: [0.2, 0.4, 0.6, 0.1, 1])
+        assertAllUnavailable(cmyk.componentConversionResults(), .unsupportedColorModel)
+        for index in 0..<4 {
+            for invalid: CGFloat in [.nan, .infinity, -.infinity] {
+                var components: [CGFloat] = [0.2, 0.4, 0.6, 0.5]
+                components[index] = invalid
+                // Core Graphics may sanitize infinite alpha; NaN alpha survives construction.
+                if index == 3, !invalid.isNaN { continue }
+                let color = try fixedTestColor(space: CGColorSpace.extendedSRGB, components: components)
+                assertAllUnavailable(color.componentConversionResults(), .invalidComponents)
+            }
+        }
+    }
+
+    func testExplicitAppearanceCaptureProducesStableFixedResults() throws {
+        #if canImport(UIKit)
+        let dynamic = UIColor { $0.userInterfaceStyle == .dark ? .white : .black }
+        let lightColor = Color(dynamic.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light)).cgColor)
+        let darkColor = Color(dynamic.resolvedColor(with: UITraitCollection(userInterfaceStyle: .dark)).cgColor)
+        #else
+        let dynamic = NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? .white : .black
+        }
+        func capture(_ name: NSAppearance.Name) throws -> Color {
+            let appearance = try XCTUnwrap(NSAppearance(named: name))
+            var fixed: CGColor?
+            appearance.performAsCurrentDrawingAppearance {
+                fixed = dynamic.usingColorSpace(.extendedSRGB)?.cgColor
+            }
+            return Color(try XCTUnwrap(fixed))
+        }
+        let lightColor = try capture(.aqua)
+        let darkColor = try capture(.darkAqua)
+        #endif
+        assertAllUnavailable(Color(dynamic).componentConversionResults(), .unresolvedInput)
+        let light = lightColor.componentConversionResults()
+        let dark = darkColor.componentConversionResults()
+        XCTAssertEqual(try light.srgba.get().red, 0, accuracy: 1e-6)
+        XCTAssertEqual(try dark.srgba.get().red, 1, accuracy: 1e-6)
+        XCTAssertEqual(try lightColor.componentConversionResults().srgba.get(), try light.srgba.get())
+    }
+
+    private func assertBoundedUnavailable(_ result: ColorComponentConversionResults, file: StaticString = #filePath, line: UInt = #line) {
+        assertFailure(result.hsl, .outOfSRGBGamut, file: file, line: line)
+        assertFailure(result.hsb, .outOfSRGBGamut, file: file, line: line)
+        assertFailure(result.cmyk, .outOfSRGBGamut, file: file, line: line)
+        assertFailure(result.hex, .outOfSRGBGamut, file: file, line: line)
+    }
+
+    private func assertAllUnavailable(_ result: ColorComponentConversionResults, _ issue: ColorConversionIssue, file: StaticString = #filePath, line: UInt = #line) {
+        assertFailure(result.srgba, issue, file: file, line: line)
+        assertFailure(result.hsl, issue, file: file, line: line)
+        assertFailure(result.hsb, issue, file: file, line: line)
+        assertFailure(result.cmyk, issue, file: file, line: line)
+        assertFailure(result.xyz, issue, file: file, line: line)
+        assertFailure(result.lab, issue, file: file, line: line)
+        assertFailure(result.hex, issue, file: file, line: line)
+    }
+
+    private func assertFailure<Value>(_ result: Result<Value, ColorConversionIssue>, _ issue: ColorConversionIssue, file: StaticString = #filePath, line: UInt = #line) {
+        guard case .failure(let actual) = result else {
+            return XCTFail("Expected \(issue)", file: file, line: line)
+        }
+        XCTAssertEqual(actual, issue, file: file, line: line)
+    }
+}

--- a/docs/adr/0014-require-fixed-inputs-for-component-results.md
+++ b/docs/adr/0014-require-fixed-inputs-for-component-results.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+---
+
+# Require fixed inputs for component-conversion results
+
+ColorKit 3.1's new result-bearing component-conversion entry point requires fixed
+color components and does not consult ambient appearance; callers must explicitly
+resolve named or dynamic colors that lack fixed components, including `.blue` when
+applicable. This makes the input context explicit without introducing a ColorKit
+appearance framework, at the cost of caller-side resolution for these colors.
+Existing appearance-based APIs retain their shipped behavior.

--- a/docs/adr/0015-use-correct-extended-conversion-math-in-new-results.md
+++ b/docs/adr/0015-use-correct-extended-conversion-math-in-new-results.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+---
+
+# Use correct extended conversion math in new results
+
+The new component-conversion API uses signed extended-sRGB decoding and exact CIE
+LAB constants, while preserving every legacy calculation and its existing call paths.
+This supports correct negative-channel conversion without changing shipped behavior;
+document that new XYZ/LAB results can differ from legacy values for negative channels
+and near the old rounded LAB breakpoint.

--- a/docs/adr/0016-preserve-gamut-in-component-results.md
+++ b/docs/adr/0016-preserve-gamut-in-component-results.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+---
+
+# Preserve gamut in component-conversion results
+
+The new component-conversion API preserves extended sRGBA and finite XYZ/LAB, while
+HSL, HSB, CMYK, and Hex report `outOfSRGBGamut` whenever a resolved RGB channel is
+outside `0...1`, with no clipping, tolerance, or endpoint snapping. This keeps the
+available representations tied to the same color, accepting that even a tiny platform
+conversion overshoot near white can make bounded representations unavailable.
+Legacy conversion behavior, including HSL clipping, remains unchanged.

--- a/docs/design/component-conversion-results.md
+++ b/docs/design/component-conversion-results.md
@@ -1,0 +1,173 @@
+# ColorKit 3.1 component-conversion results
+
+Status: agreed design; implementation authorized through the ship-change workflow.
+
+Review fixed point: `1e1e8b6e5f52a67d46a257c17099952204604bb7` (`v3.0.1`),
+fetched from `origin/main` on 2026-09-07. Work proceeds on
+`chore/conversion-result-design` in an isolated worktree. The baseline was clean;
+the initial design documents were the only uncommitted inputs to implementation.
+
+## Agreed contract
+
+`Color.componentConversionResults()` returns independent results derived from one
+fixed, uncomposited sRGBA snapshot. Preserve each successful representation even
+when others are unavailable. All shipped APIs and legacy behavior remain intact;
+no deprecations, replacements, new legacy enum cases, or deployment changes.
+
+```swift
+let color = Color(.displayP3, red: 1, green: 0, blue: 0)
+let conversions = color.componentConversionResults()
+if case .success(let lab) = conversions.lab {
+    print(lab.lightness, lab.a, lab.b)
+}
+switch conversions.hex {
+case .success(let hex): print(hex)
+case .failure(.outOfSRGBGamut): print("Hex would require clipping")
+case .failure(let issue): print(issue)
+}
+```
+
+The public aggregate is `ColorComponentConversionResults`, with seven read-only
+fields using standard Swift `Result<Payload, ColorConversionIssue>`:
+
+| Field | Payload | Units and limits |
+| --- | --- | --- |
+| `srgba` | `SRGBAComponents` | Nonlinear extended sRGB; finite RGB, separate unpremultiplied alpha 0–1 |
+| `hsl` | `HSLComponents` | Hue in turns `[0,1)`; saturation/lightness fractions 0–1 |
+| `hsb` | `HSBComponents` | HSV, named HSB; hue in turns `[0,1)`, saturation/brightness fractions 0–1 |
+| `cmyk` | `CMYKComponents` | Algebraic sRGB complements, fractions 0–1; no printer/ink profile |
+| `xyz` | `XYZComponents` | D65 XYZ, reference-white Y = 100; finite, not bounded to 100 |
+| `lab` | `LABComponents` | D65 L*a*b*, white (95.047,100,108.883); finite extended coordinates, no forced bounds |
+| `hex` | `String` | Uppercase `#RRGGBBAA`; nearest byte, ties upward |
+
+Numeric fields use `Double`. Payloads are immutable `Sendable, Equatable` data with
+internal construction. Aggregate construction is internal to protect the shared-input
+invariant. There is no aggregate success flag or throwing conversion method.
+
+### Input and appearance
+
+Accept the existing fixed resolver's source set: `Color.cgColor` with an RGB or
+grayscale model, valid component shape, finite components, and valid alpha. Convert
+other eligible profiles to extended nonlinear sRGB using Core Graphics relative
+colorimetric intent and no options; preserve existing sRGB/extended-sRGB values
+directly. Linear RGB, grayscale, P3, and convertible RGB profiles qualify regardless
+of cache eligibility. Patterns, CMYK sources, and other models do not.
+
+Named and dynamic colors without fixed components are unavailable, including `.blue`
+when it lacks `cgColor`. The caller explicitly captures an appearance-specific fixed
+color first. No ambient appearance fallback, light/dark Boolean, or new ColorKit
+appearance framework is introduced. Missing fixed components do not prove that
+appearance resolution will help. See [ADR 0014](../adr/0014-require-fixed-inputs-for-component-results.md).
+
+UIKit clients capture `Color(UIColor(color).resolvedColor(with: traits).cgColor)`.
+AppKit clients obtain `NSColor(color).usingColorSpace(.extendedSRGB)?.cgColor` inside
+the chosen appearance's `performAsCurrentDrawingAppearance` block, then wrap a
+non-nil value in `Color`. Both recipes still allow unsupported capture/conversion.
+The results retain coordinates, not the originating appearance or color identity.
+Platform profile conversion is not a bitwise cross-OS reproducibility promise.
+
+### Gamut, alpha, and numerical correctness
+
+Preserve extended sRGBA and finite XYZ/LAB. HSL, HSB, CMYK, and Hex report
+`outOfSRGBGamut` whenever RGB is outside `0...1`, even by one representable step.
+No clipping, tolerance, or endpoint snapping; platform-converted white can lose
+bounded representations. See [ADR 0016](../adr/0016-preserve-gamut-in-component-results.md).
+
+Alpha remains in sRGBA and Hex; other coordinates describe uncomposited RGB and
+omit opacity. Transparent red keeps red's coordinates. Invalid alpha makes the
+shared snapshot unavailable for every field. Platform-sanitized values are judged
+as received; ColorKit cannot reconstruct invalid values erased during construction.
+Hex quantization loses at most `0.5/255` per channel and is not gamut mapping.
+
+HSL/HSB use zero hue and saturation for achromatic colors. HSB brightness is maximum
+RGB. CMYK uses `K = 1 - max`, `(max-channel)/max` for the complements, and
+`(0,0,0,1)` for black. It does not predict printed appearance. Near-black arithmetic
+must not divide by the rounded quantity `1-K`; HSL saturation near white must avoid
+cancellation, and hue rounded to one turn is normalized to zero.
+
+XYZ uses signed extended-sRGB decoding: `c/12.92` for `abs(c) <= 0.04045`, otherwise
+`sign(c) * ((abs(c)+0.055)/1.055)^2.4`. Keep the documented sRGB/D65 matrix and use
+exact LAB constants `epsilon = 216/24389`, `kappa = 24389/27`. The LAB transform is
+`cbrt(t)` above epsilon, otherwise `(kappa*t+16)/116`, after reference-white scaling.
+Finite XYZ is required for LAB; reject nonfinite arithmetic outcomes independently.
+
+These new calculations deliberately differ from the legacy negative-channel decoder
+and rounded LAB constants. Preserve the legacy arithmetic and call paths. See
+[ADR 0015](../adr/0015-use-correct-extended-conversion-math-in-new-results.md) and
+[W3C's conversion reference](https://www.w3.org/TR/css-color-4/#color-conversion-code).
+Coordinates are not HDR luminance or evidence of contrast/perceptual similarity;
+legacy clamping initializers are not general inverses of extended coordinates.
+
+### Diagnostics
+
+One observable blocker per representation, with deterministic precedence:
+
+1. Missing fixed source: `unresolvedInput`.
+2. Missing or unsupported source color model: `unsupportedColorModel`.
+3. Malformed/nonfinite source components or invalid alpha: `invalidComponents`.
+4. Failed target conversion or invalid converted snapshot: `colorSpaceConversionFailed`.
+5. After successful resolution, bounded fields outside sRGB: `outOfSRGBGamut`.
+6. Nonfinite conversion arithmetic, including LAB's XYZ dependency: `nonfiniteResult`.
+
+A resolution failure propagates to every field; later failures affect only dependent
+representations. Cases are typed diagnostics, not localized messages or guessed
+platform causes. Successful zero coordinates remain distinguishable from absence.
+
+## Minimal implementation
+
+Use one internal result-bearing fixed resolver; keep its existing optional method
+as an adapter that discards the issue. Preserve its guard ordering, conversion target,
+intent, and snapshot validation. One conversion call produces one snapshot, one
+shared gamut check, and one XYZ result used by LAB. Standard `map`/`flatMap` propagate
+failures. Store the seven results; do not consult mutable legacy caches.
+
+Keep plain payloads and small arithmetic helpers together. No conversion protocol,
+strategy registry, appearance layer, lazy state, or cache is needed. One bounded
+conversion produces HSL, HSB, CMYK, and Hex, sharing extrema and hue while protecting
+rounding edge cases; the legacy HSL helper is unchanged. Corrected XYZ/LAB arithmetic
+is isolated from legacy consumers. Changing internal structure is acceptable only with unchanged legacy
+outcomes demonstrated by validation.
+
+## Evidence and acceptance
+
+The baseline [aggregate converter](../../Sources/ColorKit/Utilities/ColorSpaceConverter.swift)
+mixes appearance RGB/HSL, unchecked platform HSB extraction, strict CMYK, and
+XYZ/LAB derived from the RGB fallback. Existing `ColorComponents` does not identify
+substitutions. Standalone LAB uses fixed extended sRGBA; Hex/CMYK require bounded
+sRGB. Atomic contrast/comparison result types are not suitable aggregate models for
+independent conversions. [ADR 0012](../adr/0012-resolve-hsl-through-the-lenient-policy.md)
+protects legacy HSL clipping; [ADR 0013](../adr/0013-preserve-shipped-3x-client-contracts.md)
+protects shipped 3.x clients. Neither is reversed here.
+
+Implementation acceptance cases:
+
+- Fixed sRGB primaries, black, white, gray, hue wrapping, near-white saturation,
+  and near-black CMYK; legitimate zeros are successful values.
+- Independent signed XYZ/LAB fixtures, exact LAB constants, and direct P3 reference
+  values. The legacy LAB test's production-helper oracle is insufficient for new math.
+- Equivalent interior sRGB, linear RGB, grayscale, P3, and Adobe RGB inputs, with
+  justified numerical tolerances and source profiles preserved in fixtures.
+- Partial success for P3/extended input and arithmetic overflow; strict endpoints
+  and adjacent out-of-range values; Hex rounding including alpha.
+- Alpha zero, partial, and one: RGB is preserved, non-alpha coordinates agree, no
+  compositing; invalid inputs tested directly when construction sanitizes them.
+- Named/dynamic inputs and explicit light/dark fixed captures; patterns, unsupported
+  models, nonfinite inputs, and observable platform failures diagnosed consistently.
+- Cache poisoning cannot affect new results or be overwritten by them.
+- Existing resolver/conversion behavior on iOS and macOS, preserved released clients,
+  new nonisolated method references, and actual README/DocC client examples compile.
+
+The owning public reference is the [Color Spaces article](../../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results).
+English/Spanish READMEs, adoption guidance, and the Unreleased changelog accompany
+the implementation. Naming was reviewed using the
+[Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/);
+standard `Result` is a design choice, not a guideline mandate.
+
+## Open questions and validation limits
+
+No core design decision remains open. Shipping still requires the documented gate
+and independent review. Platform conversion failures must not be fabricated merely
+to exercise a diagnostic; inability to construct a particular failure fixture must
+be reported as a coverage limit. Minimum-deployment compilation is not runtime proof
+on those OS versions. If validation requires changing an agreed contract, return
+that specific decision to the maintainer.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -12,11 +12,11 @@ ROOT = Path(__file__).resolve().parents[1]
 DOCC = "Sources/ColorKit/Documentation.docc/"
 # Explicit inventory makes deleting a marker a failure, not a silent coverage loss.
 README_EXAMPLES = {"accessible-palette", "enhancement", "catalog", "previews", "comparison", "budget",
-                   "hsl", "cmyk", "lab"}
+                   "hsl", "cmyk", "lab", "component-results"}
 EXAMPLES = {
     "README.md": README_EXAMPLES,
     "README.es-ES.md": README_EXAMPLES,
-    DOCC + "Color-Spaces-article.md": {"rgb", "hsl", "lab"},
+    DOCC + "Color-Spaces-article.md": {"rgb", "hsl", "lab", "component-results"},
     DOCC + "Theming-article.md": {"dynamic-theme"},
     DOCC + "Accessibility-article.md": {"contrast", "enhancement", "assessed-palette"},
     DOCC + "Utilities-article.md": {"similarity"},
@@ -27,6 +27,12 @@ MARKER = re.compile(r"<!-- swift-example: ([a-z0-9-]+) -->")
 # Postconditions use the actual README variables, not copied example implementations.
 # Renaming a variable requires updating its check; removing a result cannot pass silently.
 README_CHECKS = {
+    "component-results": """
+guard case .success(let coordinates) = conversions.lab else { failExample("P3 red must retain LAB") }
+checkExample(coordinates.lightness.isFinite && coordinates.a.isFinite && coordinates.b.isFinite,
+    "Expected finite D65 LAB")
+guard case .failure(.outOfSRGBGamut) = conversions.hex else { failExample("P3 red must decline Hex") }
+""",
     "hsl": """
 guard let hsl else { failExample("Named red must resolve to HSL") }
 checkExample([hsl.hue, hsl.saturation, hsl.lightness].allSatisfy {
@@ -105,6 +111,7 @@ def check(derived_data):
     compiler = ["xcrun", "swiftc", "-swift-version", "6", "-sdk", sdk,
                 "-target", f"{architecture}-apple-macosx12.0"]
     modules = derived_data / "Build/Products/Debug"
+    run(*compiler, "-typecheck", "-I", modules, ROOT / "scripts/fixtures/component_results.swift")
     with tempfile.TemporaryDirectory(prefix="colorkit-examples-") as temporary:
         scratch = Path(temporary)
         files = []
@@ -142,6 +149,7 @@ def check(derived_data):
         run(*compiler, "-parse-as-library",
             ROOT / "Sources/ColorKit/PreviewCatalog/ThemeCodeGenerator.swift",
             ROOT / "Sources/ColorKit/Utilities/ResolvedSRGBA.swift",
+            ROOT / "Sources/ColorKit/Utilities/ColorComponentConversionResults.swift",
             ROOT / "scripts/fixtures/emit_theme.swift", "-o", emitter)
         for fixture in ("named", "fixed"):
             generated = scratch / f"theme_{fixture}.swift"

--- a/scripts/fixtures/component_results.swift
+++ b/scripts/fixtures/component_results.swift
@@ -1,0 +1,27 @@
+import ColorKit
+import SwiftUI
+
+// Compile as an ordinary nonisolated public client, independently of @MainActor examples.
+func componentResultsClient(_ color: Color) -> ColorComponentConversionResults {
+    let typed: () -> ColorComponentConversionResults = color.componentConversionResults
+    let inferred = color.componentConversionResults
+    let result = typed()
+    let _: Result<SRGBAComponents, ColorConversionIssue> = result.srgba
+    let _: Result<HSLComponents, ColorConversionIssue> = result.hsl
+    let _: Result<HSBComponents, ColorConversionIssue> = result.hsb
+    let _: Result<CMYKComponents, ColorConversionIssue> = result.cmyk
+    let _: Result<XYZComponents, ColorConversionIssue> = result.xyz
+    let _: Result<LABComponents, ColorConversionIssue> = result.lab
+    let _: Result<String, ColorConversionIssue> = result.hex
+    requireSendable(result)
+    if case .failure(let issue) = result.srgba {
+        switch issue {
+        case .unresolvedInput, .unsupportedColorModel, .invalidComponents,
+             .colorSpaceConversionFailed, .outOfSRGBGamut, .nonfiniteResult:
+            break
+        }
+    }
+    return inferred()
+}
+
+private func requireSendable<Value: Sendable>(_ value: Value) {}

--- a/scripts/tests/test_documentation.py
+++ b/scripts/tests/test_documentation.py
@@ -33,7 +33,7 @@ class DocumentationContract(unittest.TestCase):
                 self.extract(text)
 
     def test_behavior_checks_are_required_in_both_readme_inventories(self):
-        self.assertEqual(set(DOCS.README_CHECKS), {"hsl", "cmyk", "lab"})
+        self.assertEqual(set(DOCS.README_CHECKS), {"hsl", "cmyk", "lab", "component-results"})
         for path in ("README.md", "README.es-ES.md"):
             self.assertLessEqual(DOCS.README_CHECKS.keys(), DOCS.EXAMPLES[path])
 


### PR DESCRIPTION
## Summary

Add `Color.componentConversionResults()` so callers can retain available component representations without interpreting zero fallbacks as successful conversions. Every field derives from one fixed sRGBA snapshot; P3 red, for example, retains XYZ/LAB while Hex reports `outOfSRGBGamut`.

## Changes

- Return independent Swift `Result` values for sRGBA, HSL, HSB, CMYK, XYZ, LAB, and Hex, with typed diagnostics.
- Share one fixed resolver and gamut check, calculate XYZ once for LAB, and preserve all legacy APIs and numerical behavior through the existing optional adapter.
- Use signed extended-sRGB decoding, exact LAB constants, and stable bounded arithmetic at hue/white/black edges.
- Document the agreed contract and adoption path in ADRs, DocC, English/Spanish READMEs, migration guidance, and the Unreleased changelog; compile actual public examples and a nonisolated client fixture.

## Alternatives considered

Wrapping the old aggregate would retain mixed appearance and gamut policies plus ambiguous fallback coordinates. A new appearance framework, conversion registry, or custom availability abstraction would add unnecessary surface. The implementation uses direct arithmetic and standard `Result` instead.

## Notes

No deprecations, removals, version bump, UI changes, or release are included. Named/dynamic colors without fixed components require caller-side resolution. Strict gamut checks deliberately reject even tiny endpoint overshoots. CMYK is algebraic, not profile-based printing output. New XYZ/LAB values can differ from legacy values for negative channels and near the old LAB breakpoint.

The platform `colorSpaceConversionFailed` branch has no fabricated failure fixture; invalid-input, unsupported-model, gamut, and overflow paths are exercised. Minimum-deployment compilation does not establish runtime validation on the oldest supported OS. No speedup claim is made.

## Screenshots

Not applicable; no UI changes.

## Testing

- PASS: canonical `scripts/run_tests.sh` iOS/macOS matrix, including serialized cache/theme integration suites.
- PASS: preserved 3.0.0 client compilation and public API comparisons on iOS/macOS via `scripts/check_compatibility.py`.
- PASS: strict SwiftLint and DocC with warnings treated as errors.
- PASS: 35 compiled public examples, eight executed README conversion examples, generated theme code, and a nonisolated result client at macOS 12 and iOS 14 deployment targets.
- PASS: 25 tooling tests and five Release benchmark correctness tests.
- Independent worktree review identified missing non-red hue-sector assertions; primary/secondary fixtures were added and the full matrix passed again.
