### PR TITLE
feat(previews): Demonstrate component conversion results

### DIFF
--- a/Sources/ColorKit/PreviewCatalog/ComponentConversionPreview.swift
+++ b/Sources/ColorKit/PreviewCatalog/ComponentConversionPreview.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+/// A small client of the result API; the existing color-space preview remains independent.
+struct ComponentConversionPreview: View {
+    @State private var sample = ComponentConversionSample.black
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Picker("Input color", selection: $sample) {
+                ForEach(ComponentConversionSample.allCases) { sample in
+                    Text(sample.rawValue).tag(sample)
+                }
+            }
+            .pickerStyle(MenuPickerStyle())
+            .padding()
+
+            ComponentConversionInspection(sample: sample)
+        }
+        .navigationTitle("Component Results")
+    }
+}
+
+enum ComponentConversionSample: String, CaseIterable, Identifiable {
+    case black = "Fixed sRGB black"
+    case wideGamut = "Display P3 red"
+    case unresolved = "Dynamic primary"
+
+    var id: String { rawValue }
+
+    var color: Color {
+        switch self {
+        case .black: return Color(.sRGB, red: 0, green: 0, blue: 0)
+        case .wideGamut: return Color(.displayP3, red: 1, green: 0, blue: 0)
+        case .unresolved: return .primary
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .black:
+            return "Zero is a valid component value. Black has zero hue by convention and 100% CMYK black."
+        case .wideGamut:
+            return "This red is outside sRGB. Extended sRGBA and finite XYZ/LAB remain available; bounded conversions would require clipping."
+        case .unresolved:
+            return "The swatch follows appearance, but .primary has no fixed components here. Resolve it for an explicit appearance before converting."
+        }
+    }
+}
+
+struct ComponentConversionInspection: View {
+    let sample: ComponentConversionSample
+
+    var body: some View {
+        // One call supplies every row, including partial failures.
+        let rows = ComponentConversionRow.rows(for: sample.color.componentConversionResults())
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                sample.color
+                    .frame(height: 44)
+                    .overlay(Rectangle().stroke(Color.secondary, lineWidth: 1))
+                    .accessibilityHidden(true)
+                Text(sample.rawValue).font(.title2).accessibilityAddTraits(.isHeader)
+                Text(sample.explanation)
+                Text("All values share one fixed, uncomposited sRGBA snapshot. No automatic appearance resolution or gamut clipping. Alpha is retained only in sRGBA and Hex.")
+                    .font(.footnote)
+                ForEach(rows) { row in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(row.title).font(.headline)
+                        Text(row.isAvailable ? "Available" : "Unavailable").font(.subheadline)
+                        Text(row.units).font(.footnote)
+                        Text(row.detail).font(.body)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityAddTraits(.isStaticText)
+                    .accessibilityLabel(Text(row.title))
+                    .accessibilityValue(Text("\(row.isAvailable ? "Available" : "Unavailable"). \(row.units). \(row.detail)"))
+                    .accessibilityIdentifier("conversion-\(row.title)")
+                    Divider()
+                }
+                Text("Values are rounded for display. XYZ and LAB are coordinates, not percentages. CMYK uses no printer profile. The swatch is not a display-accuracy guarantee.")
+                    .font(.footnote)
+            }
+            .padding()
+            .accessibilityElement(children: .contain)
+        }
+    }
+}
+
+/// Presentation only: failures never enter the numeric formatter.
+struct ComponentConversionRow: Identifiable {
+    let title: String
+    let units: String
+    let detail: String
+    let isAvailable: Bool
+    var id: String { title }
+
+    init<Value>(_ title: String, units: String, result: Result<Value, ColorConversionIssue>, format: (Value) -> String) {
+        self.title = title
+        self.units = units
+        switch result {
+        case .success(let value):
+            detail = format(value)
+            isAvailable = true
+        case .failure(let issue):
+            detail = Self.explanation(for: issue)
+            isAvailable = false
+        }
+    }
+
+    static func rows(for result: ColorComponentConversionResults) -> [Self] {
+        [
+            Self("sRGBA", units: "Extended sRGB fractions; alpha 0–1", result: result.srgba) {
+                "Red \(number($0.red)), green \(number($0.green)), blue \(number($0.blue)), alpha \(number($0.alpha))"
+            },
+            Self("HSL", units: "Hue in degrees; saturation and lightness 0–100%", result: result.hsl) {
+                "Hue \(number($0.hue * 360))°, saturation \(number($0.saturation * 100))%, lightness \(number($0.lightness * 100))%"
+            },
+            Self("HSB", units: "Hue in degrees; saturation and brightness 0–100%", result: result.hsb) {
+                "Hue \(number($0.hue * 360))°, saturation \(number($0.saturation * 100))%, brightness \(number($0.brightness * 100))%"
+            },
+            Self("CMYK", units: "Algebraic components shown as 0–100%", result: result.cmyk) {
+                "Cyan \(number($0.cyan * 100))%, magenta \(number($0.magenta * 100))%, yellow \(number($0.yellow * 100))%, black \(number($0.key * 100))%"
+            },
+            Self("XYZ", units: "D65 reference white Y = 100; unbounded", result: result.xyz) {
+                "X \(number($0.x)), Y \(number($0.y)), Z \(number($0.z))"
+            },
+            Self("LAB", units: "CIE L*a*b*, D65; extended values are unbounded", result: result.lab) {
+                "L* \(number($0.lightness)), a* \(number($0.a)), b* \(number($0.b))"
+            },
+            Self("Hex", units: "sRGB #RRGGBBAA; rounded 8-bit channels", result: result.hex) { $0 }
+        ]
+    }
+
+    private static func number(_ value: Double) -> String {
+        // NumberFormatter supports the catalog's iOS 14 deployment target.
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 3
+        return formatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+
+    static func explanation(for issue: ColorConversionIssue) -> String {
+        switch issue {
+        case .unresolvedInput:
+            return "No fixed components. Named or dynamic colors may need explicit appearance resolution."
+        case .unsupportedColorModel:
+            return "The source needs an RGB or grayscale color space."
+        case .invalidComponents:
+            return "Components must be finite and alpha must be between 0 and 1."
+        case .colorSpaceConversionFailed:
+            return "The platform could not convert this input to extended sRGB."
+        case .outOfSRGBGamut:
+            return "Outside sRGB: this representation would require clipping."
+        case .nonfiniteResult:
+            return "This conversion could not produce finite coordinates."
+        }
+    }
+}
+
+#Preview {
+    ComponentConversionPreview()
+}

--- a/Sources/ColorKit/PreviewCatalog/MainCatalogView.swift
+++ b/Sources/ColorKit/PreviewCatalog/MainCatalogView.swift
@@ -58,6 +58,7 @@ public struct MainCatalogView: View {
 
 enum PreviewFeature: String, CaseIterable, Identifiable {
     case colorSpaces = "Color Spaces"
+    case componentResults = "Component Results"
     case blending = "Color Blending"
     case gradients = "Gradient Generation"
     case accessibility = "Accessibility Tools"
@@ -76,6 +77,8 @@ enum PreviewFeature: String, CaseIterable, Identifiable {
         switch self {
         case .colorSpaces:
             return "Explore color space conversions and representations"
+        case .componentResults:
+            return "Inspect available components and individual conversion limitations"
         case .blending:
             return "Test different color blending modes and effects"
         case .gradients:
@@ -101,6 +104,8 @@ enum PreviewFeature: String, CaseIterable, Identifiable {
         switch self {
         case .colorSpaces:
             return "paintpalette"
+        case .componentResults:
+            return "list.bullet.rectangle"
         case .blending:
             return "circle.lefthalf.filled"
         case .gradients:
@@ -126,6 +131,8 @@ enum PreviewFeature: String, CaseIterable, Identifiable {
         switch self {
         case .colorSpaces:
             ColorSpacePreview()
+        case .componentResults:
+            ComponentConversionPreview()
         case .blending:
             BlendingPreview()
         case .gradients:

--- a/Tests/ColorKitTests/Utilities/ComponentConversionPreviewTests.swift
+++ b/Tests/ColorKitTests/Utilities/ComponentConversionPreviewTests.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import XCTest
+
+@testable import ColorKit
+
+@MainActor
+final class ComponentConversionPreviewTests: XCTestCase {
+    func testBlackShowsAvailableZerosAndUnits() {
+        let rows = rows(for: .black)
+        XCTAssertEqual(rows.map(\.title), ["sRGBA", "HSL", "HSB", "CMYK", "XYZ", "LAB", "Hex"])
+        XCTAssertTrue(rows.allSatisfy(\.isAvailable))
+        XCTAssertEqual(rows[1].detail, "Hue 0°, saturation 0%, lightness 0%")
+        XCTAssertEqual(rows[3].detail, "Cyan 0%, magenta 0%, yellow 0%, black 100%")
+        XCTAssertEqual(rows[4].detail, "X 0, Y 0, Z 0")
+        XCTAssertFalse(rows[4].detail.contains("%"))
+        XCTAssertFalse(rows[5].detail.contains("%"))
+        XCTAssertEqual(rows[6].detail, "#000000FF")
+    }
+
+    func testHueTurnsAndFractionsAreConvertedForDisplay() {
+        let result = Color(.sRGB, red: 0, green: 1, blue: 0, opacity: 0).componentConversionResults()
+        let rows = ComponentConversionRow.rows(for: result)
+        XCTAssertEqual(rows[1].detail, "Hue 120°, saturation 100%, lightness 50%")
+        XCTAssertEqual(rows[2].detail, "Hue 120°, saturation 100%, brightness 100%")
+        XCTAssertEqual(rows[6].detail, "#00FF0000")
+    }
+
+    func testWideGamutPreservesSuccessfulRowsAndExplainsEachFailure() {
+        let rows = rows(for: .wideGamut)
+        XCTAssertEqual(rows.filter(\.isAvailable).map(\.title), ["sRGBA", "XYZ", "LAB"])
+        XCTAssertEqual(rows.filter { !$0.isAvailable }.map(\.title), ["HSL", "HSB", "CMYK", "Hex"])
+        for row in rows where !row.isAvailable {
+            XCTAssertEqual(row.detail, "Outside sRGB: this representation would require clipping.")
+        }
+    }
+
+    func testUnresolvedInputNeverUsesNumericFallbacks() {
+        let rows = rows(for: .unresolved)
+        XCTAssertTrue(rows.allSatisfy { !$0.isAvailable })
+        for row in rows {
+            XCTAssertEqual(row.detail, "No fixed components. Named or dynamic colors may need explicit appearance resolution.")
+        }
+        let issues: [ColorConversionIssue] = [
+            .unresolvedInput, .unsupportedColorModel, .invalidComponents,
+            .colorSpaceConversionFailed, .outOfSRGBGamut, .nonfiniteResult
+        ]
+        XCTAssertEqual(Set(issues.map(ComponentConversionRow.explanation)).count, issues.count)
+        for issue in issues {
+            let row = ComponentConversionRow("Test", units: "", result: Result<Int, ColorConversionIssue>.failure(issue)) { _ in
+                XCTFail("An unavailable result must never enter the numeric formatter")
+                return "0"
+            }
+            XCTAssertFalse(row.isAvailable)
+            XCTAssertFalse(row.detail.isEmpty)
+        }
+    }
+
+    func testHostedLightAndDarkInspectionStates() async throws {
+        for sample in ComponentConversionSample.allCases {
+            for scheme in [ColorScheme.light, .dark] {
+                try await capture(sample: sample, scheme: scheme)
+            }
+        }
+    }
+
+    func testHostedAccessibilityTextSize() async throws {
+        try await capture(sample: .wideGamut, scheme: .dark, size: .accessibilityExtraExtraExtraLarge)
+    }
+
+    private func rows(for sample: ComponentConversionSample) -> [ComponentConversionRow] {
+        ComponentConversionRow.rows(for: sample.color.componentConversionResults())
+    }
+
+    #if !os(macOS)
+    private func scrollView(in view: UIView) -> UIScrollView? {
+        (view as? UIScrollView) ?? view.subviews.lazy.compactMap { self.scrollView(in: $0) }.first
+    }
+    #endif
+
+    private func capture(sample: ComponentConversionSample, scheme: ColorScheme, size: ContentSizeCategory = .large) async throws {
+        // Capture the real inspection content at a narrow width and enough height to review every row.
+        let height: CGFloat = size == .large ? 3_000 : 4_000
+        let appeared = expectation(description: "Inspection appeared")
+        let root = ComponentConversionInspection(sample: sample)
+            .environment(\.colorScheme, scheme)
+            .environment(\.sizeCategory, size)
+            .background(scheme == .dark ? Color.black : Color.white)
+            .onAppear { appeared.fulfill() }
+        let name = "\(sample)-\(scheme)-\(size)"
+        #if os(macOS)
+        let controller = NSHostingController(rootView: root)
+        let window = NSWindow(contentViewController: controller)
+        window.isReleasedWhenClosed = false
+        window.setContentSize(NSSize(width: 390, height: height))
+        window.appearance = NSAppearance(named: scheme == .dark ? .darkAqua : .aqua)
+        window.orderFront(nil)
+        defer { window.close() }
+        await fulfillment(of: [appeared], timeout: 3)
+        controller.view.layoutSubtreeIfNeeded()
+        let bitmap = try XCTUnwrap(controller.view.bitmapImageRepForCachingDisplay(in: controller.view.bounds))
+        controller.view.cacheDisplay(in: controller.view.bounds, to: bitmap)
+        let image = NSImage(size: controller.view.bounds.size)
+        image.addRepresentation(bitmap)
+        #else
+        let controller = UIHostingController(rootView: root)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: height))
+        window.overrideUserInterfaceStyle = scheme == .dark ? .dark : .light
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+        await fulfillment(of: [appeared], timeout: 3)
+        controller.view.layoutIfNeeded()
+        let renderer = UIGraphicsImageRenderer(bounds: controller.view.bounds)
+        let image = renderer.image { context in
+            controller.view.layer.render(in: context.cgContext)
+        }
+        if size != .large {
+            let scroll = try XCTUnwrap(scrollView(in: controller.view))
+            XCTAssertGreaterThan(scroll.contentSize.height, scroll.bounds.height)
+            XCTAssertLessThanOrEqual(scroll.contentSize.width, scroll.bounds.width)
+            scroll.setContentOffset(CGPoint(x: 0, y: scroll.contentSize.height - scroll.bounds.height), animated: false)
+            controller.view.layoutIfNeeded()
+            let bottom = renderer.image { context in controller.view.layer.render(in: context.cgContext) }
+            let attachment = XCTAttachment(image: bottom)
+            attachment.name = "\(name)-scrolled-bottom"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+        #endif
+        let attachment = XCTAttachment(image: image)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/docs/design/component-conversion-example.md
+++ b/docs/design/component-conversion-example.md
@@ -1,0 +1,34 @@
+# Component Results catalog example
+
+Dependency: approved contract in `component-conversion-results.md` and implementation
+commit `4282e79ecc8712b90195032bbfe7c4fab1975da3` (PR #62).
+Branch `feature/conversion-result-example` starts at that commit.
+
+Open **ColorKit Catalog → Component Results**. Select fixed sRGB black for genuine
+zeros, Display P3 red for partial availability, or dynamic primary for unavailable
+fixed components. The example calls `componentConversionResults()` once per
+inspection and switches on each field independently. It does not change existing
+public previews or conversion APIs.
+
+Hue turns become degrees; bounded fractions become percentages. Extended sRGBA,
+XYZ and LAB retain their coordinate scales. Failed fields show explanations and
+never pass through the numeric formatter. All fields describe the same fixed,
+uncomposited snapshot; appearance-dependent input requires caller-side resolution.
+
+Focused tests cover units, zero, independent failures, diagnostics, and hosted
+light/dark rendering on iOS and macOS, including accessibility text size. Review
+captures belong in ignored `.build/` storage and PR attachments, not Git.
+
+Validation (2026-09-07): six focused tests passed on iOS 26.5 (iPhone 17
+simulator) and macOS 26.6.2. Run with `scripts/run_tests.sh` and
+`-only-testing:ColorKitTests/ComponentConversionPreviewTests -parallel-testing-enabled NO`.
+Strict SwiftLint and `git diff --check` passed. The catalog and sample picker were
+also exercised in native review hosts on both platforms. Accessibility labels and
+values were inspected in the running apps; this was not a full spoken VoiceOver audit.
+
+Final captures: `.build/review/accepted/ios/` and `.build/review/accepted/macos/`.
+Each contains all three samples in both appearances. The iOS accessibility-size
+capture includes the scrolled bottom, with a test asserting vertical scrolling
+and no horizontal overflow. macOS does not scale these fonts via iOS Dynamic Type.
+The tall hosted captures expose the inspection content for review; they are not
+claims about physical screen size or display gamut accuracy.


### PR DESCRIPTION
## Summary

Add **ColorKit Catalog → Component Results**, a focused example showing successful values alongside individual unavailable conversions. Fixed black demonstrates genuine zeros, Display P3 red demonstrates partial availability, and dynamic primary explains why fixed components require explicit caller-side resolution.

## Changes

- Add one catalog destination without migrating existing public previews.
- Format hue turns as degrees and bounded fractions as percentages; preserve extended sRGBA and XYZ/LAB coordinate scales.
- Give every representation its own availability, units, value or explanation, and accessibility label/value.
- Add focused tests and record the pinned implementation dependency.

## Alternatives considered

Migrating the existing color-space preview would broaden scope and change legacy behavior. Implicit appearance resolution, gamut clipping, or numeric fallbacks would conceal the approved result contract.

## Notes

The implementation dependency #62 is merged. This branch starts at implementation commit `4282e79ecc8712b90195032bbfe7c4fab1975da3` and is updated from `main`; the PR diff now contains only the example, its catalog entry, focused tests, and dependency note. The example adds no conversion API signatures or appearance framework. Review the example-only changes through [the dependency comparison](https://github.com/agisilaos/ColorKit/compare/4282e79ecc8712b90195032bbfe7c4fab1975da3...feature/conversion-result-example).

The inspection uses one fixed, uncomposited snapshot. CMYK has no printer profile; the swatch makes no display-gamut accuracy claim. Accessibility labels and values were inspected in native hosts; a full spoken VoiceOver audit was not performed.

## Screenshots

Hosted captures from iOS 26.5 and macOS 26.6.2. These tall captures expose the inspection content; they do not represent physical screen dimensions. Review images are attached here and remain outside Git.

<details>
<summary>iOS — Fixed black: genuine zeros</summary>

| Light | Dark |
| --- | --- |
| ![iOS, Fixed black: genuine zeros, light appearance](https://github.com/user-attachments/assets/86a58589-cb3e-42bc-9a05-814e4decd181) | ![iOS, Fixed black: genuine zeros, dark appearance](https://github.com/user-attachments/assets/e9517771-1692-4354-bba9-8425f77ac7f5) |

</details>

<details>
<summary>iOS — Display P3 red: partial availability</summary>

| Light | Dark |
| --- | --- |
| ![iOS, Display P3 red: partial availability, light appearance](https://github.com/user-attachments/assets/c7893f6b-3f53-4d66-ac53-5d0f9dad8fa8) | ![iOS, Display P3 red: partial availability, dark appearance](https://github.com/user-attachments/assets/21525143-9407-4593-b9e4-c40eda7a168e) |

</details>

<details>
<summary>iOS — Dynamic primary: unavailable input</summary>

| Light | Dark |
| --- | --- |
| ![iOS, Dynamic primary: unavailable input, light appearance](https://github.com/user-attachments/assets/fa790e31-5e46-40ba-92ea-dd897841ce4b) | ![iOS, Dynamic primary: unavailable input, dark appearance](https://github.com/user-attachments/assets/b902fba1-a25a-4cfd-ac52-d79b97d60495) |

</details>

<details>
<summary>macOS — Fixed black: genuine zeros</summary>

| Light | Dark |
| --- | --- |
| ![macOS, Fixed black: genuine zeros, light appearance](https://github.com/user-attachments/assets/8e34c654-6142-4953-9a93-ffd7602279f8) | ![macOS, Fixed black: genuine zeros, dark appearance](https://github.com/user-attachments/assets/ff5dcf46-713f-4dd9-8048-382bfda204ad) |

</details>

<details>
<summary>macOS — Display P3 red: partial availability</summary>

| Light | Dark |
| --- | --- |
| ![macOS, Display P3 red: partial availability, light appearance](https://github.com/user-attachments/assets/292b490b-a8ad-4c9d-8446-dc14fd987e65) | ![macOS, Display P3 red: partial availability, dark appearance](https://github.com/user-attachments/assets/43905c67-f4a4-4ebc-8f74-b927c1fdfe53) |

</details>

<details>
<summary>macOS — Dynamic primary: unavailable input</summary>

| Light | Dark |
| --- | --- |
| ![macOS, Dynamic primary: unavailable input, light appearance](https://github.com/user-attachments/assets/e5e36558-0501-4d5f-89b5-90573141c0f9) | ![macOS, Dynamic primary: unavailable input, dark appearance](https://github.com/user-attachments/assets/5139854a-0a74-46d5-8fb5-8d56c4037789) |

</details>

<details>
<summary>iOS — largest accessibility text size, top and scrolled bottom</summary>

![Top: Display P3 partial results at largest accessibility text size](https://github.com/user-attachments/assets/ab1e23c6-264e-4ea6-b80a-c65e0280f9d8)

![Scrolled bottom: Display P3 partial results at largest accessibility text size](https://github.com/user-attachments/assets/e9e7648c-645c-435d-8cd3-2ab51522c969)

</details>

## Testing

- PASS: six focused tests on macOS 26.6.2 and iOS 26.5 (iPhone 17 simulator), rerun before publication using `scripts/run_tests.sh` with `-only-testing:ColorKitTests/ComponentConversionPreviewTests -parallel-testing-enabled NO`.
- PASS: strict SwiftLint and `git diff --check`.
- Covered genuine zeros, hue/percentage formatting, retained alpha-zero channels, P3 partial failures, unresolved input, all six issue explanations, light/dark hosted rendering, and vertical scrolling without horizontal overflow at the largest iOS accessibility text size.
- Exercised catalog navigation and sample selection in native iOS/macOS review hosts and inspected accessibility labels. macOS does not scale these fonts through iOS Dynamic Type.
- Tall hosted captures expose all inspection rows for review; they do not represent physical screen dimensions.


