### PR TITLE
test(conversion): Validate integrated component conversion results

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -12,7 +12,7 @@ swift test --package-path Benchmarks -c release
 python3 Benchmarks/run.py --output .build/benchmark-results/first
 ```
 
-The output directory must be new. The command builds first, then runs seven named
+The output directory must be new. The command builds first, then runs eight named
 scenarios serially, using a fresh process for every scenario/cache pair in each
 of three runs. Each process performs 10 untimed warm-up requests and records 10
 samples of 100 individually timed requests. Override these modest defaults with
@@ -24,6 +24,7 @@ settings. The report records power information but does not control system load.
 
 | Scenario | Complete request |
 | --- | --- |
+| `component-results-red` | All seven component-conversion results for opaque sRGB red (cache unused) |
 | `hsl-red` | Convert opaque sRGB red to HSL |
 | `lab-red` | Convert opaque sRGB red to D65 LAB |
 | `comparison-black-white` | Full comparison, including CIEDE2000, RGB/HSL deltas, contrast, and compliance |

--- a/Benchmarks/Sources/ColorKitBenchmarks/Scenarios.swift
+++ b/Benchmarks/Sources/ColorKitBenchmarks/Scenarios.swift
@@ -9,6 +9,39 @@ func scenarios() -> [Scenario] {
     var cases = [
         Scenario(
             description: ScenarioDescription(
+                id: "component-results-red",
+                purpose: "Convert fixed red to all seven independent component results",
+                inputs: "sRGB RGBA (1, 0, 0, 1)",
+                settings: "componentConversionResults()",
+                expected: "Seven successes; red coordinates and #FF0000FF",
+                unit: "aggregate conversion",
+                modes: [.unused]
+            ),
+            input: red,
+            operation: { $0.componentConversionResults() },
+            validate: { value in
+                let rgb = try value.srgba.get()
+                let hsl = try value.hsl.get()
+                let hsb = try value.hsb.get()
+                let cmyk = try value.cmyk.get()
+                let xyz = try value.xyz.get()
+                let lab = try value.lab.get()
+                let hex = try value.hex.get()
+                try requireFixture(
+                    rgb.red == 1 && rgb.green == 0 && rgb.blue == 0 && rgb.alpha == 1
+                        && hsl.hue == 0 && hsl.saturation == 1 && hsl.lightness == 0.5
+                        && hsb.hue == 0 && hsb.saturation == 1 && hsb.brightness == 1
+                        && cmyk.cyan == 0 && cmyk.magenta == 1 && cmyk.yellow == 1 && cmyk.key == 0
+                        && abs(xyz.x - 41.24564) < 0.001 && abs(xyz.y - 21.26729) < 0.001
+                        && abs(xyz.z - 1.93339) < 0.001 && abs(lab.lightness - 53.2408) < 0.001
+                        && abs(lab.a - 80.0925) < 0.001 && abs(lab.b - 67.2032) < 0.001
+                        && hex == "#FF0000FF",
+                    "Incorrect aggregate red conversion"
+                )
+            }
+        ),
+        Scenario(
+            description: ScenarioDescription(
                 id: "hsl-red",
                 purpose: "Convert fixed red to HSL components",
                 inputs: "sRGB RGBA (1, 0, 0, 1)",

--- a/Benchmarks/Tests/ColorKitBenchmarksTests/MeasurementTests.swift
+++ b/Benchmarks/Tests/ColorKitBenchmarksTests/MeasurementTests.swift
@@ -49,7 +49,7 @@ struct ScenarioTests {
     @Test("Every named fixture validates in all supported cache modes")
     func fixtures() throws {
         let cases = scenarios()
-        #expect(cases.count == 7)
+        #expect(cases.count == 8)
         #expect(Set(cases.map(\.description.id)).count == cases.count)
         for scenario in cases {
             for mode in scenario.description.modes {

--- a/Tests/ColorKitTests/Utilities/PublicComponentConversionTests.swift
+++ b/Tests/ColorKitTests/Utilities/PublicComponentConversionTests.swift
@@ -1,0 +1,66 @@
+import ColorKit
+import SwiftUI
+import Testing
+
+/// Independent caller checks: deliberately no access to internal construction or resolver helpers.
+struct PublicComponentConversionTests {
+    @Test(arguments: [0.0, 0.5, 1.0])
+    func transparentGreenRetainsCoordinates(alpha: Double) throws {
+        let result = Color(.sRGB, red: 0, green: 1, blue: 0, opacity: alpha).componentConversionResults()
+        let rgb = try result.srgba.get()
+        #expect(rgb.red == 0 && rgb.green == 1 && rgb.blue == 0 && rgb.alpha == alpha)
+        let hsl = try result.hsl.get()
+        #expect(hsl.hue == 1.0 / 3 && hsl.saturation == 1 && hsl.lightness == 0.5)
+        let hsb = try result.hsb.get()
+        #expect(hsb.hue == hsl.hue && hsb.saturation == 1 && hsb.brightness == 1)
+        let cmyk = try result.cmyk.get()
+        #expect(cmyk.cyan == 1 && cmyk.magenta == 0 && cmyk.yellow == 1 && cmyk.key == 0)
+        let xyz = try result.xyz.get()
+        // Independently pinned green column of the agreed sRGB/D65 matrix, Y = 100 scale.
+        #expect(abs(xyz.x - 35.75761) < 1e-9)
+        #expect(abs(xyz.y - 71.51522) < 1e-9)
+        #expect(abs(xyz.z - 11.91920) < 1e-9)
+        let lab = try result.lab.get()
+        #expect(abs(lab.lightness - 87.7347223528) < 1e-9)
+        #expect(abs(lab.a + 86.1827164205) < 1e-9)
+        #expect(abs(lab.b - 83.1793205027) < 1e-9)
+        #expect(try result.hex.get() == "#00FF00" + (alpha == 0 ? "00" : alpha == 0.5 ? "80" : "FF"))
+    }
+
+    @Test
+    func partialAvailabilityAndRetainedSnapshot() throws {
+        let color = Color(.displayP3, red: 1, green: 0, blue: 0, opacity: 0.5)
+        let result = color.componentConversionResults()
+        let rgb = try result.srgba.get()
+        #expect(rgb.red > 1 && rgb.green < 0 && rgb.alpha == 0.5)
+        #expect(result.hsl == .failure(.outOfSRGBGamut))
+        #expect(result.hsb == .failure(.outOfSRGBGamut))
+        #expect(result.cmyk == .failure(.outOfSRGBGamut))
+        #expect(result.hex == .failure(.outOfSRGBGamut))
+        #expect(try result.xyz.get().x.isFinite)
+        #expect(try result.lab.get().lightness.isFinite)
+        // Reconstruct only the published snapshot; all representations must agree.
+        let space = try #require(CGColorSpace(name: CGColorSpace.extendedSRGB))
+        let cgColor = try #require(CGColor(colorSpace: space, components: [rgb.red, rgb.green, rgb.blue, rgb.alpha]))
+        let replay = Color(cgColor).componentConversionResults()
+        #expect(result.srgba == replay.srgba)
+        #expect(result.xyz == replay.xyz)
+        #expect(result.lab == replay.lab)
+        #expect(result.hex == replay.hex)
+    }
+
+    @Test
+    func completeUnavailabilityIsNotSuccessfulZero() throws {
+        let result = Color.primary.componentConversionResults()
+        #expect(result.srgba == .failure(.unresolvedInput))
+        #expect(result.hsl == .failure(.unresolvedInput))
+        #expect(result.hsb == .failure(.unresolvedInput))
+        #expect(result.cmyk == .failure(.unresolvedInput))
+        #expect(result.xyz == .failure(.unresolvedInput))
+        #expect(result.lab == .failure(.unresolvedInput))
+        #expect(result.hex == .failure(.unresolvedInput))
+        let black = Color(.sRGB, red: 0, green: 0, blue: 0).componentConversionResults()
+        #expect(try black.lab.get().lightness == 0)
+        #expect(try black.hex.get() == "#000000FF")
+    }
+}

--- a/Validation/ComponentConsumer/.gitignore
+++ b/Validation/ComponentConsumer/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/Validation/ComponentConsumer/Package.swift
+++ b/Validation/ComponentConsumer/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "ComponentConsumer",
+    platforms: [.macOS(.v12)],
+    dependencies: [.package(name: "ColorKit", path: "../..")],
+    targets: [.executableTarget(
+        name: "ComponentConsumer",
+        dependencies: [.product(name: "ColorKit", package: "ColorKit")]
+    )]
+)

--- a/Validation/ComponentConsumer/README.md
+++ b/Validation/ComponentConsumer/README.md
@@ -1,0 +1,22 @@
+# Component conversion consumer validation
+
+A separate macOS SwiftPM executable consumes the repository's library product with
+ordinary public imports. It hosts its own SwiftUI inspection view in an AppKit
+window; it does not import or instantiate the catalog implementation.
+
+From the repository root:
+
+```sh
+swift run --package-path Validation/ComponentConsumer -c release
+```
+
+The smoke run checks 7/7, 3/7, and 0/7 available representations for fixed black,
+P3 red, and dynamic primary, lays out each inspection, then exercises the documented
+AppKit light/dark capture recipe. A failure exits unsuccessfully. Pass
+`--interactive` to retain the final window for manual inspection.
+This is consumer integration evidence, not a visual or accessibility audit.
+
+The public behavioral assertions live in
+`Tests/ColorKitTests/Utilities/PublicComponentConversionTests.swift` and run on both
+platforms with the normal test runner. The existing nonisolated compilation fixture
+remains `scripts/fixtures/component_results.swift`.

--- a/Validation/ComponentConsumer/Sources/ComponentConsumer/Consumer.swift
+++ b/Validation/ComponentConsumer/Sources/ComponentConsumer/Consumer.swift
@@ -1,0 +1,75 @@
+import AppKit
+import ColorKit
+import SwiftUI
+
+// A separate consuming app: one aggregate per inspection, with independent display decisions.
+private struct Inspection: View {
+    let result: ColorComponentConversionResults
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Consumer color inspection").font(.headline)
+            row("sRGBA", result.srgba)
+            row("HSL (turns, fractions)", result.hsl)
+            row("HSB (turns, fractions)", result.hsb)
+            row("CMYK (fractions)", result.cmyk)
+            row("XYZ (D65, Y = 100)", result.xyz)
+            row("LAB (D65)", result.lab)
+            row("Hex", result.hex)
+        }.padding()
+    }
+
+    private func row<Value>(_ title: String, _ value: Result<Value, ColorConversionIssue>) -> some View {
+        let text: String
+        switch value {
+        case .success(let coordinates): text = String(describing: coordinates)
+        case .failure(let issue): text = "Unavailable: \(issue)"
+        }
+        return Text("\(title): \(text)")
+    }
+}
+
+@main
+private enum Consumer {
+    @MainActor static func main() throws {
+        let app = NSApplication.shared
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 500),
+                              styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        let samples: [(String, Color, Int)] = [
+            ("fixed black", Color(.sRGB, red: 0, green: 0, blue: 0), 7),
+            ("P3 red", Color(.displayP3, red: 1, green: 0, blue: 0), 3),
+            ("dynamic primary", .primary, 0)
+        ]
+        for (name, color, expected) in samples {
+            let result = color.componentConversionResults()
+            func available<Value>(_ value: Result<Value, ColorConversionIssue>) -> Int {
+                if case .success = value { return 1 }
+                return 0
+            }
+            let count = available(result.srgba) + available(result.hsl) + available(result.hsb)
+                + available(result.cmyk) + available(result.xyz) + available(result.lab) + available(result.hex)
+            precondition(count == expected, "Unexpected availability for \(name)")
+            window.contentView = NSHostingView(rootView: Inspection(result: result))
+            window.makeKeyAndOrderFront(nil)
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            print("PASS consumer hosted \(name): \(count)/7 available")
+        }
+        // Exercise the documented caller-side AppKit appearance capture recipe.
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            var fixed: CGColor?
+            NSAppearance(named: name)?.performAsCurrentDrawingAppearance {
+                fixed = NSColor(Color.primary).usingColorSpace(.extendedSRGB)?.cgColor
+            }
+            guard let fixed else { fatalError("Appearance capture unavailable") }
+            let result = Color(fixed).componentConversionResults()
+            _ = try result.srgba.get()
+            _ = try result.lab.get()
+            window.contentView = NSHostingView(rootView: Inspection(result: result))
+            window.contentView?.layoutSubtreeIfNeeded()
+            print("PASS consumer capture \(name.rawValue)")
+        }
+        if CommandLine.arguments.contains("--interactive") { app.run() }
+        window.orderOut(nil)
+    }
+}

--- a/docs/validation/component-conversion-2026-09-08/README.md
+++ b/docs/validation/component-conversion-2026-09-08/README.md
@@ -1,162 +1,95 @@
 # Integrated component-conversion validation — 2026-09-08
 
-**PASS within the requested feature-validation scope. No production defect found.**
-This is evidence for considering 3.1, not release preflight or publication approval.
+**PASS within the requested feature scope. No production defect found.**
+Candidate `bc46e3e1e264d8b7d420cb607d546bf7d014b9e3` matched fetched `origin/main`
+with #62 and #63 integrated. This is evidence for considering 3.1, not release approval.
+Changes add public tests, a separate consumer fixture, benchmark coverage, and evidence;
+production behavior, deployment requirements, version metadata, and frozen clients are unchanged.
 
-Candidate: `bc46e3e1e264d8b7d420cb607d546bf7d014b9e3`, verified equal to fetched
-`origin/main`, including #62 and #63. Started clean and created
-`chore/conversion-result-validation`. Production sources, package deployment
-requirements, frozen 3.0.0 clients, and version metadata remain unchanged.
-The only changes are public validation tests, a separate consuming app, one
-benchmark scenario with its inventory/README update, and this evidence.
+Review covered repository guidance, the [approved contract](../../design/component-conversion-results.md),
+[catalog example](../../design/component-conversion-example.md), ADRs 0012–0016,
+implementation/resolver, existing tests, and adoption material.
 
-Reviewed AGENTS.md, CONTRIBUTING.md, CONTEXT.md, repository agent guidance,
-component-conversion-results.md, component-conversion-example.md, ADRs 0012–0016,
-release-client compatibility policy, implementation/resolver, existing focused
-fixtures, inspector, and adoption material. Public calls were also checked against
-the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
-No API naming or contract contradiction was found.
+## Findings and follow-up
 
-## Findings ordered by caller impact
+- **P2 — protect clients after publication.** The mutable nonisolated fixture
+  `scripts/fixtures/component_results.swift` is compiled by the documentation job,
+  but the 3.0.0 baseline cannot protect APIs introduced later. After 3.1 is published,
+  preserve that fixture and representative payload getter/equality calls under
+  `Compatibility/Clients/3.1.0/`, pinning `revision` to the full released commit.
+  Use the [existing compatibility gate](../../../Compatibility/README.md); no unreleased baseline was registered.
+- **P3 — retain extra validation where useful.** This audit's iOS example compilation
+  and separate consumer smoke run are not additional CI requirements.
+- **Documentation:** DocC, English/Spanish README sections, and MIGRATION.md agree
+  with the implementation. Only ordinary release wording and frozen-fixture guidance
+  need follow-up after publication; no adoption material needs rewriting.
 
-1. **P2, post-release compatibility protection:** the current nonisolated fixture
-   (`scripts/fixtures/component_results.swift`) is compiled by the documentation
-   job but is mutable with current examples. The frozen 3.0.0 API baseline cannot
-   detect removal of an API that did not exist in that release. Once 3.1 is actually
-   published, add `Compatibility/Clients/3.1.0/revision` pinned to its full released
-   commit and preserve the existing fixture as a separate client in that directory.
-   Include representative payload getter/equality use in the release client coverage;
-   do not rely on evolving README examples for that promise. The existing checker
-   discovers release directories, builds each pinned release and candidate on both
-   platforms, compares APIs, and rejects edits to established fixtures relative to
-   the PR base. No baseline was registered now, and no 3.0.0 client was edited.
-2. **P3, repeatability of extra validation:** current CI compiles examples and the
-   nonisolated fixture on macOS. This audit additionally compiled them for iOS, but
-   that extra command and the separate consumer app are not new CI requirements.
-   Consider retaining those checks when adopting the released fixture; this is a
-   validation-maintenance opportunity, not an observed caller failure.
+## Checks performed
 
-**Documentation follow-up:** no component-contract correction is required in DocC,
-the English/Spanish README sections, or MIGRATION.md. They agree on independent
-availability, fixed input, strict gamut, alpha, scales, and deliberate legacy math
-differences. Preserve their existing content. After publication, perform ordinary
-release wording updates and document the newly frozen fixture. Historical paths
-and dates in the approved design/example documents describe their original work.
+All checks passed with Xcode 26.5 / Swift 6.3.2 on macOS 26.6.2 and, where applicable,
+an iPhone 17 simulator running iOS 26.5.
 
-## Checks and results
-
-| Check | Result |
+| Check | Evidence |
 | --- | --- |
-| `python3 scripts/check_compatibility.py` | PASS: frozen 3.0.0 clients against release and candidate, full API digester including deprecated API, macOS and iOS Simulator; Swift 6 mode, client targets macOS 12 / iOS 14 |
-| Existing focused behavioral suites on macOS 26.6.2 and iPhone 17 / iOS 26.5 Simulator | PASS: 71 XCTest tests on each platform, serialized |
-| `PublicComponentConversionTests`, ordinary `import ColorKit` | PASS on both platforms: 3 Swift Testing functions, including 3 alpha argument cases (5 invocations) |
-| Separate `Validation/ComponentConsumer` Release executable | PASS: hosted own SwiftUI view with 7/7, 3/7, 0/7 availability, then AppKit aqua/darkAqua capture |
-| DocC `--warnings-as-errors` | PASS |
-| Existing `scripts/check_documentation.py` | PASS: 35 actual marked examples compile, 8 actual English/Spanish README conversion examples execute; generated theme output compiles |
-| Same extracted examples plus existing nonisolated fixture, iOS public module | PASS: 35 examples and fixture typecheck in Swift 6 with iOS 14 Simulator deployment target |
-| `swift test --package-path Benchmarks -c release` | PASS: 5 tests, including all 8 scenarios and supported cache modes |
-| Strict SwiftLint / `git diff --check` | PASS |
+| Released clients/API | Frozen 3.0.0 clients compile against release and candidate on both platforms; API digester includes deprecated API; Swift 6, macOS 12 / iOS 14 client targets |
+| Focused behavior | 71 existing XCTest tests per platform, serialized |
+| Independent public imports | 3 Swift Testing functions / 5 invocations per platform: transparent green references, P3 snapshot replay, and unavailability versus black |
+| Separate macOS consumer | Own hosted SwiftUI inspection: 7/7, 3/7, 0/7 availability, plus aqua/darkAqua capture |
+| Documentation | DocC warnings-as-errors; 35 actual marked examples and existing nonisolated fixture compile on both platforms; 8 README examples execute on macOS; generated theme output compiles |
+| Benchmark / hygiene | 5 Release tests cover all 8 scenarios and cache modes; strict SwiftLint and diff checks pass |
 
-Focused XCTest suites: `ColorComponentConversionResultsTests`, `ResolvedSRGBATests`,
+Existing suites: `ColorComponentConversionResultsTests`, `ResolvedSRGBATests`,
 `ColorSpaceConverterTests`, `HSLResolutionTests`, `LABResolutionTests`,
 `ColorCacheIntegrationTests`, and `ComponentConversionPreviewTests`.
-The six catalog tests are supporting evidence, including hosted appearance/layout
-checks; the separate consumer does not instantiate catalog types.
+Together with `PublicComponentConversionTests`, these cover units/ranges, signed
+XYZ/LAB, alpha without compositing, byte rounding, adjacent gamut endpoints,
+near-white/subnormal arithmetic, grayscale/linear/P3/Adobe profiles, overflow,
+unsupported/nonfinite input, fixed versus dynamic capture, cache isolation, and legacy behavior.
+Source inspection confirms one resolution and one XYZ calculation feeding LAB;
+public snapshot replay checks agreement, not the exact invocation count.
 
-Coverage combines existing numerical tests with independent public-client checks:
-primaries, legitimate zero, signed XYZ/LAB reference values, reference-white scales,
-turns/fractions, alpha 0/0.5/1 without compositing, byte rounding, strict adjacent
-endpoints, near-white HSL, subnormal CMYK/hue, grayscale/linear/P3/Adobe profiles,
-extended gamut and overflow partial success, named/dynamic unavailable input,
-light/dark fixed capture, unsupported models and surviving nonfinite input,
-cache poisoning and unchanged legacy paths. Public tests independently pin green
-XYZ/LAB coordinates, preserve transparent RGB, distinguish all-field unavailability
-from black, and reconstruct a P3 result's published sRGBA to verify XYZ/LAB agreement.
-Source inspection confirms one `resolveResult` call, one bounded branch, one XYZ
-calculation feeding LAB, immutable stored outputs, and no legacy-cache consultation.
-Replay equality alone is not proof of the exact resolver invocation count.
+## Release measurement
 
-## Measurements
+`component-results-red` measures one complete seven-field request for opaque sRGB red,
+cache `unused`, with whole-result consumption. Apple M4 Pro (Mac16,7), arm64 Release,
+AC power; this task's builds finished before sampling, but system load/thermals were uncontrolled.
 
-Added `component-results-red`: one complete public aggregate request for fixed
-opaque sRGB red, all seven fields validated outside timing, whole result consumed.
-ColorKit cache mode is `unused`. Harness timing/preparation code was not changed.
+| Median sample mean | Sample-mean range | Median control |
+| ---: | ---: | ---: |
+| 1,682.5 ns/request | 1,589.2–1,810.9 ns | 27.1 ns/request |
 
-Apple M4 Pro (Mac16,7), macOS 26.6.2 (25G83), Xcode 26.5 (17F42), Swift 6.3.2,
-arm64 Release, AC power. This task's builds/tests finished before sampling;
-other system activity and thermals were not controlled.
+Three processes × 10 samples × 100 requests, plus 10 untimed warmups/process.
+Request/control order alternates; control (~1.6%) is approximate and never subtracted.
+Timing includes clocks, barriers, dispatch, conversion, and result lifetime;
+input construction, preparation, validation, storage, and reporting are excluded.
+[Raw data](raw.json) retain all 39 scenario/cache/run records, environment and executable hash;
+[full summary](benchmark-summary.md) retains reference scenarios.
+[Disassembly](disassembly.txt) confirms the aggregate call and consumption survive inside
+the timed loop. These are machine-specific reference measurements, not profiling
+attribution, thresholds, or speedup comparisons with different legacy contracts.
 
-| Workload | Median sample mean | Sample-mean range | Median control |
-| --- | ---: | ---: | ---: |
-| Seven-field red aggregate | 1,682.5 ns/request | 1,589.2–1,810.9 ns | 27.1 ns/request |
+## Reproduce and inspect
 
-Three independent processes, 10 samples/process, 100 requests/sample: 3,000 measured
-aggregate requests, plus 10 untimed warmups/process. Request/control sample order
-alternates. The approximately 1.6% control is reported without subtraction and is
-not a precise decomposition of overhead. The interval includes clock/barrier,
-dispatch, conversion, result lifetime/consumption costs; construction, cache
-preparation, correctness checks, storage, and reporting stay outside it.
+Use the [documented gate commands](../../../CONTRIBUTING.md#ci-validation),
+[consumer command](../../../Validation/ComponentConsumer/README.md), and
+[Release runner](../../../Benchmarks/README.md). For focused tests, pass the suites
+above to `scripts/run_tests.sh` with `-only-testing:ColorKitTests/SUITE` and
+`-parallel-testing-enabled NO`. Destinations: `platform=macOS,arch=arm64` and
+`platform=iOS Simulator,name=iPhone 17,OS=26.5`.
 
-[Raw samples and environment](raw.json) retain all 39 scenario/cache/run records
-(`complete: true`) and the executable hash; [full summary](benchmark-summary.md)
-includes the unchanged reference scenarios. Individual legacy HSL/LAB calls perform
-different work, have different cache policies, and may have different numeric
-contracts. Their timings do not establish a speedup or regression for this API.
-No thresholds, overhead subtraction, iOS claims, or before/after claims were added.
-
-[Disassembly excerpts](disassembly.txt) show the aggregate specialization's timed
-loop retaining input barrier, indirect operation call, whole-result consume and
-destruction, and clock calls before/after. The operation closure directly calls
-`Color.componentConversionResults()` at `0x1000ca640`. The timed operation at
-`0x1000c8d70` and consume at `0x1000c8d88` remain within the loop; cache preparation
-precedes the start clock. Full local disassembly is retained under `.build`.
-This validates optimization boundaries, not a Time Profiler attribution of cost.
-
-## Reproduction and local artifacts
-
-```sh
-python3 scripts/check_compatibility.py
-swift run --package-path Validation/ComponentConsumer -c release
-swift test --package-path Benchmarks -c release
-python3 Benchmarks/run.py --output .build/conversion-validation/new-benchmark-run
-xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' \
-  -derivedDataPath .build/conversion-validation/docc -skipMacroValidation \
-  'OTHER_DOCC_FLAGS=--warnings-as-errors'
-python3 scripts/check_documentation.py --derived-data .build/conversion-validation/docc
-swiftlint lint --strict
-git diff --check
-```
-
-For focused tests use `scripts/run_tests.sh --log-file PATH PLATFORM DESTINATION
--parallel-testing-enabled NO`, followed by one
-`-only-testing:ColorKitTests/SUITE` per suite named above and
-`PublicComponentConversionTests`. Destinations used were
-`platform=macOS,arch=arm64` and `platform=iOS Simulator,name=iPhone 17,OS=26.5`.
-
-Local raw logs: `.build/conversion-validation/{compatibility,macos,ios,public-macos,
-consumer,docc,examples,ios-examples,benchmark-tests,benchmark-run,lint}.log`.
-Compatibility inventories/environment: `.build/compatibility/run-3x3nv2ep/`.
-XCTest bundles: `.build/xcode/Logs/Test/`. These local logs/build products are ignored;
-the measurement JSON, summary, and bounded disassembly excerpts are retained here.
-The iOS compilation reused the documentation checker's extraction/wrapping helpers,
-with `xcrun swiftc -typecheck -swift-version 6 -target arm64-apple-ios14.0-simulator`,
-the simulator SDK, and `.build/xcode/Build/Products/Debug-iphonesimulator` as import
-path. Extracted sources remain in `.build/conversion-validation/ios-examples/`.
-
-During fixture preparation one benchmark build rejected a test file modified while
-compilation was running; the subsequent stable-source run passed. Initial lint
-reported two attribute-placement errors in the new public tests; formatting was
-corrected and strict lint passed. Neither failure involved production behavior.
+Extra iOS example compilation reused `scripts/check_documentation.py` extraction/wrapping
+helpers with `xcrun swiftc -typecheck -swift-version 6 -target arm64-apple-ios14.0-simulator`,
+the simulator SDK, and `.build/xcode/Build/Products/Debug-iphonesimulator` as import path.
+Local logs, extracted iOS examples, and full disassembly: `.build/conversion-validation/`;
+compatibility inventories: `.build/compatibility/run-3x3nv2ep/`;
+XCTest bundles: `.build/xcode/Logs/Test/`. These local artifacts are ignored.
 
 ## Limits
 
-This is a focused feature audit, not the full release matrix or final CI state.
-Minimum-deployment compilation does not prove runtime on iOS 14/macOS 12, older
-compilers, physical devices, Intel runtime, or binary compatibility. Consumer
-hosting was exercised on macOS only; iOS has public behavioral tests and client
-compilation. No new visual, spoken VoiceOver, or physical gamut audit was performed.
-Platform-sanitized invalid inputs cannot be reconstructed; direct resolver tests
-cover otherwise unobservable alpha validation. A real platform
-`colorSpaceConversionFailed` was not manufactured, and cross-OS profile conversion
-is not guaranteed bitwise identical. One bounded red benchmark does not characterize
-P3 profile conversion, failures, UI rendering, or all caller workloads.
+Focused audit only: no full release matrix/final CI claim, minimum-OS runtime,
+older-compiler, physical-device, Intel runtime, or binary-compatibility proof.
+Consumer hosting was macOS-only; no new visual, spoken VoiceOver, or physical-gamut audit.
+Platform-sanitized invalid inputs remain unobservable (direct resolver tests cover
+alpha guards); no real `colorSpaceConversionFailed` fixture was manufactured.
+Profile conversion is not bitwise portable across OS versions. One bounded-red
+workload does not characterize P3 conversion, failures, rendering, or iOS performance.

--- a/docs/validation/component-conversion-2026-09-08/README.md
+++ b/docs/validation/component-conversion-2026-09-08/README.md
@@ -1,0 +1,162 @@
+# Integrated component-conversion validation — 2026-09-08
+
+**PASS within the requested feature-validation scope. No production defect found.**
+This is evidence for considering 3.1, not release preflight or publication approval.
+
+Candidate: `bc46e3e1e264d8b7d420cb607d546bf7d014b9e3`, verified equal to fetched
+`origin/main`, including #62 and #63. Started clean and created
+`chore/conversion-result-validation`. Production sources, package deployment
+requirements, frozen 3.0.0 clients, and version metadata remain unchanged.
+The only changes are public validation tests, a separate consuming app, one
+benchmark scenario with its inventory/README update, and this evidence.
+
+Reviewed AGENTS.md, CONTRIBUTING.md, CONTEXT.md, repository agent guidance,
+component-conversion-results.md, component-conversion-example.md, ADRs 0012–0016,
+release-client compatibility policy, implementation/resolver, existing focused
+fixtures, inspector, and adoption material. Public calls were also checked against
+the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
+No API naming or contract contradiction was found.
+
+## Findings ordered by caller impact
+
+1. **P2, post-release compatibility protection:** the current nonisolated fixture
+   (`scripts/fixtures/component_results.swift`) is compiled by the documentation
+   job but is mutable with current examples. The frozen 3.0.0 API baseline cannot
+   detect removal of an API that did not exist in that release. Once 3.1 is actually
+   published, add `Compatibility/Clients/3.1.0/revision` pinned to its full released
+   commit and preserve the existing fixture as a separate client in that directory.
+   Include representative payload getter/equality use in the release client coverage;
+   do not rely on evolving README examples for that promise. The existing checker
+   discovers release directories, builds each pinned release and candidate on both
+   platforms, compares APIs, and rejects edits to established fixtures relative to
+   the PR base. No baseline was registered now, and no 3.0.0 client was edited.
+2. **P3, repeatability of extra validation:** current CI compiles examples and the
+   nonisolated fixture on macOS. This audit additionally compiled them for iOS, but
+   that extra command and the separate consumer app are not new CI requirements.
+   Consider retaining those checks when adopting the released fixture; this is a
+   validation-maintenance opportunity, not an observed caller failure.
+
+**Documentation follow-up:** no component-contract correction is required in DocC,
+the English/Spanish README sections, or MIGRATION.md. They agree on independent
+availability, fixed input, strict gamut, alpha, scales, and deliberate legacy math
+differences. Preserve their existing content. After publication, perform ordinary
+release wording updates and document the newly frozen fixture. Historical paths
+and dates in the approved design/example documents describe their original work.
+
+## Checks and results
+
+| Check | Result |
+| --- | --- |
+| `python3 scripts/check_compatibility.py` | PASS: frozen 3.0.0 clients against release and candidate, full API digester including deprecated API, macOS and iOS Simulator; Swift 6 mode, client targets macOS 12 / iOS 14 |
+| Existing focused behavioral suites on macOS 26.6.2 and iPhone 17 / iOS 26.5 Simulator | PASS: 71 XCTest tests on each platform, serialized |
+| `PublicComponentConversionTests`, ordinary `import ColorKit` | PASS on both platforms: 3 Swift Testing functions, including 3 alpha argument cases (5 invocations) |
+| Separate `Validation/ComponentConsumer` Release executable | PASS: hosted own SwiftUI view with 7/7, 3/7, 0/7 availability, then AppKit aqua/darkAqua capture |
+| DocC `--warnings-as-errors` | PASS |
+| Existing `scripts/check_documentation.py` | PASS: 35 actual marked examples compile, 8 actual English/Spanish README conversion examples execute; generated theme output compiles |
+| Same extracted examples plus existing nonisolated fixture, iOS public module | PASS: 35 examples and fixture typecheck in Swift 6 with iOS 14 Simulator deployment target |
+| `swift test --package-path Benchmarks -c release` | PASS: 5 tests, including all 8 scenarios and supported cache modes |
+| Strict SwiftLint / `git diff --check` | PASS |
+
+Focused XCTest suites: `ColorComponentConversionResultsTests`, `ResolvedSRGBATests`,
+`ColorSpaceConverterTests`, `HSLResolutionTests`, `LABResolutionTests`,
+`ColorCacheIntegrationTests`, and `ComponentConversionPreviewTests`.
+The six catalog tests are supporting evidence, including hosted appearance/layout
+checks; the separate consumer does not instantiate catalog types.
+
+Coverage combines existing numerical tests with independent public-client checks:
+primaries, legitimate zero, signed XYZ/LAB reference values, reference-white scales,
+turns/fractions, alpha 0/0.5/1 without compositing, byte rounding, strict adjacent
+endpoints, near-white HSL, subnormal CMYK/hue, grayscale/linear/P3/Adobe profiles,
+extended gamut and overflow partial success, named/dynamic unavailable input,
+light/dark fixed capture, unsupported models and surviving nonfinite input,
+cache poisoning and unchanged legacy paths. Public tests independently pin green
+XYZ/LAB coordinates, preserve transparent RGB, distinguish all-field unavailability
+from black, and reconstruct a P3 result's published sRGBA to verify XYZ/LAB agreement.
+Source inspection confirms one `resolveResult` call, one bounded branch, one XYZ
+calculation feeding LAB, immutable stored outputs, and no legacy-cache consultation.
+Replay equality alone is not proof of the exact resolver invocation count.
+
+## Measurements
+
+Added `component-results-red`: one complete public aggregate request for fixed
+opaque sRGB red, all seven fields validated outside timing, whole result consumed.
+ColorKit cache mode is `unused`. Harness timing/preparation code was not changed.
+
+Apple M4 Pro (Mac16,7), macOS 26.6.2 (25G83), Xcode 26.5 (17F42), Swift 6.3.2,
+arm64 Release, AC power. This task's builds/tests finished before sampling;
+other system activity and thermals were not controlled.
+
+| Workload | Median sample mean | Sample-mean range | Median control |
+| --- | ---: | ---: | ---: |
+| Seven-field red aggregate | 1,682.5 ns/request | 1,589.2–1,810.9 ns | 27.1 ns/request |
+
+Three independent processes, 10 samples/process, 100 requests/sample: 3,000 measured
+aggregate requests, plus 10 untimed warmups/process. Request/control sample order
+alternates. The approximately 1.6% control is reported without subtraction and is
+not a precise decomposition of overhead. The interval includes clock/barrier,
+dispatch, conversion, result lifetime/consumption costs; construction, cache
+preparation, correctness checks, storage, and reporting stay outside it.
+
+[Raw samples and environment](raw.json) retain all 39 scenario/cache/run records
+(`complete: true`) and the executable hash; [full summary](benchmark-summary.md)
+includes the unchanged reference scenarios. Individual legacy HSL/LAB calls perform
+different work, have different cache policies, and may have different numeric
+contracts. Their timings do not establish a speedup or regression for this API.
+No thresholds, overhead subtraction, iOS claims, or before/after claims were added.
+
+[Disassembly excerpts](disassembly.txt) show the aggregate specialization's timed
+loop retaining input barrier, indirect operation call, whole-result consume and
+destruction, and clock calls before/after. The operation closure directly calls
+`Color.componentConversionResults()` at `0x1000ca640`. The timed operation at
+`0x1000c8d70` and consume at `0x1000c8d88` remain within the loop; cache preparation
+precedes the start clock. Full local disassembly is retained under `.build`.
+This validates optimization boundaries, not a Time Profiler attribution of cost.
+
+## Reproduction and local artifacts
+
+```sh
+python3 scripts/check_compatibility.py
+swift run --package-path Validation/ComponentConsumer -c release
+swift test --package-path Benchmarks -c release
+python3 Benchmarks/run.py --output .build/conversion-validation/new-benchmark-run
+xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' \
+  -derivedDataPath .build/conversion-validation/docc -skipMacroValidation \
+  'OTHER_DOCC_FLAGS=--warnings-as-errors'
+python3 scripts/check_documentation.py --derived-data .build/conversion-validation/docc
+swiftlint lint --strict
+git diff --check
+```
+
+For focused tests use `scripts/run_tests.sh --log-file PATH PLATFORM DESTINATION
+-parallel-testing-enabled NO`, followed by one
+`-only-testing:ColorKitTests/SUITE` per suite named above and
+`PublicComponentConversionTests`. Destinations used were
+`platform=macOS,arch=arm64` and `platform=iOS Simulator,name=iPhone 17,OS=26.5`.
+
+Local raw logs: `.build/conversion-validation/{compatibility,macos,ios,public-macos,
+consumer,docc,examples,ios-examples,benchmark-tests,benchmark-run,lint}.log`.
+Compatibility inventories/environment: `.build/compatibility/run-3x3nv2ep/`.
+XCTest bundles: `.build/xcode/Logs/Test/`. These local logs/build products are ignored;
+the measurement JSON, summary, and bounded disassembly excerpts are retained here.
+The iOS compilation reused the documentation checker's extraction/wrapping helpers,
+with `xcrun swiftc -typecheck -swift-version 6 -target arm64-apple-ios14.0-simulator`,
+the simulator SDK, and `.build/xcode/Build/Products/Debug-iphonesimulator` as import
+path. Extracted sources remain in `.build/conversion-validation/ios-examples/`.
+
+During fixture preparation one benchmark build rejected a test file modified while
+compilation was running; the subsequent stable-source run passed. Initial lint
+reported two attribute-placement errors in the new public tests; formatting was
+corrected and strict lint passed. Neither failure involved production behavior.
+
+## Limits
+
+This is a focused feature audit, not the full release matrix or final CI state.
+Minimum-deployment compilation does not prove runtime on iOS 14/macOS 12, older
+compilers, physical devices, Intel runtime, or binary compatibility. Consumer
+hosting was exercised on macOS only; iOS has public behavioral tests and client
+compilation. No new visual, spoken VoiceOver, or physical gamut audit was performed.
+Platform-sanitized invalid inputs cannot be reconstructed; direct resolver tests
+cover otherwise unobservable alpha validation. A real platform
+`colorSpaceConversionFailed` was not manufactured, and cross-OS profile conversion
+is not guaranteed bitwise identical. One bounded red benchmark does not characterize
+P3 profile conversion, failures, UI rendering, or all caller workloads.

--- a/docs/validation/component-conversion-2026-09-08/benchmark-summary.md
+++ b/docs/validation/component-conversion-2026-09-08/benchmark-summary.md
@@ -1,0 +1,23 @@
+# ColorKit macOS Release baseline
+
+Times include input barriers, clock reads, dispatch, and result consumption. The control substitutes a precomputed result and is an overhead estimate; it is reported without subtraction. Cache preparation is outside timing.
+
+| Scenario | Cache preparation | Median ns/request | Sample range | Median control ns/request |
+| --- | --- | ---: | ---: | ---: |
+| component-results-red | unused | 1,682.5 | 1,589.2–1,810.9 | 27.1 |
+| hsl-red | empty | 3,441.1 | 3,196.2–3,763.3 | 15.4 |
+| hsl-red | primed | 1,166.0 | 1,108.3–1,271.1 | 20.2 |
+| lab-red | empty | 2,091.9 | 1,932.5–2,488.8 | 15.8 |
+| lab-red | primed | 1,212.5 | 1,094.2–1,321.7 | 15.8 |
+| comparison-black-white | unused | 667.7 | 582.5–754.2 | 25.8 |
+| enhancement-compliant | unused | 1,024.4 | 934.2–1,168.8 | 24.0 |
+| enhancement-adjusted | empty | 31,828.7 | 30,243.3–32,879.6 | 21.5 |
+| enhancement-adjusted | primed | 24,991.1 | 23,282.9–27,046.3 | 29.9 |
+| enhancement-best-effort | empty | 25,308.7 | 22,294.2–26,872.1 | 24.6 |
+| enhancement-best-effort | primed | 19,641.9 | 18,664.6–20,805.7 | 30.0 |
+| palette-red-five | empty | 68,759.4 | 63,308.8–74,265.0 | 18.1 |
+| palette-red-five | primed | 60,556.7 | 54,805.4–65,955.9 | 26.5 |
+
+Each sample is the mean of individually timed complete requests. The table's median and range describe those sample means across runs, not individual-request latency percentiles.
+
+Read raw.json for every sample, fixture description, run identity, and environment. Large ranges or a control close to the request time limit useful comparisons. These are reference measurements, not speedup claims, CI thresholds, or iOS results.

--- a/docs/validation/component-conversion-2026-09-08/disassembly.txt
+++ b/docs/validation/component-conversion-2026-09-08/disassembly.txt
@@ -1,0 +1,103 @@
+Release executable SHA-256: 732c5b274b805c108ac9fa178d9a755a1f4f3c4dd7cc5f5e3afa4d3aea460b80
+Generated with xcrun llvm-objdump --disassemble --demangle, then xcrun swift-demangle.
+Original line numbers below refer to .build/conversion-validation/benchmark-demangled.txt.
+
+Lines 212389-212400
+00000001000c883c <generic specialization <SwiftUI.Color, ColorKit.ColorComponentConversionResults> of closure #2 (ColorKitBenchmarks.CacheMode, Swift.Int, Swift.Int) throws -> [ColorKitBenchmarks.Sample] in ColorKitBenchmarks.Scenario.init<A, B>(description: ColorKitBenchmarks.ScenarioDescription, input: A, operation: (A) -> B, validate: (B) throws -> ()) -> ColorKitBenchmarks.Scenario>:
+1000c883c: f81a0ffc    	str	x28, [sp, #-0x60]!
+1000c8840: a9016bfb    	stp	x27, x26, [sp, #0x10]
+1000c8844: a90263f9    	stp	x25, x24, [sp, #0x20]
+1000c8848: a9035bf7    	stp	x23, x22, [sp, #0x30]
+1000c884c: a9044ff4    	stp	x20, x19, [sp, #0x40]
+1000c8850: a9057bfd    	stp	x29, x30, [sp, #0x50]
+1000c8854: 910143fd    	add	x29, sp, #0x50
+1000c8858: d11103ff    	sub	sp, sp, #0x440
+1000c885c: 910003f3    	mov	x19, sp
+1000c8860: aa1503f6    	mov	x22, x21
+1000c8864: aa0703fb    	mov	x27, x7
+
+Lines 212695-212737
+1000c8d00: 14000008    	b	0x1000c8d20 <generic specialization <SwiftUI.Color, ColorKit.ColorComponentConversionResults> of closure #2 (ColorKitBenchmarks.CacheMode, Swift.Int, Swift.Int) throws -> [ColorKitBenchmarks.Sample] in ColorKitBenchmarks.Scenario.init<A, B>(description: ColorKitBenchmarks.ScenarioDescription, input: A, operation: (A) -> B, validate: (B) throws -> ()) -> ColorKitBenchmarks.Scenario+0x4e4>
+1000c8d04: f9402a68    	ldr	x8, [x19, #0x50]
+1000c8d08: f9400114    	ldr	x20, [x8]
+1000c8d0c: aa1403e0    	mov	x0, x20
+1000c8d10: 940012f9    	bl	0x1000cd8f4 <_voucher_adopt+0x1000cd8f4>
+1000c8d14: 97fe268f    	bl	0x100052750 <ColorKit.ColorCache.clearCache() -> ()>
+1000c8d18: aa1403e0    	mov	x0, x20
+1000c8d1c: 940012f0    	bl	0x1000cd8dc <_voucher_adopt+0x1000cd8dc>
+1000c8d20: aa1c03e8    	mov	x8, x28
+1000c8d24: 94001093    	bl	0x1000ccf70 <_voucher_adopt+0x1000ccf70>
+1000c8d28: aa1c03f4    	mov	x20, x28
+1000c8d2c: 9400108e    	bl	0x1000ccf64 <_voucher_adopt+0x1000ccf64>
+1000c8d30: aa0003f7    	mov	x23, x0
+1000c8d34: a946ea68    	ldp	x8, x26, [x19, #0x68]
+1000c8d38: f9400519    	ldr	x25, [x8, #0x8]
+1000c8d3c: aa1c03e0    	mov	x0, x28
+1000c8d40: aa1a03e1    	mov	x1, x26
+1000c8d44: d63f0320    	blr	x25
+1000c8d48: f9403e68    	ldr	x8, [x19, #0x78]
+1000c8d4c: f9004668    	str	x8, [x19, #0x88]
+1000c8d50: 91020268    	add	x8, x19, #0x80
+1000c8d54: 91022260    	add	x0, x19, #0x88
+1000c8d58: 90000201    	adrp	x1, 0x100108000 <_voucher_adopt+0x100108000>
+1000c8d5c: f946f821    	ldr	x1, [x1, #0xdf0]
+1000c8d60: 97ffd5df    	bl	0x1000be4dc <ColorKitBenchmarks.opaqueInput<A>(A) -> A>
+1000c8d64: 9105c268    	add	x8, x19, #0x170
+1000c8d68: 91020260    	add	x0, x19, #0x80
+1000c8d6c: a9445269    	ldp	x9, x20, [x19, #0x40]
+1000c8d70: d63f0120    	blr	x9
+1000c8d74: f9404260    	ldr	x0, [x19, #0x80]
+1000c8d78: 940012d9    	bl	0x1000cd8dc <_voucher_adopt+0x1000cd8dc>
+1000c8d7c: 9105c260    	add	x0, x19, #0x170
+1000c8d80: 90000221    	adrp	x1, 0x10010c000 <value witness table for ColorKit.(RGBDifferenceView in _09B5711F82AA56ED9525B22CCB0366A0)+0x8>
+1000c8d84: 91164021    	add	x1, x1, #0x590
+1000c8d88: 97ffd5df    	bl	0x1000be504 <ColorKitBenchmarks.consume<A>(A) -> ()>
+1000c8d8c: 9105c260    	add	x0, x19, #0x170
+1000c8d90: 97fed34c    	bl	0x10007dac0 <outlined destroy of ColorKit.ColorComponentConversionResults>
+1000c8d94: aa1c03e8    	mov	x8, x28
+1000c8d98: 94001076    	bl	0x1000ccf70 <_voucher_adopt+0x1000ccf70>
+1000c8d9c: aa1c03f4    	mov	x20, x28
+1000c8da0: 94001071    	bl	0x1000ccf64 <_voucher_adopt+0x1000ccf64>
+1000c8da4: aa0003f4    	mov	x20, x0
+1000c8da8: aa1c03e0    	mov	x0, x28
+
+Lines 214306-214344
+
+00000001000ca624 <closure #1 (SwiftUI.Color) -> ColorKit.ColorComponentConversionResults in ColorKitBenchmarks.scenarios() -> [ColorKitBenchmarks.Scenario]>:
+1000ca624: d10443ff    	sub	sp, sp, #0x110
+1000ca628: a90f4ff4    	stp	x20, x19, [sp, #0xf0]
+1000ca62c: a9107bfd    	stp	x29, x30, [sp, #0x100]
+1000ca630: 910403fd    	add	x29, sp, #0x100
+1000ca634: aa0803f3    	mov	x19, x8
+1000ca638: f9400000    	ldr	x0, [x0]
+1000ca63c: 910023e8    	add	x8, sp, #0x8
+1000ca640: 97fe3ca9    	bl	0x1000598e4 <(extension in ColorKit):SwiftUI.Color.componentConversionResults() -> ColorKit.ColorComponentConversionResults>
+1000ca644: 3ccc83e0    	ldur	q0, [sp, #0xc8]
+1000ca648: 3ccd83e1    	ldur	q1, [sp, #0xd8]
+1000ca64c: ad060660    	stp	q0, q1, [x19, #0xc0]
+1000ca650: 3943a3e8    	ldrb	w8, [sp, #0xe8]
+1000ca654: 39038268    	strb	w8, [x19, #0xe0]
+1000ca658: 3cc883e0    	ldur	q0, [sp, #0x88]
+1000ca65c: 3cc983e1    	ldur	q1, [sp, #0x98]
+1000ca660: ad040660    	stp	q0, q1, [x19, #0x80]
+1000ca664: 3ccb83e0    	ldur	q0, [sp, #0xb8]
+1000ca668: 3cca83e1    	ldur	q1, [sp, #0xa8]
+1000ca66c: ad050261    	stp	q1, q0, [x19, #0xa0]
+1000ca670: 3cc483e0    	ldur	q0, [sp, #0x48]
+1000ca674: 3cc583e1    	ldur	q1, [sp, #0x58]
+1000ca678: ad020660    	stp	q0, q1, [x19, #0x40]
+1000ca67c: 3cc783e0    	ldur	q0, [sp, #0x78]
+1000ca680: 3cc683e1    	ldur	q1, [sp, #0x68]
+1000ca684: ad030261    	stp	q1, q0, [x19, #0x60]
+1000ca688: 3cc083e0    	ldur	q0, [sp, #0x8]
+1000ca68c: 3cc183e1    	ldur	q1, [sp, #0x18]
+1000ca690: ad000660    	stp	q0, q1, [x19]
+1000ca694: 3cc383e0    	ldur	q0, [sp, #0x38]
+1000ca698: 3cc283e1    	ldur	q1, [sp, #0x28]
+1000ca69c: ad010261    	stp	q1, q0, [x19, #0x20]
+1000ca6a0: a9507bfd    	ldp	x29, x30, [sp, #0x100]
+1000ca6a4: a94f4ff4    	ldp	x20, x19, [sp, #0xf0]
+1000ca6a8: 910443ff    	add	sp, sp, #0x110
+1000ca6ac: d65f03c0    	ret
+
+00000001000ca6b0 <closure #2 (ColorKit.ColorComponentConversionResults) throws -> () in ColorKitBenchmarks.scenarios() -> [ColorKitBenchmarks.Scenario]>:

--- a/docs/validation/component-conversion-2026-09-08/raw.json
+++ b/docs/validation/component-conversion-2026-09-08/raw.json
@@ -1,0 +1,2673 @@
+{
+  "schemaVersion": 1,
+  "complete": true,
+  "environment": {
+    "timestampUTC": "2026-09-08T11:34:18.829946+00:00",
+    "revision": "bc46e3e1e264d8b7d420cb607d546bf7d014b9e3",
+    "trackedChanges": "Benchmarks/README.md                               |  3 +-\n .../Sources/ColorKitBenchmarks/Scenarios.swift     | 33 ++++++++++++++++++++++\n .../ColorKitBenchmarksTests/MeasurementTests.swift |  2 +-\n 3 files changed, 36 insertions(+), 2 deletions(-)",
+    "untrackedFiles": "Tests/ColorKitTests/Utilities/PublicComponentConversionTests.swift\nValidation/ComponentConsumer/.gitignore\nValidation/ComponentConsumer/Package.swift\nValidation/ComponentConsumer/README.md\nValidation/ComponentConsumer/Sources/ComponentConsumer/Consumer.swift",
+    "binarySHA256": "732c5b274b805c108ac9fa178d9a755a1f4f3c4dd7cc5f5e3afa4d3aea460b80",
+    "configuration": "release",
+    "buildCommand": "swift build --package-path Benchmarks -c release",
+    "swift": "Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)\nTarget: arm64-apple-macosx26.0",
+    "xcode": "Xcode 26.5\nBuild version 17F42",
+    "sdk": "26.5",
+    "os": "ProductName:\t\tmacOS\nProductVersion:\t\t26.6.2\nBuildVersion:\t\t25G83",
+    "architecture": "arm64",
+    "hardwareModel": "Mac16,7",
+    "cpu": "Apple M4 Pro",
+    "memoryBytes": 51539607552,
+    "power": "Now drawing from 'AC Power'\n -InternalBattery-0 (id=22216803)\t100%; charged; 0:00 remaining present: true",
+    "runs": 3,
+    "samplesPerRun": 10,
+    "requestsPerSample": 100,
+    "warmupRequests": 10,
+    "clock": "DispatchTime.uptimeNanoseconds",
+    "sampling": "Sum individually timed requests; preparation excluded; alternating request/control sample order"
+  },
+  "records": [
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2666,
+          "requestCount": 100,
+          "requestNanoseconds": 177541
+        },
+        {
+          "controlNanoseconds": 2707,
+          "requestCount": 100,
+          "requestNanoseconds": 163620
+        },
+        {
+          "controlNanoseconds": 2583,
+          "requestCount": 100,
+          "requestNanoseconds": 163793
+        },
+        {
+          "controlNanoseconds": 2499,
+          "requestCount": 100,
+          "requestNanoseconds": 170625
+        },
+        {
+          "controlNanoseconds": 2541,
+          "requestCount": 100,
+          "requestNanoseconds": 163171
+        },
+        {
+          "controlNanoseconds": 2709,
+          "requestCount": 100,
+          "requestNanoseconds": 162830
+        },
+        {
+          "controlNanoseconds": 2542,
+          "requestCount": 100,
+          "requestNanoseconds": 162831
+        },
+        {
+          "controlNanoseconds": 2623,
+          "requestCount": 100,
+          "requestNanoseconds": 162458
+        },
+        {
+          "controlNanoseconds": 2920,
+          "requestCount": 100,
+          "requestNanoseconds": 168872
+        },
+        {
+          "controlNanoseconds": 2875,
+          "requestCount": 100,
+          "requestNanoseconds": 179208
+        }
+      ],
+      "scenario": {
+        "expected": "Seven successes; red coordinates and #FF0000FF",
+        "id": "component-results-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Convert fixed red to all seven independent component results",
+        "settings": "componentConversionResults()",
+        "unit": "aggregate conversion"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1291,
+          "requestCount": 100,
+          "requestNanoseconds": 341876
+        },
+        {
+          "controlNanoseconds": 1416,
+          "requestCount": 100,
+          "requestNanoseconds": 322725
+        },
+        {
+          "controlNanoseconds": 1208,
+          "requestCount": 100,
+          "requestNanoseconds": 321329
+        },
+        {
+          "controlNanoseconds": 1334,
+          "requestCount": 100,
+          "requestNanoseconds": 319970
+        },
+        {
+          "controlNanoseconds": 1209,
+          "requestCount": 100,
+          "requestNanoseconds": 348004
+        },
+        {
+          "controlNanoseconds": 1079,
+          "requestCount": 100,
+          "requestNanoseconds": 319625
+        },
+        {
+          "controlNanoseconds": 1251,
+          "requestCount": 100,
+          "requestNanoseconds": 333835
+        },
+        {
+          "controlNanoseconds": 1542,
+          "requestCount": 100,
+          "requestNanoseconds": 342454
+        },
+        {
+          "controlNanoseconds": 1542,
+          "requestCount": 100,
+          "requestNanoseconds": 344421
+        },
+        {
+          "controlNanoseconds": 1626,
+          "requestCount": 100,
+          "requestNanoseconds": 331757
+        }
+      ],
+      "scenario": {
+        "expected": "HSL (0, 1, 0.5), tolerance 0.001",
+        "id": "hsl-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to HSL components",
+        "settings": "hslComponents()",
+        "unit": "conversion"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 2580,
+          "requestCount": 100,
+          "requestNanoseconds": 110835
+        },
+        {
+          "controlNanoseconds": 1992,
+          "requestCount": 100,
+          "requestNanoseconds": 125168
+        },
+        {
+          "controlNanoseconds": 2207,
+          "requestCount": 100,
+          "requestNanoseconds": 114959
+        },
+        {
+          "controlNanoseconds": 2086,
+          "requestCount": 100,
+          "requestNanoseconds": 118003
+        },
+        {
+          "controlNanoseconds": 2248,
+          "requestCount": 100,
+          "requestNanoseconds": 117080
+        },
+        {
+          "controlNanoseconds": 1671,
+          "requestCount": 100,
+          "requestNanoseconds": 117958
+        },
+        {
+          "controlNanoseconds": 2077,
+          "requestCount": 100,
+          "requestNanoseconds": 116793
+        },
+        {
+          "controlNanoseconds": 1994,
+          "requestCount": 100,
+          "requestNanoseconds": 117369
+        },
+        {
+          "controlNanoseconds": 1917,
+          "requestCount": 100,
+          "requestNanoseconds": 127000
+        },
+        {
+          "controlNanoseconds": 2044,
+          "requestCount": 100,
+          "requestNanoseconds": 118295
+        }
+      ],
+      "scenario": {
+        "expected": "HSL (0, 1, 0.5), tolerance 0.001",
+        "id": "hsl-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to HSL components",
+        "settings": "hslComponents()",
+        "unit": "conversion"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1667,
+          "requestCount": 100,
+          "requestNanoseconds": 218804
+        },
+        {
+          "controlNanoseconds": 1667,
+          "requestCount": 100,
+          "requestNanoseconds": 206203
+        },
+        {
+          "controlNanoseconds": 1666,
+          "requestCount": 100,
+          "requestNanoseconds": 196042
+        },
+        {
+          "controlNanoseconds": 1584,
+          "requestCount": 100,
+          "requestNanoseconds": 195166
+        },
+        {
+          "controlNanoseconds": 1625,
+          "requestCount": 100,
+          "requestNanoseconds": 200519
+        },
+        {
+          "controlNanoseconds": 1543,
+          "requestCount": 100,
+          "requestNanoseconds": 194039
+        },
+        {
+          "controlNanoseconds": 1872,
+          "requestCount": 100,
+          "requestNanoseconds": 198247
+        },
+        {
+          "controlNanoseconds": 1750,
+          "requestCount": 100,
+          "requestNanoseconds": 215038
+        },
+        {
+          "controlNanoseconds": 1583,
+          "requestCount": 100,
+          "requestNanoseconds": 193255
+        },
+        {
+          "controlNanoseconds": 1584,
+          "requestCount": 100,
+          "requestNanoseconds": 200540
+        }
+      ],
+      "scenario": {
+        "expected": "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+        "id": "lab-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to D65 LAB components",
+        "settings": "labComponents()",
+        "unit": "conversion"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 1917,
+          "requestCount": 100,
+          "requestNanoseconds": 119961
+        },
+        {
+          "controlNanoseconds": 1587,
+          "requestCount": 100,
+          "requestNanoseconds": 121874
+        },
+        {
+          "controlNanoseconds": 1580,
+          "requestCount": 100,
+          "requestNanoseconds": 121374
+        },
+        {
+          "controlNanoseconds": 1670,
+          "requestCount": 100,
+          "requestNanoseconds": 120997
+        },
+        {
+          "controlNanoseconds": 1879,
+          "requestCount": 100,
+          "requestNanoseconds": 132171
+        },
+        {
+          "controlNanoseconds": 1501,
+          "requestCount": 100,
+          "requestNanoseconds": 125210
+        },
+        {
+          "controlNanoseconds": 1664,
+          "requestCount": 100,
+          "requestNanoseconds": 120624
+        },
+        {
+          "controlNanoseconds": 1290,
+          "requestCount": 100,
+          "requestNanoseconds": 123831
+        },
+        {
+          "controlNanoseconds": 1750,
+          "requestCount": 100,
+          "requestNanoseconds": 122958
+        },
+        {
+          "controlNanoseconds": 1292,
+          "requestCount": 100,
+          "requestNanoseconds": 123830
+        }
+      ],
+      "scenario": {
+        "expected": "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+        "id": "lab-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to D65 LAB components",
+        "settings": "labComponents()",
+        "unit": "conversion"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2793,
+          "requestCount": 100,
+          "requestNanoseconds": 74957
+        },
+        {
+          "controlNanoseconds": 2542,
+          "requestCount": 100,
+          "requestNanoseconds": 66960
+        },
+        {
+          "controlNanoseconds": 2541,
+          "requestCount": 100,
+          "requestNanoseconds": 67624
+        },
+        {
+          "controlNanoseconds": 2582,
+          "requestCount": 100,
+          "requestNanoseconds": 66624
+        },
+        {
+          "controlNanoseconds": 2457,
+          "requestCount": 100,
+          "requestNanoseconds": 67456
+        },
+        {
+          "controlNanoseconds": 2710,
+          "requestCount": 100,
+          "requestNanoseconds": 70539
+        },
+        {
+          "controlNanoseconds": 2459,
+          "requestCount": 100,
+          "requestNanoseconds": 65915
+        },
+        {
+          "controlNanoseconds": 2668,
+          "requestCount": 100,
+          "requestNanoseconds": 62378
+        },
+        {
+          "controlNanoseconds": 2125,
+          "requestCount": 100,
+          "requestNanoseconds": 58833
+        },
+        {
+          "controlNanoseconds": 2669,
+          "requestCount": 100,
+          "requestNanoseconds": 58456
+        }
+      ],
+      "scenario": {
+        "expected": "Available CIEDE2000 100 and contrast 21",
+        "id": "comparison-black-white",
+        "inputs": "sRGB RGBA first (0, 0, 0, 1), second (1, 1, 1, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Compute all public color-comparison metrics",
+        "settings": "comparisonResult(with:)",
+        "unit": "comparison"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2208,
+          "requestCount": 100,
+          "requestNanoseconds": 110082
+        },
+        {
+          "controlNanoseconds": 2305,
+          "requestCount": 100,
+          "requestNanoseconds": 94542
+        },
+        {
+          "controlNanoseconds": 1830,
+          "requestCount": 100,
+          "requestNanoseconds": 93418
+        },
+        {
+          "controlNanoseconds": 2583,
+          "requestCount": 100,
+          "requestNanoseconds": 93834
+        },
+        {
+          "controlNanoseconds": 1960,
+          "requestCount": 100,
+          "requestNanoseconds": 93958
+        },
+        {
+          "controlNanoseconds": 1917,
+          "requestCount": 100,
+          "requestNanoseconds": 94376
+        },
+        {
+          "controlNanoseconds": 2003,
+          "requestCount": 100,
+          "requestNanoseconds": 94581
+        },
+        {
+          "controlNanoseconds": 2458,
+          "requestCount": 100,
+          "requestNanoseconds": 103251
+        },
+        {
+          "controlNanoseconds": 2041,
+          "requestCount": 100,
+          "requestNanoseconds": 106125
+        },
+        {
+          "controlNanoseconds": 2141,
+          "requestCount": 100,
+          "requestNanoseconds": 106124
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-compliant",
+        "inputs": "sRGB RGBA foreground (0, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Budgeted enhancement: compliant",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2001,
+          "requestCount": 100,
+          "requestNanoseconds": 3183748
+        },
+        {
+          "controlNanoseconds": 1667,
+          "requestCount": 100,
+          "requestNanoseconds": 3219467
+        },
+        {
+          "controlNanoseconds": 2001,
+          "requestCount": 100,
+          "requestNanoseconds": 3142625
+        },
+        {
+          "controlNanoseconds": 1291,
+          "requestCount": 100,
+          "requestNanoseconds": 3160333
+        },
+        {
+          "controlNanoseconds": 2334,
+          "requestCount": 100,
+          "requestNanoseconds": 3143874
+        },
+        {
+          "controlNanoseconds": 2499,
+          "requestCount": 100,
+          "requestNanoseconds": 3170293
+        },
+        {
+          "controlNanoseconds": 1833,
+          "requestCount": 100,
+          "requestNanoseconds": 3234293
+        },
+        {
+          "controlNanoseconds": 2792,
+          "requestCount": 100,
+          "requestNanoseconds": 3118963
+        },
+        {
+          "controlNanoseconds": 2000,
+          "requestCount": 100,
+          "requestNanoseconds": 3287963
+        },
+        {
+          "controlNanoseconds": 2083,
+          "requestCount": 100,
+          "requestNanoseconds": 3118293
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-adjusted",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: adjusted",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 3330,
+          "requestCount": 100,
+          "requestNanoseconds": 2704630
+        },
+        {
+          "controlNanoseconds": 3213,
+          "requestCount": 100,
+          "requestNanoseconds": 2689839
+        },
+        {
+          "controlNanoseconds": 3165,
+          "requestCount": 100,
+          "requestNanoseconds": 2703132
+        },
+        {
+          "controlNanoseconds": 3126,
+          "requestCount": 100,
+          "requestNanoseconds": 2601658
+        },
+        {
+          "controlNanoseconds": 2702,
+          "requestCount": 100,
+          "requestNanoseconds": 2535374
+        },
+        {
+          "controlNanoseconds": 2711,
+          "requestCount": 100,
+          "requestNanoseconds": 2558544
+        },
+        {
+          "controlNanoseconds": 2629,
+          "requestCount": 100,
+          "requestNanoseconds": 2533713
+        },
+        {
+          "controlNanoseconds": 3209,
+          "requestCount": 100,
+          "requestNanoseconds": 2526995
+        },
+        {
+          "controlNanoseconds": 2587,
+          "requestCount": 100,
+          "requestNanoseconds": 2549540
+        },
+        {
+          "controlNanoseconds": 2500,
+          "requestCount": 100,
+          "requestNanoseconds": 2577705
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-adjusted",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: adjusted",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2791,
+          "requestCount": 100,
+          "requestNanoseconds": 2493171
+        },
+        {
+          "controlNanoseconds": 2584,
+          "requestCount": 100,
+          "requestNanoseconds": 2555916
+        },
+        {
+          "controlNanoseconds": 2586,
+          "requestCount": 100,
+          "requestNanoseconds": 2541955
+        },
+        {
+          "controlNanoseconds": 4875,
+          "requestCount": 100,
+          "requestNanoseconds": 2569832
+        },
+        {
+          "controlNanoseconds": 2460,
+          "requestCount": 100,
+          "requestNanoseconds": 2595502
+        },
+        {
+          "controlNanoseconds": 2457,
+          "requestCount": 100,
+          "requestNanoseconds": 2598124
+        },
+        {
+          "controlNanoseconds": 2793,
+          "requestCount": 100,
+          "requestNanoseconds": 2530583
+        },
+        {
+          "controlNanoseconds": 2541,
+          "requestCount": 100,
+          "requestNanoseconds": 2531165
+        },
+        {
+          "controlNanoseconds": 2540,
+          "requestCount": 100,
+          "requestNanoseconds": 2521665
+        },
+        {
+          "controlNanoseconds": 2375,
+          "requestCount": 100,
+          "requestNanoseconds": 2535750
+        }
+      ],
+      "scenario": {
+        "expected": "bestEffort; distance <= 25.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-best-effort",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: best-effort",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 25.0",
+        "unit": "enhancement"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 3583,
+          "requestCount": 100,
+          "requestNanoseconds": 1893957
+        },
+        {
+          "controlNanoseconds": 3248,
+          "requestCount": 100,
+          "requestNanoseconds": 2036705
+        },
+        {
+          "controlNanoseconds": 3377,
+          "requestCount": 100,
+          "requestNanoseconds": 2045833
+        },
+        {
+          "controlNanoseconds": 3212,
+          "requestCount": 100,
+          "requestNanoseconds": 2033456
+        },
+        {
+          "controlNanoseconds": 3547,
+          "requestCount": 100,
+          "requestNanoseconds": 2037795
+        },
+        {
+          "controlNanoseconds": 2963,
+          "requestCount": 100,
+          "requestNanoseconds": 1985424
+        },
+        {
+          "controlNanoseconds": 2707,
+          "requestCount": 100,
+          "requestNanoseconds": 1973250
+        },
+        {
+          "controlNanoseconds": 2836,
+          "requestCount": 100,
+          "requestNanoseconds": 1993371
+        },
+        {
+          "controlNanoseconds": 3129,
+          "requestCount": 100,
+          "requestNanoseconds": 1977828
+        },
+        {
+          "controlNanoseconds": 3206,
+          "requestCount": 100,
+          "requestNanoseconds": 1964291
+        }
+      ],
+      "scenario": {
+        "expected": "bestEffort; distance <= 25.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-best-effort",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: best-effort",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 25.0",
+        "unit": "enhancement"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2125,
+          "requestCount": 100,
+          "requestNanoseconds": 6755001
+        },
+        {
+          "controlNanoseconds": 2499,
+          "requestCount": 100,
+          "requestNanoseconds": 7270250
+        },
+        {
+          "controlNanoseconds": 2126,
+          "requestCount": 100,
+          "requestNanoseconds": 7426499
+        },
+        {
+          "controlNanoseconds": 2125,
+          "requestCount": 100,
+          "requestNanoseconds": 6888208
+        },
+        {
+          "controlNanoseconds": 1834,
+          "requestCount": 100,
+          "requestNanoseconds": 7078499
+        },
+        {
+          "controlNanoseconds": 1750,
+          "requestCount": 100,
+          "requestNanoseconds": 7188999
+        },
+        {
+          "controlNanoseconds": 1666,
+          "requestCount": 100,
+          "requestNanoseconds": 7162289
+        },
+        {
+          "controlNanoseconds": 1791,
+          "requestCount": 100,
+          "requestNanoseconds": 6330876
+        },
+        {
+          "controlNanoseconds": 1833,
+          "requestCount": 100,
+          "requestNanoseconds": 7177165
+        },
+        {
+          "controlNanoseconds": 1750,
+          "requestCount": 100,
+          "requestNanoseconds": 6863663
+        }
+      ],
+      "scenario": {
+        "expected": "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+        "id": "palette-red-five",
+        "inputs": "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Generate and assess one five-color palette (stochastic candidate search)",
+        "settings": "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+        "unit": "palette"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 3122,
+          "requestCount": 100,
+          "requestNanoseconds": 6214498
+        },
+        {
+          "controlNanoseconds": 3131,
+          "requestCount": 100,
+          "requestNanoseconds": 6149167
+        },
+        {
+          "controlNanoseconds": 2539,
+          "requestCount": 100,
+          "requestNanoseconds": 6187999
+        },
+        {
+          "controlNanoseconds": 2541,
+          "requestCount": 100,
+          "requestNanoseconds": 5645500
+        },
+        {
+          "controlNanoseconds": 2545,
+          "requestCount": 100,
+          "requestNanoseconds": 6043336
+        },
+        {
+          "controlNanoseconds": 2919,
+          "requestCount": 100,
+          "requestNanoseconds": 6068005
+        },
+        {
+          "controlNanoseconds": 2498,
+          "requestCount": 100,
+          "requestNanoseconds": 5944574
+        },
+        {
+          "controlNanoseconds": 2752,
+          "requestCount": 100,
+          "requestNanoseconds": 6193413
+        },
+        {
+          "controlNanoseconds": 2338,
+          "requestCount": 100,
+          "requestNanoseconds": 5633206
+        },
+        {
+          "controlNanoseconds": 2419,
+          "requestCount": 100,
+          "requestNanoseconds": 6143633
+        }
+      ],
+      "scenario": {
+        "expected": "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+        "id": "palette-red-five",
+        "inputs": "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Generate and assess one five-color palette (stochastic candidate search)",
+        "settings": "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+        "unit": "palette"
+      },
+      "run": 1
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 2745,
+          "requestCount": 100,
+          "requestNanoseconds": 5836091
+        },
+        {
+          "controlNanoseconds": 2457,
+          "requestCount": 100,
+          "requestNanoseconds": 6487333
+        },
+        {
+          "controlNanoseconds": 2633,
+          "requestCount": 100,
+          "requestNanoseconds": 5480542
+        },
+        {
+          "controlNanoseconds": 2379,
+          "requestCount": 100,
+          "requestNanoseconds": 6232630
+        },
+        {
+          "controlNanoseconds": 2747,
+          "requestCount": 100,
+          "requestNanoseconds": 5998495
+        },
+        {
+          "controlNanoseconds": 2292,
+          "requestCount": 100,
+          "requestNanoseconds": 5978087
+        },
+        {
+          "controlNanoseconds": 2718,
+          "requestCount": 100,
+          "requestNanoseconds": 6257169
+        },
+        {
+          "controlNanoseconds": 2329,
+          "requestCount": 100,
+          "requestNanoseconds": 5622378
+        },
+        {
+          "controlNanoseconds": 2920,
+          "requestCount": 100,
+          "requestNanoseconds": 5846703
+        },
+        {
+          "controlNanoseconds": 2209,
+          "requestCount": 100,
+          "requestNanoseconds": 5796833
+        }
+      ],
+      "scenario": {
+        "expected": "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+        "id": "palette-red-five",
+        "inputs": "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Generate and assess one five-color palette (stochastic candidate search)",
+        "settings": "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+        "unit": "palette"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2128,
+          "requestCount": 100,
+          "requestNanoseconds": 6362708
+        },
+        {
+          "controlNanoseconds": 1961,
+          "requestCount": 100,
+          "requestNanoseconds": 7076129
+        },
+        {
+          "controlNanoseconds": 1875,
+          "requestCount": 100,
+          "requestNanoseconds": 6829456
+        },
+        {
+          "controlNanoseconds": 1958,
+          "requestCount": 100,
+          "requestNanoseconds": 6936544
+        },
+        {
+          "controlNanoseconds": 1581,
+          "requestCount": 100,
+          "requestNanoseconds": 6735037
+        },
+        {
+          "controlNanoseconds": 1584,
+          "requestCount": 100,
+          "requestNanoseconds": 6732288
+        },
+        {
+          "controlNanoseconds": 1793,
+          "requestCount": 100,
+          "requestNanoseconds": 7013706
+        },
+        {
+          "controlNanoseconds": 1709,
+          "requestCount": 100,
+          "requestNanoseconds": 7001297
+        },
+        {
+          "controlNanoseconds": 1665,
+          "requestCount": 100,
+          "requestNanoseconds": 6625248
+        },
+        {
+          "controlNanoseconds": 1625,
+          "requestCount": 100,
+          "requestNanoseconds": 6528617
+        }
+      ],
+      "scenario": {
+        "expected": "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+        "id": "palette-red-five",
+        "inputs": "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Generate and assess one five-color palette (stochastic candidate search)",
+        "settings": "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+        "unit": "palette"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 3167,
+          "requestCount": 100,
+          "requestNanoseconds": 1944418
+        },
+        {
+          "controlNanoseconds": 3162,
+          "requestCount": 100,
+          "requestNanoseconds": 2016417
+        },
+        {
+          "controlNanoseconds": 3037,
+          "requestCount": 100,
+          "requestNanoseconds": 1969121
+        },
+        {
+          "controlNanoseconds": 3048,
+          "requestCount": 100,
+          "requestNanoseconds": 1952329
+        },
+        {
+          "controlNanoseconds": 3166,
+          "requestCount": 100,
+          "requestNanoseconds": 1936331
+        },
+        {
+          "controlNanoseconds": 3046,
+          "requestCount": 100,
+          "requestNanoseconds": 1907716
+        },
+        {
+          "controlNanoseconds": 3000,
+          "requestCount": 100,
+          "requestNanoseconds": 1925838
+        },
+        {
+          "controlNanoseconds": 2706,
+          "requestCount": 100,
+          "requestNanoseconds": 1907208
+        },
+        {
+          "controlNanoseconds": 2666,
+          "requestCount": 100,
+          "requestNanoseconds": 1916790
+        },
+        {
+          "controlNanoseconds": 2544,
+          "requestCount": 100,
+          "requestNanoseconds": 1963668
+        }
+      ],
+      "scenario": {
+        "expected": "bestEffort; distance <= 25.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-best-effort",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: best-effort",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 25.0",
+        "unit": "enhancement"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2583,
+          "requestCount": 100,
+          "requestNanoseconds": 2229423
+        },
+        {
+          "controlNanoseconds": 2292,
+          "requestCount": 100,
+          "requestNanoseconds": 2261838
+        },
+        {
+          "controlNanoseconds": 2293,
+          "requestCount": 100,
+          "requestNanoseconds": 2291376
+        },
+        {
+          "controlNanoseconds": 2540,
+          "requestCount": 100,
+          "requestNanoseconds": 2269955
+        },
+        {
+          "controlNanoseconds": 2458,
+          "requestCount": 100,
+          "requestNanoseconds": 2300499
+        },
+        {
+          "controlNanoseconds": 2500,
+          "requestCount": 100,
+          "requestNanoseconds": 2277872
+        },
+        {
+          "controlNanoseconds": 2458,
+          "requestCount": 100,
+          "requestNanoseconds": 2315751
+        },
+        {
+          "controlNanoseconds": 2709,
+          "requestCount": 100,
+          "requestNanoseconds": 2274917
+        },
+        {
+          "controlNanoseconds": 2125,
+          "requestCount": 100,
+          "requestNanoseconds": 2287206
+        },
+        {
+          "controlNanoseconds": 2459,
+          "requestCount": 100,
+          "requestNanoseconds": 2338793
+        }
+      ],
+      "scenario": {
+        "expected": "bestEffort; distance <= 25.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-best-effort",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: best-effort",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 25.0",
+        "unit": "enhancement"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 3082,
+          "requestCount": 100,
+          "requestNanoseconds": 2456547
+        },
+        {
+          "controlNanoseconds": 3544,
+          "requestCount": 100,
+          "requestNanoseconds": 2558506
+        },
+        {
+          "controlNanoseconds": 2751,
+          "requestCount": 100,
+          "requestNanoseconds": 2536374
+        },
+        {
+          "controlNanoseconds": 3249,
+          "requestCount": 100,
+          "requestNanoseconds": 2541921
+        },
+        {
+          "controlNanoseconds": 3336,
+          "requestCount": 100,
+          "requestNanoseconds": 2472421
+        },
+        {
+          "controlNanoseconds": 3039,
+          "requestCount": 100,
+          "requestNanoseconds": 2451123
+        },
+        {
+          "controlNanoseconds": 2629,
+          "requestCount": 100,
+          "requestNanoseconds": 2427408
+        },
+        {
+          "controlNanoseconds": 2918,
+          "requestCount": 100,
+          "requestNanoseconds": 2442416
+        },
+        {
+          "controlNanoseconds": 2957,
+          "requestCount": 100,
+          "requestNanoseconds": 2328291
+        },
+        {
+          "controlNanoseconds": 2990,
+          "requestCount": 100,
+          "requestNanoseconds": 2415248
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-adjusted",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: adjusted",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2332,
+          "requestCount": 100,
+          "requestNanoseconds": 3024331
+        },
+        {
+          "controlNanoseconds": 2332,
+          "requestCount": 100,
+          "requestNanoseconds": 3143419
+        },
+        {
+          "controlNanoseconds": 2459,
+          "requestCount": 100,
+          "requestNanoseconds": 3153375
+        },
+        {
+          "controlNanoseconds": 2334,
+          "requestCount": 100,
+          "requestNanoseconds": 3170834
+        },
+        {
+          "controlNanoseconds": 1625,
+          "requestCount": 100,
+          "requestNanoseconds": 3173578
+        },
+        {
+          "controlNanoseconds": 2375,
+          "requestCount": 100,
+          "requestNanoseconds": 3187668
+        },
+        {
+          "controlNanoseconds": 1542,
+          "requestCount": 100,
+          "requestNanoseconds": 3173535
+        },
+        {
+          "controlNanoseconds": 1918,
+          "requestCount": 100,
+          "requestNanoseconds": 3178664
+        },
+        {
+          "controlNanoseconds": 2541,
+          "requestCount": 100,
+          "requestNanoseconds": 3181995
+        },
+        {
+          "controlNanoseconds": 2126,
+          "requestCount": 100,
+          "requestNanoseconds": 3162384
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-adjusted",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: adjusted",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2541,
+          "requestCount": 100,
+          "requestNanoseconds": 100791
+        },
+        {
+          "controlNanoseconds": 2544,
+          "requestCount": 100,
+          "requestNanoseconds": 105667
+        },
+        {
+          "controlNanoseconds": 2375,
+          "requestCount": 100,
+          "requestNanoseconds": 106170
+        },
+        {
+          "controlNanoseconds": 2417,
+          "requestCount": 100,
+          "requestNanoseconds": 95626
+        },
+        {
+          "controlNanoseconds": 2625,
+          "requestCount": 100,
+          "requestNanoseconds": 101794
+        },
+        {
+          "controlNanoseconds": 2833,
+          "requestCount": 100,
+          "requestNanoseconds": 116875
+        },
+        {
+          "controlNanoseconds": 2459,
+          "requestCount": 100,
+          "requestNanoseconds": 111085
+        },
+        {
+          "controlNanoseconds": 2709,
+          "requestCount": 100,
+          "requestNanoseconds": 111497
+        },
+        {
+          "controlNanoseconds": 2125,
+          "requestCount": 100,
+          "requestNanoseconds": 102126
+        },
+        {
+          "controlNanoseconds": 2208,
+          "requestCount": 100,
+          "requestNanoseconds": 95375
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-compliant",
+        "inputs": "sRGB RGBA foreground (0, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Budgeted enhancement: compliant",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2833,
+          "requestCount": 100,
+          "requestNanoseconds": 75418
+        },
+        {
+          "controlNanoseconds": 2580,
+          "requestCount": 100,
+          "requestNanoseconds": 68458
+        },
+        {
+          "controlNanoseconds": 2749,
+          "requestCount": 100,
+          "requestNanoseconds": 68915
+        },
+        {
+          "controlNanoseconds": 2669,
+          "requestCount": 100,
+          "requestNanoseconds": 69082
+        },
+        {
+          "controlNanoseconds": 2669,
+          "requestCount": 100,
+          "requestNanoseconds": 67960
+        },
+        {
+          "controlNanoseconds": 2583,
+          "requestCount": 100,
+          "requestNanoseconds": 67211
+        },
+        {
+          "controlNanoseconds": 2579,
+          "requestCount": 100,
+          "requestNanoseconds": 67166
+        },
+        {
+          "controlNanoseconds": 2542,
+          "requestCount": 100,
+          "requestNanoseconds": 66835
+        },
+        {
+          "controlNanoseconds": 2168,
+          "requestCount": 100,
+          "requestNanoseconds": 64205
+        },
+        {
+          "controlNanoseconds": 2208,
+          "requestCount": 100,
+          "requestNanoseconds": 58250
+        }
+      ],
+      "scenario": {
+        "expected": "Available CIEDE2000 100 and contrast 21",
+        "id": "comparison-black-white",
+        "inputs": "sRGB RGBA first (0, 0, 0, 1), second (1, 1, 1, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Compute all public color-comparison metrics",
+        "settings": "comparisonResult(with:)",
+        "unit": "comparison"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 2087,
+          "requestCount": 100,
+          "requestNanoseconds": 109418
+        },
+        {
+          "controlNanoseconds": 1419,
+          "requestCount": 100,
+          "requestNanoseconds": 112456
+        },
+        {
+          "controlNanoseconds": 1542,
+          "requestCount": 100,
+          "requestNanoseconds": 111205
+        },
+        {
+          "controlNanoseconds": 1286,
+          "requestCount": 100,
+          "requestNanoseconds": 116579
+        },
+        {
+          "controlNanoseconds": 1586,
+          "requestCount": 100,
+          "requestNanoseconds": 115873
+        },
+        {
+          "controlNanoseconds": 1793,
+          "requestCount": 100,
+          "requestNanoseconds": 112413
+        },
+        {
+          "controlNanoseconds": 1541,
+          "requestCount": 100,
+          "requestNanoseconds": 114041
+        },
+        {
+          "controlNanoseconds": 1498,
+          "requestCount": 100,
+          "requestNanoseconds": 112915
+        },
+        {
+          "controlNanoseconds": 1790,
+          "requestCount": 100,
+          "requestNanoseconds": 121212
+        },
+        {
+          "controlNanoseconds": 1455,
+          "requestCount": 100,
+          "requestNanoseconds": 119584
+        }
+      ],
+      "scenario": {
+        "expected": "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+        "id": "lab-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to D65 LAB components",
+        "settings": "labComponents()",
+        "unit": "conversion"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1583,
+          "requestCount": 100,
+          "requestNanoseconds": 220715
+        },
+        {
+          "controlNanoseconds": 1501,
+          "requestCount": 100,
+          "requestNanoseconds": 220133
+        },
+        {
+          "controlNanoseconds": 1584,
+          "requestCount": 100,
+          "requestNanoseconds": 207748
+        },
+        {
+          "controlNanoseconds": 1500,
+          "requestCount": 100,
+          "requestNanoseconds": 218095
+        },
+        {
+          "controlNanoseconds": 1624,
+          "requestCount": 100,
+          "requestNanoseconds": 210576
+        },
+        {
+          "controlNanoseconds": 1596,
+          "requestCount": 100,
+          "requestNanoseconds": 217553
+        },
+        {
+          "controlNanoseconds": 1707,
+          "requestCount": 100,
+          "requestNanoseconds": 209085
+        },
+        {
+          "controlNanoseconds": 1619,
+          "requestCount": 100,
+          "requestNanoseconds": 217499
+        },
+        {
+          "controlNanoseconds": 1539,
+          "requestCount": 100,
+          "requestNanoseconds": 209613
+        },
+        {
+          "controlNanoseconds": 1579,
+          "requestCount": 100,
+          "requestNanoseconds": 217169
+        }
+      ],
+      "scenario": {
+        "expected": "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+        "id": "lab-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to D65 LAB components",
+        "settings": "labComponents()",
+        "unit": "conversion"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 1625,
+          "requestCount": 100,
+          "requestNanoseconds": 119752
+        },
+        {
+          "controlNanoseconds": 1544,
+          "requestCount": 100,
+          "requestNanoseconds": 121042
+        },
+        {
+          "controlNanoseconds": 2000,
+          "requestCount": 100,
+          "requestNanoseconds": 116873
+        },
+        {
+          "controlNanoseconds": 1541,
+          "requestCount": 100,
+          "requestNanoseconds": 115885
+        },
+        {
+          "controlNanoseconds": 1995,
+          "requestCount": 100,
+          "requestNanoseconds": 114836
+        },
+        {
+          "controlNanoseconds": 2001,
+          "requestCount": 100,
+          "requestNanoseconds": 115255
+        },
+        {
+          "controlNanoseconds": 1712,
+          "requestCount": 100,
+          "requestNanoseconds": 115614
+        },
+        {
+          "controlNanoseconds": 1792,
+          "requestCount": 100,
+          "requestNanoseconds": 115051
+        },
+        {
+          "controlNanoseconds": 1832,
+          "requestCount": 100,
+          "requestNanoseconds": 127112
+        },
+        {
+          "controlNanoseconds": 1586,
+          "requestCount": 100,
+          "requestNanoseconds": 116413
+        }
+      ],
+      "scenario": {
+        "expected": "HSL (0, 1, 0.5), tolerance 0.001",
+        "id": "hsl-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to HSL components",
+        "settings": "hslComponents()",
+        "unit": "conversion"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1541,
+          "requestCount": 100,
+          "requestNanoseconds": 368250
+        },
+        {
+          "controlNanoseconds": 1582,
+          "requestCount": 100,
+          "requestNanoseconds": 355249
+        },
+        {
+          "controlNanoseconds": 1622,
+          "requestCount": 100,
+          "requestNanoseconds": 342414
+        },
+        {
+          "controlNanoseconds": 1624,
+          "requestCount": 100,
+          "requestNanoseconds": 349211
+        },
+        {
+          "controlNanoseconds": 1743,
+          "requestCount": 100,
+          "requestNanoseconds": 341499
+        },
+        {
+          "controlNanoseconds": 1542,
+          "requestCount": 100,
+          "requestNanoseconds": 341795
+        },
+        {
+          "controlNanoseconds": 1375,
+          "requestCount": 100,
+          "requestNanoseconds": 363295
+        },
+        {
+          "controlNanoseconds": 1416,
+          "requestCount": 100,
+          "requestNanoseconds": 348214
+        },
+        {
+          "controlNanoseconds": 1455,
+          "requestCount": 100,
+          "requestNanoseconds": 350372
+        },
+        {
+          "controlNanoseconds": 1667,
+          "requestCount": 100,
+          "requestNanoseconds": 348578
+        }
+      ],
+      "scenario": {
+        "expected": "HSL (0, 1, 0.5), tolerance 0.001",
+        "id": "hsl-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to HSL components",
+        "settings": "hslComponents()",
+        "unit": "conversion"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 3043,
+          "requestCount": 100,
+          "requestNanoseconds": 173456
+        },
+        {
+          "controlNanoseconds": 2959,
+          "requestCount": 100,
+          "requestNanoseconds": 170417
+        },
+        {
+          "controlNanoseconds": 2539,
+          "requestCount": 100,
+          "requestNanoseconds": 160581
+        },
+        {
+          "controlNanoseconds": 2458,
+          "requestCount": 100,
+          "requestNanoseconds": 159833
+        },
+        {
+          "controlNanoseconds": 2625,
+          "requestCount": 100,
+          "requestNanoseconds": 167623
+        },
+        {
+          "controlNanoseconds": 2666,
+          "requestCount": 100,
+          "requestNanoseconds": 161664
+        },
+        {
+          "controlNanoseconds": 2581,
+          "requestCount": 100,
+          "requestNanoseconds": 158916
+        },
+        {
+          "controlNanoseconds": 2457,
+          "requestCount": 100,
+          "requestNanoseconds": 159336
+        },
+        {
+          "controlNanoseconds": 2959,
+          "requestCount": 100,
+          "requestNanoseconds": 169537
+        },
+        {
+          "controlNanoseconds": 2794,
+          "requestCount": 100,
+          "requestNanoseconds": 177332
+        }
+      ],
+      "scenario": {
+        "expected": "Seven successes; red coordinates and #FF0000FF",
+        "id": "component-results-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Convert fixed red to all seven independent component results",
+        "settings": "componentConversionResults()",
+        "unit": "aggregate conversion"
+      },
+      "run": 2
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2956,
+          "requestCount": 100,
+          "requestNanoseconds": 173538
+        },
+        {
+          "controlNanoseconds": 2745,
+          "requestCount": 100,
+          "requestNanoseconds": 170871
+        },
+        {
+          "controlNanoseconds": 2921,
+          "requestCount": 100,
+          "requestNanoseconds": 180581
+        },
+        {
+          "controlNanoseconds": 2712,
+          "requestCount": 100,
+          "requestNanoseconds": 161874
+        },
+        {
+          "controlNanoseconds": 2668,
+          "requestCount": 100,
+          "requestNanoseconds": 162081
+        },
+        {
+          "controlNanoseconds": 2793,
+          "requestCount": 100,
+          "requestNanoseconds": 172370
+        },
+        {
+          "controlNanoseconds": 3000,
+          "requestCount": 100,
+          "requestNanoseconds": 179960
+        },
+        {
+          "controlNanoseconds": 2958,
+          "requestCount": 100,
+          "requestNanoseconds": 174454
+        },
+        {
+          "controlNanoseconds": 3045,
+          "requestCount": 100,
+          "requestNanoseconds": 165248
+        },
+        {
+          "controlNanoseconds": 2960,
+          "requestCount": 100,
+          "requestNanoseconds": 181086
+        }
+      ],
+      "scenario": {
+        "expected": "Seven successes; red coordinates and #FF0000FF",
+        "id": "component-results-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Convert fixed red to all seven independent component results",
+        "settings": "componentConversionResults()",
+        "unit": "aggregate conversion"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1250,
+          "requestCount": 100,
+          "requestNanoseconds": 368076
+        },
+        {
+          "controlNanoseconds": 1376,
+          "requestCount": 100,
+          "requestNanoseconds": 344995
+        },
+        {
+          "controlNanoseconds": 1459,
+          "requestCount": 100,
+          "requestNanoseconds": 343790
+        },
+        {
+          "controlNanoseconds": 1627,
+          "requestCount": 100,
+          "requestNanoseconds": 341539
+        },
+        {
+          "controlNanoseconds": 1749,
+          "requestCount": 100,
+          "requestNanoseconds": 376331
+        },
+        {
+          "controlNanoseconds": 1708,
+          "requestCount": 100,
+          "requestNanoseconds": 353834
+        },
+        {
+          "controlNanoseconds": 1625,
+          "requestCount": 100,
+          "requestNanoseconds": 342006
+        },
+        {
+          "controlNanoseconds": 1630,
+          "requestCount": 100,
+          "requestNanoseconds": 341414
+        },
+        {
+          "controlNanoseconds": 1627,
+          "requestCount": 100,
+          "requestNanoseconds": 358411
+        },
+        {
+          "controlNanoseconds": 1458,
+          "requestCount": 100,
+          "requestNanoseconds": 347203
+        }
+      ],
+      "scenario": {
+        "expected": "HSL (0, 1, 0.5), tolerance 0.001",
+        "id": "hsl-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to HSL components",
+        "settings": "hslComponents()",
+        "unit": "conversion"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 2457,
+          "requestCount": 100,
+          "requestNanoseconds": 118921
+        },
+        {
+          "controlNanoseconds": 2542,
+          "requestCount": 100,
+          "requestNanoseconds": 114589
+        },
+        {
+          "controlNanoseconds": 2328,
+          "requestCount": 100,
+          "requestNanoseconds": 114787
+        },
+        {
+          "controlNanoseconds": 1581,
+          "requestCount": 100,
+          "requestNanoseconds": 120835
+        },
+        {
+          "controlNanoseconds": 2043,
+          "requestCount": 100,
+          "requestNanoseconds": 114335
+        },
+        {
+          "controlNanoseconds": 2249,
+          "requestCount": 100,
+          "requestNanoseconds": 113333
+        },
+        {
+          "controlNanoseconds": 2537,
+          "requestCount": 100,
+          "requestNanoseconds": 115379
+        },
+        {
+          "controlNanoseconds": 2205,
+          "requestCount": 100,
+          "requestNanoseconds": 113498
+        },
+        {
+          "controlNanoseconds": 2131,
+          "requestCount": 100,
+          "requestNanoseconds": 114580
+        },
+        {
+          "controlNanoseconds": 2416,
+          "requestCount": 100,
+          "requestNanoseconds": 119839
+        }
+      ],
+      "scenario": {
+        "expected": "HSL (0, 1, 0.5), tolerance 0.001",
+        "id": "hsl-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to HSL components",
+        "settings": "hslComponents()",
+        "unit": "conversion"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1666,
+          "requestCount": 100,
+          "requestNanoseconds": 248879
+        },
+        {
+          "controlNanoseconds": 1666,
+          "requestCount": 100,
+          "requestNanoseconds": 194785
+        },
+        {
+          "controlNanoseconds": 1583,
+          "requestCount": 100,
+          "requestNanoseconds": 193912
+        },
+        {
+          "controlNanoseconds": 1583,
+          "requestCount": 100,
+          "requestNanoseconds": 195214
+        },
+        {
+          "controlNanoseconds": 1541,
+          "requestCount": 100,
+          "requestNanoseconds": 202541
+        },
+        {
+          "controlNanoseconds": 1584,
+          "requestCount": 100,
+          "requestNanoseconds": 215497
+        },
+        {
+          "controlNanoseconds": 1500,
+          "requestCount": 100,
+          "requestNanoseconds": 206251
+        },
+        {
+          "controlNanoseconds": 1625,
+          "requestCount": 100,
+          "requestNanoseconds": 211911
+        },
+        {
+          "controlNanoseconds": 1665,
+          "requestCount": 100,
+          "requestNanoseconds": 209588
+        },
+        {
+          "controlNanoseconds": 1584,
+          "requestCount": 100,
+          "requestNanoseconds": 209296
+        }
+      ],
+      "scenario": {
+        "expected": "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+        "id": "lab-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to D65 LAB components",
+        "settings": "labComponents()",
+        "unit": "conversion"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 1293,
+          "requestCount": 100,
+          "requestNanoseconds": 128206
+        },
+        {
+          "controlNanoseconds": 1788,
+          "requestCount": 100,
+          "requestNanoseconds": 122205
+        },
+        {
+          "controlNanoseconds": 1336,
+          "requestCount": 100,
+          "requestNanoseconds": 121209
+        },
+        {
+          "controlNanoseconds": 998,
+          "requestCount": 100,
+          "requestNanoseconds": 124626
+        },
+        {
+          "controlNanoseconds": 1624,
+          "requestCount": 100,
+          "requestNanoseconds": 121295
+        },
+        {
+          "controlNanoseconds": 1879,
+          "requestCount": 100,
+          "requestNanoseconds": 120661
+        },
+        {
+          "controlNanoseconds": 1666,
+          "requestCount": 100,
+          "requestNanoseconds": 122958
+        },
+        {
+          "controlNanoseconds": 1500,
+          "requestCount": 100,
+          "requestNanoseconds": 122421
+        },
+        {
+          "controlNanoseconds": 1332,
+          "requestCount": 100,
+          "requestNanoseconds": 121830
+        },
+        {
+          "controlNanoseconds": 1624,
+          "requestCount": 100,
+          "requestNanoseconds": 121415
+        }
+      ],
+      "scenario": {
+        "expected": "LAB (53.2408, 80.0925, 67.2032), tolerance 0.001",
+        "id": "lab-red",
+        "inputs": "sRGB RGBA (1, 0, 0, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Convert fixed red to D65 LAB components",
+        "settings": "labComponents()",
+        "unit": "conversion"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2711,
+          "requestCount": 100,
+          "requestNanoseconds": 64584
+        },
+        {
+          "controlNanoseconds": 2542,
+          "requestCount": 100,
+          "requestNanoseconds": 59668
+        },
+        {
+          "controlNanoseconds": 2584,
+          "requestCount": 100,
+          "requestNanoseconds": 60079
+        },
+        {
+          "controlNanoseconds": 2918,
+          "requestCount": 100,
+          "requestNanoseconds": 66750
+        },
+        {
+          "controlNanoseconds": 3041,
+          "requestCount": 100,
+          "requestNanoseconds": 66793
+        },
+        {
+          "controlNanoseconds": 2918,
+          "requestCount": 100,
+          "requestNanoseconds": 67208
+        },
+        {
+          "controlNanoseconds": 2791,
+          "requestCount": 100,
+          "requestNanoseconds": 59955
+        },
+        {
+          "controlNanoseconds": 2458,
+          "requestCount": 100,
+          "requestNanoseconds": 60085
+        },
+        {
+          "controlNanoseconds": 2710,
+          "requestCount": 100,
+          "requestNanoseconds": 59919
+        },
+        {
+          "controlNanoseconds": 2583,
+          "requestCount": 100,
+          "requestNanoseconds": 59668
+        }
+      ],
+      "scenario": {
+        "expected": "Available CIEDE2000 100 and contrast 21",
+        "id": "comparison-black-white",
+        "inputs": "sRGB RGBA first (0, 0, 0, 1), second (1, 1, 1, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Compute all public color-comparison metrics",
+        "settings": "comparisonResult(with:)",
+        "unit": "comparison"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "unused",
+      "samples": [
+        {
+          "controlNanoseconds": 2502,
+          "requestCount": 100,
+          "requestNanoseconds": 97040
+        },
+        {
+          "controlNanoseconds": 2375,
+          "requestCount": 100,
+          "requestNanoseconds": 101164
+        },
+        {
+          "controlNanoseconds": 2417,
+          "requestCount": 100,
+          "requestNanoseconds": 96955
+        },
+        {
+          "controlNanoseconds": 2332,
+          "requestCount": 100,
+          "requestNanoseconds": 102748
+        },
+        {
+          "controlNanoseconds": 2459,
+          "requestCount": 100,
+          "requestNanoseconds": 102751
+        },
+        {
+          "controlNanoseconds": 2416,
+          "requestCount": 100,
+          "requestNanoseconds": 102790
+        },
+        {
+          "controlNanoseconds": 2042,
+          "requestCount": 100,
+          "requestNanoseconds": 98501
+        },
+        {
+          "controlNanoseconds": 2124,
+          "requestCount": 100,
+          "requestNanoseconds": 103083
+        },
+        {
+          "controlNanoseconds": 2417,
+          "requestCount": 100,
+          "requestNanoseconds": 103540
+        },
+        {
+          "controlNanoseconds": 2456,
+          "requestCount": 100,
+          "requestNanoseconds": 103043
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-compliant",
+        "inputs": "sRGB RGBA foreground (0, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "unused"
+        ],
+        "purpose": "Budgeted enhancement: compliant",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 2207,
+          "requestCount": 100,
+          "requestNanoseconds": 3269423
+        },
+        {
+          "controlNanoseconds": 2082,
+          "requestCount": 100,
+          "requestNanoseconds": 3270284
+        },
+        {
+          "controlNanoseconds": 2207,
+          "requestCount": 100,
+          "requestNanoseconds": 3248041
+        },
+        {
+          "controlNanoseconds": 2542,
+          "requestCount": 100,
+          "requestNanoseconds": 3262546
+        },
+        {
+          "controlNanoseconds": 2000,
+          "requestCount": 100,
+          "requestNanoseconds": 3273629
+        },
+        {
+          "controlNanoseconds": 2374,
+          "requestCount": 100,
+          "requestNanoseconds": 3269625
+        },
+        {
+          "controlNanoseconds": 2497,
+          "requestCount": 100,
+          "requestNanoseconds": 3246048
+        },
+        {
+          "controlNanoseconds": 2167,
+          "requestCount": 100,
+          "requestNanoseconds": 3238375
+        },
+        {
+          "controlNanoseconds": 2084,
+          "requestCount": 100,
+          "requestNanoseconds": 3266085
+        },
+        {
+          "controlNanoseconds": 1958,
+          "requestCount": 100,
+          "requestNanoseconds": 3247665
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-adjusted",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: adjusted",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 2786,
+          "requestCount": 100,
+          "requestNanoseconds": 2451043
+        },
+        {
+          "controlNanoseconds": 3419,
+          "requestCount": 100,
+          "requestNanoseconds": 2496213
+        },
+        {
+          "controlNanoseconds": 3160,
+          "requestCount": 100,
+          "requestNanoseconds": 2502001
+        },
+        {
+          "controlNanoseconds": 3211,
+          "requestCount": 100,
+          "requestNanoseconds": 2513501
+        },
+        {
+          "controlNanoseconds": 2746,
+          "requestCount": 100,
+          "requestNanoseconds": 2406916
+        },
+        {
+          "controlNanoseconds": 3627,
+          "requestCount": 100,
+          "requestNanoseconds": 2486249
+        },
+        {
+          "controlNanoseconds": 2836,
+          "requestCount": 100,
+          "requestNanoseconds": 2439288
+        },
+        {
+          "controlNanoseconds": 3000,
+          "requestCount": 100,
+          "requestNanoseconds": 2436544
+        },
+        {
+          "controlNanoseconds": 2495,
+          "requestCount": 100,
+          "requestNanoseconds": 2430000
+        },
+        {
+          "controlNanoseconds": 2916,
+          "requestCount": 100,
+          "requestNanoseconds": 2451465
+        }
+      ],
+      "scenario": {
+        "expected": "meetsTarget; distance <= 100.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-adjusted",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: adjusted",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 100.0",
+        "unit": "enhancement"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1871,
+          "requestCount": 100,
+          "requestNanoseconds": 2480491
+        },
+        {
+          "controlNanoseconds": 2168,
+          "requestCount": 100,
+          "requestNanoseconds": 2530301
+        },
+        {
+          "controlNanoseconds": 2292,
+          "requestCount": 100,
+          "requestNanoseconds": 2571919
+        },
+        {
+          "controlNanoseconds": 2168,
+          "requestCount": 100,
+          "requestNanoseconds": 2625210
+        },
+        {
+          "controlNanoseconds": 1792,
+          "requestCount": 100,
+          "requestNanoseconds": 2590872
+        },
+        {
+          "controlNanoseconds": 1707,
+          "requestCount": 100,
+          "requestNanoseconds": 2644624
+        },
+        {
+          "controlNanoseconds": 2792,
+          "requestCount": 100,
+          "requestNanoseconds": 2687207
+        },
+        {
+          "controlNanoseconds": 2291,
+          "requestCount": 100,
+          "requestNanoseconds": 2610918
+        },
+        {
+          "controlNanoseconds": 2208,
+          "requestCount": 100,
+          "requestNanoseconds": 2608292
+        },
+        {
+          "controlNanoseconds": 2167,
+          "requestCount": 100,
+          "requestNanoseconds": 2608171
+        }
+      ],
+      "scenario": {
+        "expected": "bestEffort; distance <= 25.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-best-effort",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: best-effort",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 25.0",
+        "unit": "enhancement"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 2750,
+          "requestCount": 100,
+          "requestNanoseconds": 1898084
+        },
+        {
+          "controlNanoseconds": 3004,
+          "requestCount": 100,
+          "requestNanoseconds": 2008505
+        },
+        {
+          "controlNanoseconds": 2506,
+          "requestCount": 100,
+          "requestNanoseconds": 2011581
+        },
+        {
+          "controlNanoseconds": 2956,
+          "requestCount": 100,
+          "requestNanoseconds": 2080573
+        },
+        {
+          "controlNanoseconds": 2956,
+          "requestCount": 100,
+          "requestNanoseconds": 2017420
+        },
+        {
+          "controlNanoseconds": 2498,
+          "requestCount": 100,
+          "requestNanoseconds": 1931666
+        },
+        {
+          "controlNanoseconds": 2210,
+          "requestCount": 100,
+          "requestNanoseconds": 1933616
+        },
+        {
+          "controlNanoseconds": 2498,
+          "requestCount": 100,
+          "requestNanoseconds": 1964082
+        },
+        {
+          "controlNanoseconds": 3044,
+          "requestCount": 100,
+          "requestNanoseconds": 1876713
+        },
+        {
+          "controlNanoseconds": 2874,
+          "requestCount": 100,
+          "requestNanoseconds": 1866456
+        }
+      ],
+      "scenario": {
+        "expected": "bestEffort; distance <= 25.0; best effort improves contrast; compliant preserves input",
+        "id": "enhancement-best-effort",
+        "inputs": "sRGB RGBA foreground (0.8, 0.8, 0.8, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Budgeted enhancement: best-effort",
+        "settings": "AA, preserveHue, preferDarker true, distance budget 25.0",
+        "unit": "enhancement"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "empty",
+      "samples": [
+        {
+          "controlNanoseconds": 1875,
+          "requestCount": 100,
+          "requestNanoseconds": 6816213
+        },
+        {
+          "controlNanoseconds": 2126,
+          "requestCount": 100,
+          "requestNanoseconds": 7388666
+        },
+        {
+          "controlNanoseconds": 2082,
+          "requestCount": 100,
+          "requestNanoseconds": 6772375
+        },
+        {
+          "controlNanoseconds": 1998,
+          "requestCount": 100,
+          "requestNanoseconds": 6817031
+        },
+        {
+          "controlNanoseconds": 1667,
+          "requestCount": 100,
+          "requestNanoseconds": 7033957
+        },
+        {
+          "controlNanoseconds": 1792,
+          "requestCount": 100,
+          "requestNanoseconds": 6971080
+        },
+        {
+          "controlNanoseconds": 1958,
+          "requestCount": 100,
+          "requestNanoseconds": 6809709
+        },
+        {
+          "controlNanoseconds": 1748,
+          "requestCount": 100,
+          "requestNanoseconds": 6727995
+        },
+        {
+          "controlNanoseconds": 1626,
+          "requestCount": 100,
+          "requestNanoseconds": 6444293
+        },
+        {
+          "controlNanoseconds": 1544,
+          "requestCount": 100,
+          "requestNanoseconds": 7116043
+        }
+      ],
+      "scenario": {
+        "expected": "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+        "id": "palette-red-five",
+        "inputs": "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Generate and assess one five-color palette (stochastic candidate search)",
+        "settings": "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+        "unit": "palette"
+      },
+      "run": 3
+    },
+    {
+      "cacheMode": "primed",
+      "samples": [
+        {
+          "controlNanoseconds": 3088,
+          "requestCount": 100,
+          "requestNanoseconds": 6595590
+        },
+        {
+          "controlNanoseconds": 2674,
+          "requestCount": 100,
+          "requestNanoseconds": 6433624
+        },
+        {
+          "controlNanoseconds": 3083,
+          "requestCount": 100,
+          "requestNanoseconds": 5971747
+        },
+        {
+          "controlNanoseconds": 2379,
+          "requestCount": 100,
+          "requestNanoseconds": 5876168
+        },
+        {
+          "controlNanoseconds": 2670,
+          "requestCount": 100,
+          "requestNanoseconds": 6493826
+        },
+        {
+          "controlNanoseconds": 2714,
+          "requestCount": 100,
+          "requestNanoseconds": 5876879
+        },
+        {
+          "controlNanoseconds": 3207,
+          "requestCount": 100,
+          "requestNanoseconds": 6286130
+        },
+        {
+          "controlNanoseconds": 2911,
+          "requestCount": 100,
+          "requestNanoseconds": 6256751
+        },
+        {
+          "controlNanoseconds": 2086,
+          "requestCount": 100,
+          "requestNanoseconds": 6495498
+        },
+        {
+          "controlNanoseconds": 2579,
+          "requestCount": 100,
+          "requestNanoseconds": 5983200
+        }
+      ],
+      "scenario": {
+        "expected": "Five entries, seed first; each assessment matches its color against white; entries need not all pass AA",
+        "id": "palette-red-five",
+        "inputs": "sRGB RGBA seed (1, 0, 0, 1), background (1, 1, 1, 1)",
+        "modes": [
+          "empty",
+          "primed"
+        ],
+        "purpose": "Generate and assess one five-color palette (stochastic candidate search)",
+        "settings": "AA, paletteSize 5, includeBlackAndWhite true; internal unseeded random hue shifts; candidate work varies; priming uses a different generated palette",
+        "unit": "palette"
+      },
+      "run": 3
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Independently validate the component-conversion API integrated through #62 and #63 before considering ColorKit 3.1. Public-client tests distinguish complete success, partial availability, and unavailable input without internal imports. No production behavior or released-client baseline changes.

## Changes

- Add independent public-import assertions and a separate macOS consumer app with hosted inspection and explicit appearance capture.
- Add one seven-field aggregate workload to the existing Release benchmark harness, preserving timing boundaries and result consumption.
- Retain the assessment, raw samples, environment metadata, and disassembly evidence under `docs/validation/component-conversion-2026-09-08/`.

## Alternatives considered

Existing catalog/internal tests alone do not prove separate consumer adoption. Individual legacy conversion timings measure different contracts. Reuse the existing harness and adoption documentation instead of creating replacements.

## Notes

- Scoped assessment: PASS; no production defects found against integrated candidate `bc46e3e`.
- Aggregate red workload: median 1,682.5 ns/request, sample-mean range 1,589.2–1,810.9 ns, control 27.1 ns without subtraction. Apple M4 Pro, macOS 26.6.2, Xcode 26.5; 3,000 measured requests. These are reference measurements, not speedup claims or thresholds.
- After 3.1 publication, freeze the existing nonisolated fixture against its actual released commit, including payload getter/equality coverage. Frozen 3.0.0 clients remain unchanged.
- Consumer hosting is macOS-only. Minimum-OS runtime, physical devices, binary compatibility, full release matrix, and final CI are outside this evidence.
- Existing DocC, English/Spanish examples, and adoption guidance agree with implementation.

## Screenshots

Native hosted-view captures of the separate macOS consumer's inspection view in light and dark appearance. A temporary capture driver selects each sample and appearance and supplies the native window background; the view and conversion code are unchanged. Captures are attached here, not committed to the repository.

| Input | Light | Dark |
| --- | --- | --- |
| Fixed black — 7/7 available | <img src="https://github.com/user-attachments/assets/b5d7cf37-ec3f-4a25-aea7-7843ff059ce1" alt="Fixed black — 7/7 available, light appearance" width="600"> | <img src="https://github.com/user-attachments/assets/36679c38-8e4a-4bc8-aced-a645c639ea8c" alt="Fixed black — 7/7 available, dark appearance" width="600"> |
| Display P3 red — 3/7 available | <img src="https://github.com/user-attachments/assets/ae5891ca-fe8b-41bc-a795-56df99dc22b7" alt="Display P3 red — 3/7 available, light appearance" width="600"> | <img src="https://github.com/user-attachments/assets/673462c6-ef18-4e15-b86f-e9a1ae9b57e1" alt="Display P3 red — 3/7 available, dark appearance" width="600"> |
| Dynamic primary — 0/7 available | <img src="https://github.com/user-attachments/assets/450e4f00-b4f5-4926-83bf-a51d986da11f" alt="Dynamic primary — 0/7 available, light appearance" width="600"> | <img src="https://github.com/user-attachments/assets/cc56a491-1c9b-4d87-8a4b-ab6b9a9863cf" alt="Dynamic primary — 0/7 available, dark appearance" width="600"> |

## Testing

- PASS: released 3.0.0 public clients and API comparison on macOS and iOS Simulator.
- PASS: 71 existing focused XCTest tests per platform; independent public-import tests on both platforms (3 functions, 5 invocations).
- PASS: separate Release consumer smoke run, including 7/7, 3/7, 0/7 availability and light/dark capture.
- PASS: DocC warnings-as-errors; 35 actual examples and nonisolated fixture compile on both platforms; 8 actual README examples execute on macOS.
- PASS: `swift test --package-path Benchmarks -c release` (5 tests; rerun before opening), complete Release measurement run, strict SwiftLint, documentation/evidence checks, and `git diff --check`.
