### PR TITLE
doc(release): Prepare ColorKit 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-09-09
+
 ### Added
 - Add `Color.componentConversionResults()` with independent results for sRGBA, HSL, HSB, CMYK, XYZ, LAB, and Hex from one fixed color. Preserve extended sRGBA and finite D65 XYZ/LAB; report unavailable bounded representations without clipping. Include typed diagnostics, explicit alpha/appearance limits, and signed extended-sRGB decoding with exact LAB constants. Existing conversion APIs and legacy calculations remain unchanged, with no deprecations.
+- Add a Component Results catalog example showing genuine zeros, partial availability, and unavailable fixed components with per-representation explanations.
+
+### Tooling
+- Add independent public-client conversion checks, a separate macOS consumer fixture, and a representative aggregate-conversion Release benchmark with retained validation evidence.
 
 ## [3.0.1] - 2026-09-07
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-## Unreleased additions for ColorKit 3.1
+## ColorKit 3.1.0
 
 ### Component conversion results
 

--- a/Sources/ColorKit/ColorKit.swift
+++ b/Sources/ColorKit/ColorKit.swift
@@ -41,7 +41,7 @@ public enum ColorKit {
     /// - MAJOR version for incompatible API changes
     /// - MINOR version for added functionality in a backward compatible manner
     /// - PATCH version for backward compatible bug fixes
-    public static let version = "3.0.1"
+    public static let version = "3.1.0"
 
     /// WCAG Compliance Checker namespace.
     ///


### PR DESCRIPTION
## Summary

Prepare ColorKit 3.1.0 for stable publication using the existing release process.

## Changes

- Set ColorKit.version to 3.1.0 and date the changelog.
- Finalize the adoption-guide heading and include the catalog example and independent validation in release notes.

## Alternatives considered

The maintainer chose direct stable publication rather than introducing release-candidate tooling. Existing compatibility, behavioral, and documentation gates remain required.

## Notes

Component conversion is additive; existing APIs and legacy calculations remain unchanged. No new deprecations or platform requirements. The clean-main release preflight will run after merge. Validation does not establish minimum-OS runtime coverage, physical-device coverage, or separate iOS consumer hosting. Registering the new client against the exact stable release commit remains a post-publication follow-up.

## Screenshots

Not applicable; no UI changes.

## Testing

- PASS: canonical iOS/macOS test matrix, including serialized shared-state suites.
- PASS: 25 tooling tests and strict SwiftLint with zero violations in 121 files.
- PASS: DocC warnings-as-errors, compiled public examples, eight README runtime checks, and generated theme code.
- PASS: diff whitespace and metadata review; no added TODO/FIXME markers.

Local logs: /tmp/colorkit-310-tests.log, /tmp/colorkit-310-tooling.log, /tmp/colorkit-310-lint.log, /tmp/colorkit-310-docs.log, and /tmp/colorkit-310-examples.log.
