### PR TITLE
feat(examples): add a runnable contrast-pair report

### DIFF
--- a/Examples/ContrastPairReport/.gitignore
+++ b/Examples/ContrastPairReport/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/Examples/ContrastPairReport/Package.swift
+++ b/Examples/ContrastPairReport/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "ContrastPairReport",
+    platforms: [.macOS(.v14)],
+    dependencies: [.package(name: "ColorKit", path: "../..")],
+    targets: [
+        .executableTarget(
+            name: "ContrastPairReport",
+            dependencies: [.product(name: "ColorKit", package: "ColorKit")]
+        ),
+        .testTarget(name: "ContrastPairReportTests", dependencies: ["ContrastPairReport"])
+    ]
+)

--- a/Examples/ContrastPairReport/README.md
+++ b/Examples/ContrastPairReport/README.md
@@ -1,0 +1,29 @@
+# Contrast pair report
+
+Standalone macOS example using public ColorKit APIs. Requires macOS 14+ and
+Swift 6.2+. From the repository root:
+
+```sh
+swift run --package-path Examples/ContrastPairReport ContrastPairReport
+# Control-C stops the process. Run the separate empty case with:
+swift run --package-path Examples/ContrastPairReport ContrastPairReport --empty
+swift test --package-path Examples/ContrastPairReport
+```
+
+Edit `Samples` in `Sources/ContrastPairReport/ContrastPairReportApp.swift` to supply
+ordered foreground/background pairs with labels and explicit WCAG targets.
+Samples cover passes, a shortfall, duplicate labels and identical pairs,
+a translucent background, and independently unresolved inputs.
+
+Callers own appearance capture. Supply fixed colors for the intended appearance;
+`.primary` deliberately demonstrates unavailability. The report neither captures
+ambient appearance nor evaluates both appearances. Classification uses unrounded
+ratios; display uses two decimals and the current locale. Unavailable rows report
+both input issue lists without inventing a ratio. This is not a whole-app
+accessibility compliance assessment.
+
+Validated on Apple Silicon macOS 26.6.2 with Swift 6.3.2: executable build,
+six tests (including rounding boundaries for all four targets), strict lint,
+and manual inspection of populated/empty windows and scrolling. No iOS host,
+Intel build, minimum-OS runtime, or full VoiceOver interaction was tested.
+All code stays outside the library target; no additional public API is needed.

--- a/Examples/ContrastPairReport/Sources/ContrastPairReport/ContrastPairReportApp.swift
+++ b/Examples/ContrastPairReport/Sources/ContrastPairReport/ContrastPairReportApp.swift
@@ -1,0 +1,94 @@
+import AppKit
+import SwiftUI
+
+// A SwiftPM executable avoids an Xcode project and signing setup.
+@main
+struct ContrastPairReportApp {
+    @MainActor
+    static func main() {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        let report = PairReport(pairs: CommandLine.arguments.contains("--empty") ? Samples.empty : Samples.pairs)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 860, height: 820),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Contrast Pair Report"
+        window.minSize = NSSize(width: 780, height: 350)
+        window.contentView = NSHostingView(rootView: ReportView(report: report))
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate()
+        app.run()
+    }
+}
+
+struct ReportView: View {
+    let report: PairReport
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Contrast pair report").font(.title)
+                Text("Explicit pairs only. This report does not establish whole-app accessibility compliance.")
+                Text(report.summary).font(.headline)
+                Text("Ratios are displayed to two decimals; outcomes use the unrounded measurement.")
+                    .font(.caption)
+                // The report is immutable. Position preserves duplicates; labels are never identity.
+                ForEach(report.rows.indices, id: \.self) { index in
+                    assessment(report.rows[index])
+                    Divider()
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func assessment(_ row: PairAssessment) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(row.pair.label).font(.headline)
+            Text("Target: \(row.pair.target.rawValue) • Required: \(PairAssessment.ratioText(row.pair.target.minimumRatio))")
+            switch row.result {
+            case .available(let measurement):
+                HStack(spacing: 16) {
+                    swatch(row.pair.foreground, label: "Foreground")
+                    swatch(row.pair.background, label: "Background")
+                    Text("Measured: \(PairAssessment.ratioText(measurement.ratio))")
+                    Text(row.outcome.rawValue).bold()
+                }
+            case .unavailable(let issues):
+                Text(row.outcome.rawValue).bold()
+                Text("Foreground: \(PairAssessment.issueText(issues.foreground))")
+                Text("Background: \(PairAssessment.issueText(issues.background))")
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func swatch(_ color: Color, label: String) -> some View {
+        HStack {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(color)
+                .overlay(RoundedRectangle(cornerRadius: 4).stroke(.primary, lineWidth: 1))
+                .frame(width: 28, height: 28)
+                .accessibilityHidden(true)
+            Text(label)
+        }
+    }
+}
+
+// Explicit sRGB values are independent of the host's appearance.
+enum Samples {
+    static let pairs: [ContrastPair] = [
+        .init(label: "Body text", foreground: .black, background: .white, target: .AAA),
+        .init(label: "Body text", foreground: Color(.sRGB, white: 0.7), background: .white, target: .AA),
+        .init(label: "Body text", foreground: .black, background: .white, target: .AAA),
+        .init(label: "Large heading", foreground: .black, background: .white, target: .AALarge),
+        .init(label: "Translucent surface", foreground: .black, background: .white.opacity(0.5), target: .AAALarge),
+        .init(label: "Unresolved pair", foreground: .primary, background: .primary, target: .AA)
+    ]
+    static let empty: [ContrastPair] = []
+}

--- a/Examples/ContrastPairReport/Sources/ContrastPairReport/PairReport.swift
+++ b/Examples/ContrastPairReport/Sources/ContrastPairReport/PairReport.swift
@@ -1,0 +1,64 @@
+import ColorKit
+import SwiftUI
+
+// Callers supply fixed colors, capturing a chosen appearance themselves if needed.
+struct ContrastPair {
+    let label: String
+    let foreground: Color
+    let background: Color
+    let target: WCAGContrastLevel
+}
+
+struct PairAssessment {
+    let pair: ContrastPair
+    let result: ColorContrastResult
+
+    init(pair: ContrastPair) {
+        self.pair = pair
+        result = pair.foreground.contrastResult(with: pair.background)
+    }
+
+    enum Outcome: String {
+        case meetsTarget = "Meets target"
+        case belowTarget = "Below target"
+        case unavailable = "Unavailable"
+    }
+
+    var outcome: Outcome {
+        guard case .available(let measurement) = result else { return .unavailable }
+        return measurement.ratio >= pair.target.minimumRatio ? .meetsTarget : .belowTarget
+    }
+
+    static func ratioText(_ ratio: Double) -> String {
+        ratio.formatted(.number.precision(.fractionLength(2))) + ":1"
+    }
+
+    static func issueText(_ issues: [ContrastInputIssue]) -> String {
+        guard !issues.isEmpty else { return "No issues reported" }
+        return issues.map { issue in
+            switch issue {
+            case .unresolved: "Cannot resolve to fixed, finite sRGB components"
+            case .outOfSRGBGamut: "Outside the sRGB gamut"
+            case .translucentBackground: "Background is not opaque"
+            }
+        }
+        .joined(separator: "; ")
+    }
+}
+
+struct PairReport {
+    let rows: [PairAssessment]
+
+    init(pairs: [ContrastPair]) {
+        rows = pairs.map(PairAssessment.init)
+    }
+
+    func count(_ outcome: PairAssessment.Outcome) -> Int {
+        rows.filter { $0.outcome == outcome }.count
+    }
+
+    var summary: String {
+        guard !rows.isEmpty else { return "No pairs assessed." }
+        return "Meets target: \(count(.meetsTarget)) • Below target: \(count(.belowTarget)) • Unavailable: \(count(.unavailable))"
+    }
+}

--- a/Examples/ContrastPairReport/Tests/ContrastPairReportTests/PairReportTests.swift
+++ b/Examples/ContrastPairReport/Tests/ContrastPairReportTests/PairReportTests.swift
@@ -1,0 +1,101 @@
+import ColorKit
+@testable import ContrastPairReport
+import Foundation
+import SwiftUI
+import Testing
+
+struct PairReportTests {
+    @Test
+    func samplesPreserveOrderDuplicatesTargetsAndCounts() {
+        let report = PairReport(pairs: Samples.pairs)
+        #expect(report.rows.map(\.pair.label) == [
+            "Body text", "Body text", "Body text", "Large heading", "Translucent surface", "Unresolved pair"
+        ])
+        #expect(report.rows.map(\.pair.target) == [.AAA, .AA, .AAA, .AALarge, .AAALarge, .AA])
+        #expect(report.rows.map(\.outcome) == [
+            .meetsTarget, .belowTarget, .meetsTarget, .meetsTarget, .unavailable, .unavailable
+        ])
+        #expect(report.rows[0].result == report.rows[2].result)
+        #expect(report.rows[0].result.ratio == 21)
+        #expect(report.count(.meetsTarget) == 3)
+        #expect(report.count(.belowTarget) == 1)
+        #expect(report.count(.unavailable) == 2)
+        #expect(report.summary == "Meets target: 3 • Below target: 1 • Unavailable: 2")
+    }
+
+    @Test
+    func emptyReport() {
+        let report = PairReport(pairs: Samples.empty)
+        #expect(report.rows.isEmpty)
+        #expect(report.summary == "No pairs assessed.")
+        #expect(report.count(.meetsTarget) == 0)
+        #expect(report.count(.belowTarget) == 0)
+        #expect(report.count(.unavailable) == 0)
+    }
+
+    @Test
+    func independentIssuesAndNoInventedRatio() {
+        let report = PairReport(pairs: Samples.pairs)
+        guard case .unavailable(let surface) = report.rows[4].result,
+              case .unavailable(let unresolved) = report.rows[5].result else {
+            Issue.record("Expected unavailable samples")
+            return
+        }
+        #expect(surface.foreground.isEmpty)
+        #expect(surface.background == [.translucentBackground])
+        #expect(unresolved.foreground == [.unresolved])
+        #expect(unresolved.background == [.unresolved])
+        #expect(report.rows[4].result.ratio == nil)
+        #expect(report.rows[5].result.ratio == nil)
+        #expect(PairAssessment.issueText(surface.foreground) == "No issues reported")
+        #expect(PairAssessment.issueText(surface.background) == "Background is not opaque")
+        #expect(PairAssessment.issueText(unresolved.foreground) == "Cannot resolve to fixed, finite sRGB components")
+    }
+
+    @Test
+    func gamutAndOpacityIssuesAreBothRetained() {
+        let row = PairAssessment(pair: .init(
+            label: "P3",
+            foreground: Color(.displayP3, red: 1, green: 0, blue: 0),
+            background: Color(.displayP3, red: 1, green: 0, blue: 0, opacity: 0.5),
+            target: .AA
+        ))
+        guard case .unavailable(let issues) = row.result else {
+            Issue.record("Expected out-of-gamut inputs")
+            return
+        }
+        #expect(issues.foreground == [.outOfSRGBGamut])
+        #expect(issues.background == [.outOfSRGBGamut, .translucentBackground])
+        #expect(PairAssessment.issueText(issues.background) == "Outside the sRGB gamut; Background is not opaque")
+    }
+
+    @Test(arguments: WCAGContrastLevel.allCases)
+    func roundingDoesNotChangeClassification(target: WCAGContrastLevel) throws {
+        // Invert WCAG's transfer function to make real public-API measurements
+        // just below and just above each target. Both display the target ratio.
+        for offset in [-0.0001, 0.0001] {
+            let desiredRatio = target.minimumRatio + offset
+            let luminance = 1.05 / desiredRatio - 0.05
+            let component = 1.055 * pow(luminance, 1 / 2.4) - 0.055
+            let row = PairAssessment(pair: .init(
+                label: "Boundary", foreground: Color(.sRGB, white: component), background: .white, target: target
+            ))
+            let ratio = try #require(row.result.ratio)
+            #expect(abs(ratio - desiredRatio) < 0.00001)
+            #expect(PairAssessment.ratioText(ratio) == PairAssessment.ratioText(target.minimumRatio))
+            #expect(row.outcome == (offset < 0 ? .belowTarget : .meetsTarget))
+        }
+    }
+
+    @Test
+    func foregroundOpacityKeepsDirectionalMeaning() {
+        let pair = ContrastPair(label: "Overlay", foreground: .black.opacity(0.5), background: .white, target: .AA)
+        let row = PairAssessment(pair: pair)
+        #expect(row.result == pair.foreground.contrastResult(with: pair.background))
+        #expect(row.result.ratio != nil)
+        let reversed = PairAssessment(pair: .init(
+            label: pair.label, foreground: pair.background, background: pair.foreground, target: pair.target
+        ))
+        #expect(reversed.outcome == .unavailable)
+    }
+}


### PR DESCRIPTION
## Summary

Add a small runnable macOS example that reports contrast for explicitly supplied foreground/background pairs using existing ColorKit public APIs. Each pair has its own WCAG target; unavailable measurements remain unavailable instead of becoming fabricated ratios.

## Changes

- Add an isolated SwiftPM executable under `Examples/ContrastPairReport`, with two source files, focused tests, and local run instructions.
- Preserve input order, identical pairs, and duplicate labels. Display swatches, requested targets, measured/required ratios, explicit outcomes, and independent foreground/background issues.
- Count meets-target, below-target, and unavailable results separately; provide populated and empty code-configured samples.
- Classify using the unrounded measurement, leaving appearance capture to the caller.

## Alternatives considered

Existing `contrastResult(with:)` and `WCAGContrastLevel` cover the full contract, so no additional public API is necessary. A separate SwiftPM host avoids library-target example code and Xcode project setup. Consolidating the implementation into two source files and using `swift run` avoids a custom launcher and extra file fragmentation.

## Notes

- No production behavior, version, shared README/translation, or compatibility-fixture changes.
- Requires macOS 14+ and Swift 6.2+. Validated on Apple Silicon macOS 26.6.2 with Swift 6.3.2.
- No iOS host, Intel build, minimum-OS runtime, or full VoiceOver interaction was tested. Root library tests were not rerun for this isolated example.
- Pair results do not establish whole-app accessibility compliance.

## Screenshots

Captured from the example on macOS 26.6.2 in the current dark desktop appearance. Uploaded with `gh attach`; no screenshots are stored in the repository.

![Populated report: counts, duplicate labels, swatches, and measured outcomes](https://github.com/user-attachments/assets/6fc03294-e19b-4446-bd7c-c0795b700ff1)

![Scrolled report: independent foreground and background issues](https://github.com/user-attachments/assets/0993623f-77cd-4fe4-8228-bc69fb0ad654)

![Separate empty input case](https://github.com/user-attachments/assets/cffb0007-eb8c-4ad4-b587-468c78b163d8)

## Testing

- `swift test --package-path Examples/ContrastPairReport`: PASS, six tests, including four parameterized WCAG targets with measurements immediately above/below each threshold despite identical rounded display text.
- Tests also cover order, duplicate labels and pairs, requested targets, counts, empty input, independent input issues, out-of-gamut and translucent backgrounds, absent ratios, and directional foreground compositing.
- Strict SwiftLint using the repository configuration with all three example/test Swift files explicitly supplied: PASS, zero violations.
- Actual executable compiled; populated and empty UI inspected on macOS. Simplified direct `swift run` launch verified.
- `git diff --cached --check`: PASS before commit.

Run from the repository root:

```sh
swift run --package-path Examples/ContrastPairReport ContrastPairReport
# Stop with Control-C, then inspect the empty case:
swift run --package-path Examples/ContrastPairReport ContrastPairReport --empty
```

