### PR TITLE
test(examples): Integrate the contrast pair recipe with docs and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Test Benchmark Correctness in Release Mode
         run: swift test --package-path Benchmarks -c release
 
+      - name: Test Standalone Contrast Pair Report
+        run: swift test --package-path Examples/ContrastPairReport
+
       - name: Build and Test Canonical Matrix
         run: scripts/run_tests.sh --results-dir TestResults
 

--- a/Examples/ContrastPairReport/README.md
+++ b/Examples/ContrastPairReport/README.md
@@ -10,8 +10,12 @@ swift run --package-path Examples/ContrastPairReport ContrastPairReport --empty
 swift test --package-path Examples/ContrastPairReport
 ```
 
-Edit `Samples` in `Sources/ContrastPairReport/ContrastPairReportApp.swift` to supply
+The window reports passes, shortfalls, and unavailable measurements in text.
+With `--empty`, it says “No pairs assessed.”, not a successful assessment.
+
+Edit `Samples.pairs` in `Sources/ContrastPairReport/ContrastPairReportApp.swift` to supply
 ordered foreground/background pairs with labels and explicit WCAG targets.
+Input order and duplicates are retained; labels are not identity.
 Samples cover passes, a shortfall, duplicate labels and identical pairs,
 a translucent background, and independently unresolved inputs.
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -243,6 +243,9 @@ los temas solo establecen una pareja de texto/fondo blanco y negro.
 `accessibleContrastingColor(for:)` y `suggestedColor(for:)` ignoran el nivel solicitado,
 usan heurísticas distintas y no garantizan ese nivel.
 
+Ejecuta el [informe de pares de contraste](Examples/ContrastPairReport/README.md)
+independiente para macOS para evaluar pares de primer plano/fondo con objetivos WCAG explícitos por par.
+
 ### **1️⃣2️⃣ Exportar y compartir paletas de colores**  
 ```swift
 // Crear una paleta a partir de colores

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ only establish a black-and-white text/background pair.
 `accessibleContrastingColor(for:)` and `suggestedColor(for:)` ignore the requested
 level, use different heuristics, and do not guarantee that level.
 
+Run the standalone macOS [contrast pair report](Examples/ContrastPairReport/README.md)
+to assess foreground/background pairs against explicit per-pair WCAG targets.
+
 ### **1️⃣2️⃣ Export & Share Color Palettes**  
 ```swift
 // Create a palette from colors


### PR DESCRIPTION
## Summary

Make the standalone contrast-pair example discoverable and keep its tests running in CI.

## Changes

- Add matching English and Spanish README links.
- Clarify textual outcomes, empty input, and order/duplicate retention in the example README.
- Run `swift test --package-path Examples/ContrastPairReport` in the existing Build and Test job, using Xcode 26.5.

## Alternatives considered

A duplicated tutorial and broader example tooling were rejected in favor of concise links and one CI step.

## Notes

PR #67 and compatibility PR #66 are merged. Production code, compatibility fixtures, example implementation/tests, public APIs, and versions are unchanged. Existing APIs remain sufficient.

## Screenshots

Not applicable; no UI changes.

## Testing

Local validation on Apple Silicon macOS 26.6.2 with Xcode 26.5 / Swift 6.3.2:

- Six example tests passed, including all four target rounding boundaries, ordered duplicates, empty input, and unavailable diagnostics; rerun before committing.
- Example executable compiled; populated and empty windows inspected using temporary app wrappers outside the repository. Outcomes and diagnostics are expressed in text.
- DocC built with warnings as errors; 35 public documentation snippets compiled, eight README conversion checks passed, and generated theme output compiled.
- All 25 tooling tests passed; strict repository lint and focused example lint passed.
- Documentation links and `git diff --check` passed.

The merged dependency PRs had green GitHub checks; this new CI step awaits its own remote run. Minimum macOS runtime, Intel, iOS hosting, and full VoiceOver interaction were not tested.
