### PR TITLE
doc(readme): Simplify onboarding and bilingual usage guides

### DIFF
--- a/.pi/extensions/readme-parity.ts
+++ b/.pi/extensions/readme-parity.ts
@@ -1,0 +1,50 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+const DOCUMENTS = ["README.md", "README.es-ES.md", "docs/Usage.md", "docs/Usage.es-ES.md"];
+const REMINDER = "README parity required: update the English/Spanish counterpart and run check_readme_parity.";
+
+function editedDocument(event: { toolName: string; input: unknown }): boolean {
+	if (event.toolName !== "edit" && event.toolName !== "write") return false;
+	const path = String((event.input as { path?: unknown }).path ?? "");
+	return DOCUMENTS.some((document) => path === document || path.endsWith(`/${document}`));
+}
+
+async function check(pi: ExtensionAPI) {
+	const result = await pi.exec("python3", ["scripts/check_readme_parity.py"]);
+	return {
+		ok: result.code === 0,
+		text: (result.stdout || result.stderr || "README parity check failed").trim(),
+	};
+}
+
+export default function readmeParity(pi: ExtensionAPI) {
+	pi.on("tool_result", (event) => {
+		if (!event.isError && editedDocument(event)) {
+			return { content: [...event.content, { type: "text" as const, text: REMINDER }] };
+		}
+	});
+
+	pi.registerCommand("readme-parity", {
+		description: "Check English/Spanish documentation parity",
+		handler: async (_args, ctx) => {
+			const result = await check(pi);
+			ctx.ui.notify(result.text, result.ok ? "info" : "warning");
+		},
+	});
+
+	pi.registerTool({
+		name: "check_readme_parity",
+		label: "Check README parity",
+		description: "Check ColorKit English/Spanish documentation for changed-file and structural drift.",
+		parameters: Type.Object({}),
+		async execute() {
+			const result = await check(pi);
+			return {
+				content: [{ type: "text", text: result.text }],
+				details: {},
+				isError: !result.ok,
+			};
+		},
+	});
+}

--- a/.pi/prompts/ckreview.md
+++ b/.pi/prompts/ckreview.md
@@ -1,0 +1,10 @@
+Review the current ColorKit changes.
+
+Check:
+- AGENTS.md repository instructions
+- branch naming and GitHub issue/triage workflow
+- Swift/SwiftUI/API compatibility concerns
+- tests and likely regressions
+- whether the implementation matches the originating issue/spec
+
+Report blockers first, with file paths and concrete fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to ColorKit will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Simplify enhancement candidate selection to retain two request-local results instead of collecting and sorting candidates, preserving selection order, ties, budgets, and observable outcomes.
+- Shorten the English and Spanish READMEs and usage guides while preserving checked examples; align contributor guidance with current CI and documentation coverage.
+
+### Tooling
+- Add a standalone macOS contrast-pair report with explicit targets, per-pair outcomes, and focused tests run in CI. No new library API is introduced.
+- Preserve the released 3.1.0 component-conversion client alongside the 3.0.0 compatibility baseline.
+
 ## [3.1.0] - 2026-09-09
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,10 @@ _Avoid_: Zero contrast, minimum ratio
 The reason one contrast input is not measurable. Issues are retained independently for the foreground and the background so one does not hide the other. A translucent foreground is composited rather than diagnosed; only a background is diagnosed as translucent.
 _Avoid_: Contrast score, ordered failure priority
 
+**Contrast pair**:
+An explicitly chosen foreground and background used together, assessed against a requested contrast target. It is directional and does not imply that other combinations in the same palette are used together.
+_Avoid_: Unordered color pair, whole-app accessibility assessment
+
 **White-preference luminance threshold**:
 The relative luminance at which black and white contrast equally against a color, approximately 0.1791. Below it white is the stronger contrasting endpoint; above it black is. It is not the midpoint of the luminance range.
 _Avoid_: Mid gray, luminance 0.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ A successful DocC build does not compile fenced Swift. Example checks cover sele
 
 ## Run checks
 
+Optional local check: `python3 scripts/check_readme_parity.py` compares bilingual structure and changed-file coverage against `origin/main`. It requires that ref and merge-base history. CI tests the helper but does not run this document check.
+
+Parity is a heuristic, not a Swift parser or translation validator. It ignores ordinary string contents and line comments; review literal values and semantic translation manually. Pi users can also invoke `/readme-parity`.
+
 Run these from the repository root with Xcode 26.5 selected. These commands cover the current CI jobs:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,253 +1,91 @@
 # Contributing to ColorKit
 
-Thank you for your interest in contributing to ColorKit! This document outlines our coding standards and guidelines to help maintain consistency across the codebase.
+Keep changes focused, preserve shipped contracts, and provide evidence for behavior changes. Use [GitHub Issues](https://github.com/agisilaos/ColorKit/issues) to discuss bugs or proposed features.
 
-## Code Style Guidelines
+## Set up
 
-### General Principles
+1. Fork and clone the repository.
+2. Create a branch beginning with `feature/`, `fix/`, `refactor/`, or `chore/`.
+3. Select Xcode 26.5 to match the build and documentation CI jobs.
+4. Install SwiftLint with `brew install swiftlint`.
 
-- Write clear, self-documenting code
-- Follow Swift's official style guide
-- Keep functions focused and single-purpose
-- Use meaningful variable and function names
-- Add comments for complex logic or non-obvious decisions
-- Keep the code DRY (Don't Repeat Yourself)
+The library requires Swift tools 6.0, iOS 14, and macOS 12. Examples may have higher requirements; check their own READMEs. See [Package.swift](Package.swift) for the library configuration.
 
-### Naming Conventions
+## Implement and document
 
-- Use PascalCase for types (structs, classes, enums, protocols)
-- Use camelCase for properties, methods, and variables
-- Use lowerCamelCase for constants, following Swift naming conventions
-- Prefix boolean properties with verbs (is, has, should, etc.)
-- Use descriptive names that indicate purpose rather than type
+- Prefer clear call sites, focused functions, and established color terminology. Follow the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
+- Treat [.swiftlint.yml](.swiftlint.yml) as the lint source of truth. Package builds do not run lint; CI runs `swiftlint lint --strict`.
+- Preserve released 3.x source and documented behavior, including legacy fallbacks. See [ADR 0013](docs/adr/0013-preserve-shipped-3x-client-contracts.md).
+- Add focused regression tests for changed behavior. Keep tests independent; follow the shared-state rules below when independence is impossible.
+- Document public APIs and update the relevant DocC article, English/Spanish README or usage recipes, changelog, and migration guidance when affected.
+- Keep terminology in [CONTEXT.md](CONTEXT.md). Record consequential design decisions under `docs/adr/`; do not introduce abstractions solely for anticipated needs.
 
-```swift
-// Good
-struct ColorPalette {
-    let primaryColor: Color
-    let secondaryColors: [Color]
-    var isEnabled: Bool
-}
+### Checked examples
 
-// Avoid
-struct Colors {
-    let color: Color
-    let colors: [Color]
-    var enabled: Bool
-}
-```
+`scripts/check_documentation.py` compiles actual Swift fences marked with `<!-- swift-example: example-id -->`. Add each marker to the script's explicit inventory; removing a required marker must not silently reduce coverage.
 
-### Code Organization
+The READMEs contain checked quick starts and catalog examples. The bilingual [usage guides](docs/Usage.md) contain the conversion and workflow recipes. Keep snippets self-contained and translations semantically aligned.
 
-- Group related properties and methods together
-- Use MARK comments to organize code sections
-- Keep files focused and under 500 lines when possible
-- Use extensions to organize protocol conformance
-- Place private properties and methods at the bottom of the type
+The checker executes the guides' HSL, CMYK, LAB, and component-result recipes in both languages. Keep their variables aligned with `README_CHECKS`, the existing postcondition table in the script.
 
-```swift
-struct ColorKit {
-    // MARK: - Public Properties
-    
-    // MARK: - Private Properties
-    
-    // MARK: - Initialization
-    
-    // MARK: - Public Methods
-    
-    // MARK: - Private Methods
-}
-```
+Named HSL inputs are checked for availability and normalized finite components, not appearance-specific values. Fixed conversion examples use numeric or availability postconditions. Add checks when examples promise specific results.
 
-### SwiftLint Rules
+Generated theme code is compiled too, including named, translucent, grayscale, and Display P3 inputs. Temporary generated files are not committed.
 
-Install SwiftLint with `brew install swiftlint`, then run `swiftlint lint --strict`
-from the repository root. It covers `Sources` and `Tests` and is enforced by CI;
-package builds do not run lint.
+A successful DocC build does not compile fenced Swift. Example checks cover selected snippets—not all prose, UI behavior, or performance claims. Preserve both documentation generation and compiler checks.
 
-Here are some key rules and their rationale:
+## Run checks
 
-#### Enabled Rules
-- `force_unwrapping`: Avoid force unwrapping (`!`) - use optional binding or nil coalescing
-- `force_cast`: Avoid force casting (`as!`) - use optional casting (`as?`)
-- `trailing_whitespace`: Keep files clean of trailing whitespace
-- `sorted_imports`: Keep imports organized alphabetically
-- `vertical_whitespace_closing_braces`: Maintain consistent spacing
-
-#### Disabled Rules
-- `line_length`: We allow longer lines (up to 120 characters) for better readability
-- `type_body_length`: Complex types may need more than 400 lines
-- `function_body_length`: Some functions may need more than 100 lines
-- `cyclomatic_complexity`: We trust developers to keep complexity reasonable
-
-### Documentation
-
-- Document public APIs using Swift-style documentation comments
-- Include parameter descriptions and return value information
-- Add examples for complex functionality
-- Keep documentation up to date with code changes
-
-```swift
-/// Creates a new color with the specified RGB components.
-///
-/// - Parameters:
-///   - red: The red component (0-255)
-///   - green: The green component (0-255)
-///   - blue: The blue component (0-255)
-///
-/// - Returns: A new Color instance
-///
-/// - Example:
-///   ```
-///   let red = Color(r: 255, g: 0, b: 0)
-///   ```
-func color(r: UInt8, g: UInt8, b: UInt8) -> Color
-```
-
-### Testing
-
-- Write unit tests for new functionality
-- Follow the Arrange-Act-Assert pattern in tests
-- Use descriptive test names that explain the scenario
-- Keep tests focused and independent
-- Use appropriate test doubles (mocks, stubs) when needed
-
-```swift
-func testColorInitialization() {
-    // Arrange
-    let red: UInt8 = 255
-    let green: UInt8 = 0
-    let blue: UInt8 = 0
-    
-    // Act
-    let color = Color(r: red, g: green, b: blue)
-    
-    // Assert
-    XCTAssertEqual(color.red, red)
-    XCTAssertEqual(color.green, green)
-    XCTAssertEqual(color.blue, blue)
-}
-```
-
-### CI Validation
-
-CI runs strict SwiftLint checks, builds the DocC catalog with warnings treated as
-errors, compiles selected public examples as a macOS client, and tests on both
-iOS and macOS. The jobs use the `macos-26` runner with
-Xcode 26.5 and an iPhone 17 simulator running iOS 26.5.
-When changing Xcode versions, also check the simulator runtime against the
-[runner image inventory](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md).
-
-To run the same platform checks locally with Xcode 26.5 selected:
+Run these from the repository root with Xcode 26.5 selected. These commands cover the current CI jobs:
 
 ```sh
 swiftlint lint --strict
+python3 -m unittest discover -s scripts/tests
+python3 scripts/check_compatibility.py
+swift test --package-path Benchmarks -c release
+swift test --package-path Examples/ContrastPairReport
+scripts/run_tests.sh
 xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' \
-  -derivedDataPath /tmp/ColorKitDocumentation \
+  -derivedDataPath .build/documentation \
   -skipMacroValidation \
   'OTHER_DOCC_FLAGS=--warnings-as-errors'
-scripts/run_tests.sh
-python3 -m unittest discover -s scripts/tests
-python3 scripts/check_documentation.py
-python3 scripts/check_compatibility.py
+python3 scripts/check_documentation.py --derived-data .build/documentation
 ```
 
-For benchmark changes, also run `swift test --package-path Benchmarks -c release`
-and the [macOS Release runner](Benchmarks/README.md). Its correctness tests do not
-assert machine-specific duration thresholds. Record actual performance samples
-separately with other builds idle.
+CI configuration lives in [.github/workflows/ci.yml](.github/workflows/ci.yml). For local iteration, start with the relevant subset; before review, disclose which checks ran and any gaps.
 
-The zero-argument runner is the canonical CI matrix: parallel iOS and macOS tests,
-then serialized shared-state suites on each platform. Change the shared-suite list
-and pinned destinations in `scripts/run_tests.sh`, not in the workflow. Set
-`COLORKIT_IOS_DESTINATION` or `COLORKIT_MACOS_DESTINATION` for another local device.
-Build storage defaults to this checkout's `.build/xcode`; override it with
-`COLORKIT_DERIVED_DATA` when needed.
+### Platform tests and diagnostics
 
-Each matrix invocation retains raw stdout/stderr logs and result bundles in a unique directory
-under `.build/test-results`; use `--results-dir TestResults` to choose another parent.
-For a targeted run, pass a platform label, destination, and Xcode options. Only
-these explicit single-destination runs use `xcpretty` when available; add
-`--log-file path` to retain raw output (its parent directory must exist).
+The zero-argument test runner performs iOS and macOS tests with parallel testing enabled, followed by serialized shared-state suites on each platform. The pinned iOS destination is iPhone 17 with iOS 26.5.
 
-After a release PR is merged, run `scripts/check_release.sh <version>` from `main`
-before tagging. The check fetches `origin/main` and tags, then verifies the working
-tree, release metadata, synchronized commit, and tag availability, then runs the
-preserved-client/API compatibility checker and canonical behavioral test matrix.
+Keep destinations and the shared-suite list in [scripts/run_tests.sh](scripts/run_tests.sh), not duplicated in CI. Override `COLORKIT_IOS_DESTINATION`, `COLORKIT_MACOS_DESTINATION`, or `COLORKIT_DERIVED_DATA` for local needs.
 
-`ColorCacheIntegrationTests` clears `ColorCache.shared` before and after each test.
-Run it separately without parallel testing; direct cache tests use independent instances.
-`ThemeManagerIntegrationTests` also runs in this serial invocation. It preserves the
-private singleton initializer, registers unique names, uses baseline-relative
-registry assertions, and restores the previous selected value. There is no theme
-reset or removal API, so registered fixtures remain until the test process exits.
+`ColorCacheIntegrationTests` and `ThemeManagerIntegrationTests` must run without parallel testing. The canonical runner handles this. Direct cache tests use independent instances; theme tests restore selection but leave registered fixtures in the process.
 
-The `test-results` workflow artifact retains raw build logs and `.xcresult`
-bundles for 14 days, including logs from failed test commands. Check the
-"Show Xcode and Available Simulators" step if a destination cannot be found.
+Build storage defaults to `.build/xcode`. Each matrix run retains logs and result bundles under a unique `.build/test-results` directory; `--results-dir TestResults` changes the parent.
 
-### Review screenshots
+For targeted runs, use `scripts/run_tests.sh --help`. Explicit single-destination runs support `--log-file`; create its parent directory first. CI retains test and compatibility artifacts for 14 days, including failed-run diagnostics.
 
-Attach review screenshots to the pull request instead of committing them under
-`docs/screenshots/`. Keep local captures in an ignored directory. Images that
-illustrate published documentation may remain beside that documentation.
+If a simulator is missing, check CI's “Show Xcode and Available Simulators” output and the [runner image inventory](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md).
 
-### Release client compatibility
+### Compatibility and performance
 
-The [release compatibility gate](Compatibility/README.md) preserves 3.0.0 client
-source independently of current examples and compares public APIs on iOS and
-macOS. Existing client files and release commits are immutable relative to the PR
-base; extend coverage with new files. CI fetches full history and runs this gate
-in the existing Build and Test job.
+The [compatibility gate](Compatibility/README.md) protects pinned 3.0.0 and 3.1.0 clients and compares public APIs on iOS and macOS. Existing fixtures are immutable relative to the PR base; extend coverage with new files.
 
-### Keeping contracts and documentation synchronized
+Fetch full Git history before compatibility checks. CI passes its exact base commit with `--fixture-base`; local checks default to `origin/main`. These checks do not prove binary compatibility or minimum-OS runtime behavior.
 
-For every public API or behavior change, review these together in the same PR:
+Benchmark correctness tests do not enforce machine-specific timing thresholds. For performance claims, run the [Release benchmark](Benchmarks/README.md) with other builds idle and retain the inputs, environment, and raw samples.
 
-- Source/API comments and the relevant DocC article.
-- English and Spanish README examples and contract prose (or explain why neither is affected).
-- An Unreleased changelog entry and migration guidance for changed results, fallbacks,
-  enum cases, or deprecations—not only source-breaking signature changes.
-- Regression tests and representative public examples exercising the changed contract.
+## Submit a pull request
 
-`python3 scripts/check_documentation.py` compiles the actual Swift fences marked
-with `<!-- swift-example: example-id -->`, using public imports and the package's
-macOS 12 deployment target. Add each marker to the explicit inventory in that script.
-The READMEs share the same required example IDs; deleting or renaming a required
-marker fails the check. Keep marked examples self-contained. The checker also
-executes the actual HSL, CMYK, and LAB README snippets in both languages and verifies
-their result variables against the expected contract. Keep those variables aligned
-with `README_CHECKS`; add behavior checks when an example promises a specific result.
-Named HSL colors are checked for availability and normalized finite components, not
-appearance-specific numeric values. Fixed sRGB examples use numeric postconditions.
-It also executes the real theme-code generator and compiles its output for named
-defaults, translucent sRGB, grayscale, and Display P3 inputs. Generated files live
-in a temporary directory and are not committed.
+- Keep commits focused and explain the change, its reason, and meaningful alternatives.
+- Report commands run, results, and validation limitations. Distinguish local evidence from CI.
+- Include Unreleased notes for notable changes and migration guidance for changed results, fallbacks, enum cases, or deprecations—not only signature changes.
+- Reconcile documentation and migration notes after integrating overlapping work; rerun affected checks against the combined result.
+- Attach UI review screenshots to the PR, not `docs/screenshots/`. Keep local captures ignored. Images used by published documentation may remain in the repository.
 
-A successful DocC build validates documentation structure and links, not fenced
-Swift. The compilation and behavior checks cover selected examples, not every snippet
-or the truth of prose, visual behavior, or performance claims. Review translations
-for semantic parity and use measured, reproducible evidence for performance claims. When parallel
-branches touch the same contracts, reconcile their release and migration notes
-after integrating upstream changes and rerun all gates against the combined result.
+## Release preflight
 
-### Git Workflow
+After release preparation is merged, run `scripts/check_release.sh <version>` on clean, synchronized `main` before tagging. Omit the `v` prefix from the argument.
 
-- Write clear, descriptive commit messages
-- Keep commits focused and atomic
-- Use feature branches for new work
-- Update documentation when making API changes
-- Follow the existing PR review process
-
-### Getting Started
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes following these guidelines
-4. Run SwiftLint locally to check for style issues
-5. Write or update tests as needed
-6. Submit a pull request
-
-## Questions?
-
-If you have any questions about these guidelines or need clarification, please open an issue or reach out to the maintainers.
+The script verifies version/changelog metadata and tag availability, then runs compatibility and the canonical behavioral matrix. It does not publish a release or replace documentation, lint, example, and benchmark checks.

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,5 +1,8 @@
 # ColorKit 🎨
 
+![Swift Package Manager](https://img.shields.io/badge/SPM-Supported-green)
+![Swift Version](https://img.shields.io/badge/Swift-6.0%2B-blue)
+
 Conversión de colores, evaluación del contraste y temas adaptables para SwiftUI.
 
 **Swift 6+ · iOS 14+ · macOS 12+**

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,509 +1,81 @@
-# **ColorKit 🎨**  
-![Swift Package Manager](https://img.shields.io/badge/SPM-Supported-green)  
-![Swift Version](https://img.shields.io/badge/Swift-6.0%2B-blue)  
+# ColorKit 🎨
+
+Conversión de colores, evaluación del contraste y temas adaptables para SwiftUI.
+
+**Swift 6+ · iOS 14+ · macOS 12+**
 
 [English](README.md) | **Español**
 
-Un **paquete ligero de Swift** para **manipulación de colores, temas adaptables y cumplimiento de accesibilidad** en SwiftUI.  
+## Características
 
----
+- **Conversión de colores:** Hex, RGB, HSL, HSB, CMYK, XYZ y LAB, con disponibilidad por representación.
+- **Contraste y accesibilidad:** evaluación WCAG, ajustes de color acotados y simulación de deficiencias de visión del color.
+- **Operaciones de color:** fusión, interpolación y gradientes.
+- **Temas adaptables:** colores claros/oscuros, roles semánticos y modificadores de SwiftUI.
+- **Paletas y exportación:** generar candidatos, evaluarlos y exportar o compartir paletas.
+- **Inspección y vistas previas:** inspectores visuales, comparación de colores y catálogo interactivo.
 
-## **📦 Instalación**  
+## Instalación
 
-ColorKit es compatible con **Swift Package Manager (SPM)**.  
+En Xcode, selecciona **File → Add Packages** e introduce:
 
-1. Abre tu proyecto en Xcode.  
-2. Ve a **File > Add Packages**.  
-3. Ingresa la URL:  
-   ```
-   https://github.com/agisilaos/ColorKit.git
-   ```
-4. Haz clic en **Add Package**.  
+```text
+https://github.com/agisilaos/ColorKit.git
+```
 
-Al actualizar de 2.x a 3.0.0, ajusta el requisito de versión del paquete y consulta
-la [guía de migración](MIGRATION.md#colorkit-300). Los switches exhaustivos sobre el
-estado de accesibilidad y las referencias guardadas a métodos de mejora requieren
-cambios. Las métricas de comparación, los límites de distancia perceptual y las
-mediciones de color pueden producir resultados distintos.
+¿Actualizas un proyecto existente? Consulta la [guía de migración](MIGRATION.md) antes de cambiar el requisito de versión.
 
----
+## Inicio rápido
 
-## **🚀 Características**  
+Mide un primer plano sobre un fondo explícito. Trata los datos no disponibles por separado del contraste medido:
 
-✅ **Conversión HEX <-> RGB**  
-✅ **Soporte para color HSL**  
-✅ **Soporte para color CMYK**  
-✅ **Soporte para color LAB**  
-✅ **Colores adaptables (Modo Claro/Oscuro)**  
-✅ **Verificación de contraste WCAG para accesibilidad**  
-✅ **Resultados de accesibilidad verificables**
-✅ **Generación automática de paletas de colores accesibles**  
-✅ **Exportar y compartir paletas de colores**  
-✅ **Modificadores de SwiftUI para colores dinámicos**  
-✅ **Utilidades de generación de gradientes**  
-✅ **Modos de fusión de colores (Superposición, Multiplicar, Trama, etc.)**  
-✅ **Sistema de temas integral**  
-✅ **Caché de alto rendimiento para operaciones de color**  
-✅ **AccessibilityEnhancer para ajustes inteligentes de color**  
-✅ **Herramientas avanzadas de depuración de colores**  
-✅ **Catálogo de vista previa interactivo**  
-
----
-
-## **🎨 Uso**  
-
-### Resultados de conversión de componentes
-
-Usa `componentConversionResults()` cuando importe la disponibilidad. Cada campo
-devuelve su valor o un problema, de modo que un fallo de Hex no descarta LAB disponible.
-
-<!-- swift-example: component-results -->
+<!-- swift-example: contrast -->
 ```swift
-let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
-if case .success(let lab) = conversions.lab {
-    print(lab.lightness, lab.a, lab.b)
-}
-switch conversions.hex {
-case .success(let hex): print(hex)
-case .failure(let issue): print("Hex no disponible:", issue)
+import SwiftUI
+import ColorKit
+
+let foreground = Color(.sRGB, red: 0, green: 0, blue: 0)
+let background = Color(.sRGB, red: 1, green: 1, blue: 1)
+
+switch foreground.contrastResult(with: background) {
+case .available(let measurement):
+    print("Contraste:", measurement.ratio)
+    print("Cumple WCAG AA:", measurement.passingLevels.contains(.AA))
+case .unavailable(let issues):
+    print("Problemas del primer plano:", issues.foreground)
+    print("Problemas del fondo:", issues.background)
 }
 ```
 
-Los siete campos describen un único color fijo, sin composición con un fondo:
-`srgba`, `hsl`, `hsb`, `cmyk`, `xyz`, `lab` y `hex`. El llamador debe resolver
-explícitamente los colores con nombre o dinámicos que no tengan componentes fijos.
-Se conservan sRGBA extendido y XYZ/LAB D65 finitos; HSL, HSB, CMYK y Hex rechazan
-RGB fuera de `0...1`, sin recorte ni tolerancia en los extremos. Alfa se conserva
-en sRGBA y en Hex de ocho dígitos `#RRGGBBAA`; las demás coordenadas lo omiten.
-El tono se expresa en vueltas, las fracciones HSL/HSB/CMYK están en `0...1` y XYZ
-usa Y = 100 para el blanco de referencia. CMYK es una aproximación algebraica,
-no un perfil de impresión. Las API existentes no cambian ni se marcan como obsoletas.
-Consulta el [contrato de conversión](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
-y las [notas de adopción](MIGRATION.md#component-conversion-results).
+Usa colores fijos; resuelve explícitamente los que dependan de la apariencia. Un primer plano translúcido se compone sobre un fondo opaco. Un fondo translúcido no permite medir el contraste: el orden importa.
 
-### **1️⃣ Conversión HEX <-> RGB**  
-```swift
-let color = Color(hex: "#FF5733")
-print(color.hexValue()) // "#FF5733FF"
-```
+Superar el contraste no certifica la accesibilidad de toda la aplicación. Al generar colores ajustados, comprueba el resultado antes de usar el candidato.
 
-### **2️⃣ Conversión HSL**  
-<!-- swift-example: hsl -->
-```swift
-let hsl = Color.red.hslComponents()
-let customColor = Color(hue: 0.5, saturation: 1.0, lightness: 0.5)
-```
+## Guías y ejemplos
 
-`hslComponents()` resuelve colores con nombre y dinámicos para la apariencia actual.
-Convierte a sRGB y recorta los canales de gama más amplia a `0...1` antes de la
-conversión; la opacidad no forma parte de HSL. Devuelve `nil` si la resolución falla,
-por ejemplo, con un color de patrón. A diferencia de HSL, CMYK y LAB requieren
-colores fijos y no eligen una apariencia. Consulta la
-[guía de migración de HSL](MIGRATION.md#hsl-resolution).
+- [Guía de uso](docs/Usage.es-ES.md): ejemplos de conversión, fusión, temas, paletas, exportación e inspección.
+- [Espacios de color](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md): resultados por componente y contratos de conversión.
+- [Accesibilidad](Sources/ColorKit/Documentation.docc/Accessibility-article.md): objetivos de contraste, límites de ajuste y simulación.
+- [Temas](Sources/ColorKit/Documentation.docc/Theming-article.md): colores adaptables y semánticos.
+- [Comparaciones y utilidades](Sources/ColorKit/Documentation.docc/Utilities-article.md): diferencias perceptuales e inspección.
+- [Rendimiento](PERFORMANCE_IMPROVEMENTS.md): caché y orientación sobre mediciones.
 
-### **3️⃣ Conversión CMYK**  
-<!-- swift-example: cmyk -->
-```swift
-// Convertir de RGB a CMYK
-let red = Color(.sRGB, red: 1, green: 0, blue: 0)
-let cmyk = red.cmykComponents()
-// (cyan: 0.0, magenta: 1.0, yellow: 1.0, key: 0.0)
-
-// Crear color a partir de valores CMYK
-let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
-```
-
-### **4️⃣ Conversión LAB**  
-<!-- swift-example: lab -->
-```swift
-// Resolver un color fijo y convertirlo a LAB
-let red = Color(.sRGB, red: 1, green: 0, blue: 0)
-let lab = red.labComponents()
-if let lab {
-    print(lab) // (L: 53.24, a: 80.09, b: 67.20)
-}
-
-// Crear color a partir de valores LAB
-let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
-```
-
-`labComponents()` resuelve colores RGB y de escala de grises fijos —incluidos RGB
-lineal y Display P3— a sRGB no lineal antes de la conversión. Los canales finitos
-fuera de gama se conservan sin recorte. El método devuelve `nil` para los colores
-que no puede resolver, como los colores dinámicos sin resolver; el canal alfa no
-afecta a las coordenadas LAB.
-
-### **5️⃣ Colores adaptables (Modo Claro/Oscuro)**  
-```swift
-Text("Adaptive Text")
-    .adaptiveColor(light: .blue, dark: .orange)
-```
-
-### **6️⃣ Garantizar alto contraste**  
-```swift
-Text("Accessible Text")
-    .highContrastColor(base: .gray, background: .white)
-```
-
-### **7️⃣ Detección de cambios de tema**  
-```swift
-Text("Theme Change")
-    .onAdaptiveColorChange { newScheme in
-        print("El esquema de color cambió a: \(newScheme)")
-    }
-```
-
-### **8️⃣ Utilidades de generación de gradientes**  
-```swift
-let gradient = Gradient(colors: [.red, .blue])
-let linearGradient = LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom)
-```
-
-### **9️⃣ Modos de fusión de colores**  
-```swift
-let baseColor = Color.red
-let blendColor = Color.blue
-let blendedColor = baseColor.blended(with: blendColor, mode: .overlay)
-```
-
-### **🔟 Sistema de temas integral**  
-```swift
-// Definir un tema personalizado
-let oceanTheme = ColorTheme(
-    name: "Ocean",
-    primary: Color(hex: "#1E88E5"),
-    secondary: Color(hex: "#00ACC1"),
-    accent: Color(hex: "#7E57C2"),
-    background: Color(hex: "#ECEFF1"),
-    text: Color(hex: "#263238")
-)
-
-// Registrar el tema
-ThemeManager.shared.register(theme: oceanTheme)
-
-// Aplicar tema a una jerarquía de vistas
-ContentView()
-    .withThemeManager()
-
-// Usar colores con tema en las vistas
-Text("Themed Text")
-    .themedText(.primary)
-
-Button("Primary Button") {}
-    .themedButton(.primary)
-
-// Usar colores semánticos
-Rectangle()
-    .fill(Color.themed(.accent))
-```
-
-### **1️⃣1️⃣ Generación automática de paletas de colores accesibles**  
-<!-- swift-example: accessible-palette -->
-```swift
-let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let generator = AccessiblePaletteGenerator(configuration: .init(targetLevel: .AA))
-let results = generator.generateAssessedPalette(from: seedColor, against: backgroundColor)
-for result in results {
-    if result.meetsTarget {
-        Text("WCAG AA").foregroundColor(result.color).background(backgroundColor)
-    } else {
-        print(result.status)
-    }
-}
-
-let textResult = backgroundColor.accessibleContrastingColorResult(for: .AA)
-let textColor = textResult.color
-
-switch textResult.status {
-case .meetsTarget:
-    if let ratio = textResult.contrastRatio {
-        print("Contraste: \(ratio):1")
-    }
-case .bestEffort:
-    print("El mejor extremo disponible no alcanza el objetivo")
-case .unavailable:
-    print("Resuelve los colores con una apariencia explícita antes de evaluarlos")
-case .invalidConfiguration:
-    print("Proporciona un límite de distancia perceptual finito entre 0 y 100")
-}
-
-// Usar la vista de demostración para experimentar con la generación de paletas
-struct ContentView: View {
-    var body: some View {
-        ColorKit.ColorInspector.accessiblePaletteDemoView()
-    }
-}
-```
-
-Para código nuevo, comprueba `meetsTarget` o `status` antes de usar un candidato.
-La paleta evaluada conserva todos los resultados; no aplica un límite de mejora ni
-certifica el contraste entre entradas. Las paletas heredadas devuelven candidatos;
-los temas solo establecen una pareja de texto/fondo blanco y negro.
-`accessibleContrastingColor(for:)` y `suggestedColor(for:)` ignoran el nivel solicitado,
-usan heurísticas distintas y no garantizan ese nivel.
-
-Ejecuta el [informe de pares de contraste](Examples/ContrastPairReport/README.md)
-independiente para macOS para evaluar pares de primer plano/fondo con objetivos WCAG explícitos por par.
-
-### **1️⃣2️⃣ Exportar y compartir paletas de colores**  
-```swift
-// Crear una paleta a partir de colores
-let colors: [Color] = [.red, .green, .blue]
-let palette = PaletteExporter.createPalette(from: colors)
-
-// Crear una paleta a partir de un tema
-let theme = ThemeManager.shared.currentTheme
-let themePalette = PaletteExporter.createPalette(from: theme)
-
-// Exportar a varios formatos
-if let jsonData = PaletteExporter.export(
-    palette: palette,
-    to: .json,
-    paletteName: "My Palette"
-) {
-    // Usar los datos (guardar en archivo, compartir, etc.)
-}
-
-// Copiar al portapapeles
-PaletteExporter.copyToClipboard(
-    palette: palette,
-    format: .css,
-    paletteName: "My Palette"
-)
-
-// Exportar paleta accesible
-let accessiblePaletteData = seedColor.exportAccessiblePalette(
-    targetLevel: .AA,
-    to: .svg,
-    paletteName: "Accessible Palette"
-)
-
-// Agregar funcionalidad de exportación a cualquier vista
-myView.paletteExport(colors: colors, paletteName: "RGB Palette")
-myView.paletteExport(theme: theme)
-
-// Usar la interfaz de exportación directamente
-PaletteExportView(palette: palette, paletteName: "My Palette")
-```
-
-### **1️⃣3️⃣ Optimizaciones de rendimiento (v1.4.0+)**  
-```swift
-// ColorKit almacena automáticamente en caché las operaciones de color costosas
-// No se requieren cambios de código para beneficiarse de las mejoras de rendimiento
-
-// La primera llamada calcula y almacena en caché
-let lab1 = color1.labComponents()
-
-// La segunda llamada recupera desde la caché (mucho más rápido)
-let lab1Again = color1.labComponents()
-
-// Fusión con caché
-let blended = color1.blended(with: color2, mode: .overlay, amount: 0.5)
-
-// Interpolación de gradiente con caché
-let interpolated = color1.interpolated(with: color2, amount: 0.5, in: .lab)
-
-// Obtener relación de contraste en caché
-if let ratio = ColorCache.shared.getCachedContrastRatio(for: color1, with: color2) {
-    print("Cached contrast ratio: \(ratio)")
-}
-
-// Almacenar una relación de contraste en caché
-ColorCache.shared.cacheContrastRatio(for: color1, with: color2, ratio: 4.5)
-
-// Si es necesario, borrar manualmente las cachés
-ColorCache.shared.clearCache()
-```
-
-Para más detalles sobre las mejoras de rendimiento, consulta [PERFORMANCE_IMPROVEMENTS.md](PERFORMANCE_IMPROVEMENTS.md).
-
-### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
-<!-- swift-example: enhancement -->
-```swift
-// Generar un candidato dentro de un límite de distancia e inspeccionar su resultado
-let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let targetLevel = WCAGContrastLevel.AA
-
-let result = originalColor.enhancementResult(
-    with: backgroundColor,
-    targetLevel: targetLevel
-)
-let enhancedColor = result.color
-
-if result.meetsTarget {
-    if let ratio = result.contrastRatio {
-        print("Contraste medido: \(ratio):1")
-    }
-}
-```
-
-### **1️⃣5️⃣ Catálogo de vista previa**
-El Catálogo de vista previa ofrece demostraciones interactivas de las características de ColorKit:
+Ejecuta el [informe de pares de contraste](Examples/ContrastPairReport/README.md) para macOS con tus propios pares, o explora el catálogo interactivo en una vista SwiftUI:
 
 <!-- swift-example: catalog -->
 ```swift
+import SwiftUI
 import ColorKit
 
-struct ContentView: View {
+struct CatalogExample: View {
     var body: some View {
         MainCatalogView()
     }
 }
 ```
 
-Vistas previas disponibles:
+El informe independiente tiene sus propios requisitos de plataforma; consulta sus instrucciones. Las guías especializadas enlazadas están en inglés.
 
-1. **BlendingPreview**
-   - Fusión de color interactiva con todos los modos de fusión
-   - Control en tiempo real de la cantidad de fusión
-   - Métricas de rendimiento
+## Proyecto
 
-2. **GradientPreview**
-   - Creación de gradientes lineales, radiales y angulares
-   - Gestión de paradas de color
-   - Generación de código
-
-3. **ThemePreview**
-   - Pruebas de modo claro/oscuro
-   - Muestra de componentes de interfaz
-   - Generación de código de tema
-
-4. **PerformanceBenchmark**
-   - Análisis comparativo de operaciones
-   - Métricas de caché
-   - Control de iteraciones
-
-5. **ColorDebuggerPreview**
-   - Visualización del espacio de color
-   - Análisis de componentes
-   - Herramientas de comparación visual
-   - Monitoreo de rendimiento
-
-6. **PaletteStudioPreview**
-   - Generación de paletas
-   - Funcionalidad de exportación
-   - Reglas de armonía
-   - Generación de temas
-
-7. **ColorAnimationPreview**
-   - Pruebas de transición de color
-   - Modos de interpolación
-   - Curvas de temporización
-   - Métricas de rendimiento
-
-8. **AccessibilityLabPreview**
-   - Verificación de contraste WCAG
-   - Estrategias de mejora de color
-   - Sugerencias de colores accesibles
-   - Directrices educativas
-
-Cada vista previa está diseñada para ayudar a los desarrolladores a comprender y utilizar eficazmente las características de ColorKit. Accede a ellas a través de `MainCatalogView` o de forma individual:
-
-<!-- swift-example: previews -->
-```swift
-// Usar vistas previas individuales
-ColorSpacePreview()
-BlendingPreview()
-GradientPreview()
-ThemePreview()
-PerformanceBenchmark()
-ColorDebuggerPreview()
-PaletteStudioPreview()
-ColorAnimationPreview()
-AccessibilityLabPreview()
-```
-
-## **🎨 Herramientas de depuración**  
-
-ColorKit ahora incluye herramientas avanzadas de depuración para ayudar a los desarrolladores a inspeccionar colores, validar el cumplimiento de accesibilidad y garantizar una implementación correcta. Estas herramientas incluyen:
-
-### **Inspección de colores**  
-
-Inspecciona colores en múltiples espacios de color (RGB, HSL, HSB, CMYK, LAB, XYZ):
-
-```swift
-// Obtener componentes de color en todos los espacios de color
-let components = myColor.colorSpaceComponents()
-print(components.description)
-
-// Mostrar inspeccionador visual de color en SwiftUI
-ColorSpaceInspectorView(color: myColor)
-```
-
-`rgbaComponents()` resuelve la apariencia actual: UIKit conserva sRGB extendido;
-AppKit convierte a sRGB acotado. Un fallo devuelve `(0, 0, 0, 0)`, indistinguible del
-negro transparente. Los componentes agregados heredan esa política, sustituyen fallos
-HSL/CMYK por ceros, extraen HSB sin indicar éxito y derivan LAB/XYZ de RGB incluso
-si es una sustitución. Usa conversiones opcionales cuando importe la disponibilidad.
-
-### **Comparación de colores**  
-
-Compara colores sRGB fijos, opacos y dentro de gama mediante diferencias de componentes, métricas WCAG y CIEDE2000:
-
-<!-- swift-example: comparison -->
-```swift
-let color1 = Color(.sRGB, red: 0.15, green: 0.35, blue: 0.75, opacity: 1)
-let color2 = Color(.sRGB, red: 0.55, green: 0.25, blue: 0.65, opacity: 1)
-
-switch color1.comparisonResult(with: color2) {
-case .available(let difference):
-    print("Diferencia CIEDE2000: \(difference.perceptualDifference)")
-case .unavailable(let issues):
-    print("Comparación no disponible: \(issues)")
-}
-
-// Vista de comparación visual
-ColorComparisonView(color1: color1, color2: color2)
-```
-
-Los colores dinámicos, translúcidos, no finitos o fuera de la gama sRGB devuelven problemas explícitos en vez de mediciones inventadas.
-
-`isPerceptuallySimilar(to:threshold:)` usa CIE76 en LAB D65 y `distancia < umbral`
-sin validar el umbral. La igualdad o una conversión LAB no disponible devuelven `false`.
-Ignora alfa sin componer sobre un fondo y admite sRGB extendido si LAB está disponible.
-CIEDE2000 requiere colores opacos dentro de gama; los umbrales no son intercambiables.
-
-### **Depuración de accesibilidad WCAG**  
-
-Valida y mejora la accesibilidad de los colores:
-
-En `foreground.contrastResult(with: background)`, el receptor es el primer plano.
-Un primer plano translúcido se compone sobre el fondo opaco; un fondo translúcido
-no está disponible. Invertir los argumentos puede cambiar el resultado.
-
-<!-- swift-example: budget -->
-```swift
-// Verificar cumplimiento WCAG
-let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
-print(assessment.status)
-
-// Obtener candidatos dentro del límite con resultados explícitos y evidencia de medición
-let suggestions = textColor.suggestAccessibleVariantResults(
-    with: backgroundColor,
-    targetLevel: .AA,
-    maxPerceptualDistance: 30
-)
-```
-
-Las APIs de mejora que devuelven resultados aplican un límite inclusivo CIEDE2000
-Delta E 00 respecto al primer plano original (finito, en `0...100`, predeterminado: `30`).
-Si ningún candidato examinado alcanza el objetivo, devuelven el mejor esfuerzo dentro
-del límite, o un resultado explícito `invalidConfiguration` o `unavailable`.
-Las mejoras heredadas que devuelven solo colores ignoran el límite y no garantizan el objetivo.
-Consulta la [guía de migración de mejoras](MIGRATION.md#enhancement-distance-budgets).
-
-Consulta la [Documentación de depuración de colores](Sources/ColorKit/Utilities/DOCUMENTATION.md) para más detalles.
-
----
-
-## **🛠 Contribuciones**  
-¡Bienvenidas las contribuciones! No dudes en informar de problemas o abrir pull requests.  
-
-## **📜 Licencia**  
-Licencia MIT. Consulta `LICENSE` para ver los detalles.  
-
----
+[Contribuir](CONTRIBUTING.md) · [Historial de cambios](CHANGELOG.md) · [Migración](MIGRATION.md) · [Licencia MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,504 +1,81 @@
-# **ColorKit 🎨**  
-![Swift Package Manager](https://img.shields.io/badge/SPM-Supported-green)  
-![Swift Version](https://img.shields.io/badge/Swift-6.0%2B-blue)  
+# ColorKit 🎨
+
+Color conversion, contrast assessment, and adaptive themes for SwiftUI.
+
+**Swift 6+ · iOS 14+ · macOS 12+**
 
 **English** | [Español](README.es-ES.md)
 
-A lightweight **Swift package** for **color manipulation, adaptive themes, and accessibility compliance** in SwiftUI.  
+## Features
 
----
+- **Color conversion:** Hex, RGB, HSL, HSB, CMYK, XYZ, and LAB, with per-representation availability.
+- **Contrast and accessibility:** WCAG assessment, bounded color adjustments, and color-vision deficiency simulation.
+- **Color operations:** blending, interpolation, and gradients.
+- **Adaptive themes:** light/dark colors, semantic roles, and SwiftUI modifiers.
+- **Palettes and export:** generate candidates, assess them, and export or share palettes.
+- **Inspection and previews:** visual inspectors, color comparisons, and an interactive catalog.
 
-## **📦 Installation**  
+## Installation
 
-ColorKit supports **Swift Package Manager (SPM)**.  
+In Xcode, choose **File → Add Packages** and enter:
 
-1. Open your Xcode project.  
-2. Go to **File > Add Packages**.  
-3. Enter the URL:  
-   ```
-   https://github.com/agisilaos/ColorKit.git
-   ```
-4. Click **Add Package**.  
+```text
+https://github.com/agisilaos/ColorKit.git
+```
 
-When upgrading from 2.x to 3.0.0, update your package version requirement and read
-the [migration guide](MIGRATION.md#colorkit-300). Exhaustive accessibility-status
-switches and stored enhancement-method references need updates. Comparison metrics,
-enhancement budgets, and color measurements can produce different results.
+Upgrading an existing project? Read the [migration guide](MIGRATION.md) before changing your version requirement.
 
----
+## Quick start
 
-## **🚀 Features**  
+Measure a foreground against an explicit background. Handle unavailable inputs separately from measured contrast:
 
-✅ **HEX <-> RGB Conversion**  
-✅ **HSL Color Support**  
-✅ **CMYK Color Support**  
-✅ **LAB Color Support**  
-✅ **Adaptive Colors (Light/Dark Mode)**  
-✅ **WCAG Contrast Checking for Accessibility**  
-✅ **Verifiable Accessibility Results**
-✅ **Auto-Generate Accessible Color Palettes**  
-✅ **Export & Share Color Palettes**  
-✅ **SwiftUI Modifiers for Dynamic Colors**  
-✅ **Gradient Generation Utilities**  
-✅ **Color Blending Modes (Overlay, Multiply, Screen, etc.)**  
-✅ **Comprehensive Theming System**  
-✅ **High-Performance Caching for Color Operations**  
-✅ **AccessibilityEnhancer for Intelligent Color Adjustments**  
-✅ **Advanced Color Debugging Tools**  
-✅ **Interactive Preview Catalog**  
-
----
-
-## **🎨 Usage**  
-
-### Component conversion results
-
-Use `componentConversionResults()` when availability matters. Each field reports its
-own value or issue, so a failed Hex conversion does not discard available LAB.
-
-<!-- swift-example: component-results -->
+<!-- swift-example: contrast -->
 ```swift
-let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
-if case .success(let lab) = conversions.lab {
-    print(lab.lightness, lab.a, lab.b)
-}
-switch conversions.hex {
-case .success(let hex): print(hex)
-case .failure(let issue): print("Hex unavailable:", issue)
+import SwiftUI
+import ColorKit
+
+let foreground = Color(.sRGB, red: 0, green: 0, blue: 0)
+let background = Color(.sRGB, red: 1, green: 1, blue: 1)
+
+switch foreground.contrastResult(with: background) {
+case .available(let measurement):
+    print("Contrast:", measurement.ratio)
+    print("Meets WCAG AA:", measurement.passingLevels.contains(.AA))
+case .unavailable(let issues):
+    print("Foreground issues:", issues.foreground)
+    print("Background issues:", issues.background)
 }
 ```
 
-All seven fields describe one fixed, uncomposited color: `srgba`, `hsl`, `hsb`,
-`cmyk`, `xyz`, `lab`, and `hex`. Named or dynamic colors without fixed components
-must be resolved explicitly by the caller. Extended sRGBA and finite D65 XYZ/LAB
-are preserved; HSL, HSB, CMYK, and Hex reject RGB outside `0...1` without clipping
-or endpoint tolerance. Alpha is retained in sRGBA and eight-digit `#RRGGBBAA` Hex;
-other coordinates omit it. Hues are turns, HSL/HSB/CMYK fractions are `0...1`, and
-XYZ uses reference-white Y = 100. CMYK is an algebraic approximation, not a printer
-profile. Existing APIs remain unchanged and are not deprecated. See the
-[conversion contract](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
-and [adoption notes](MIGRATION.md#component-conversion-results).
+Supply fixed colors; resolve appearance-dependent colors explicitly first. A translucent foreground composites over an opaque background. A translucent background is unavailable, so argument order matters.
 
-### **1️⃣ HEX <-> RGB Conversion**  
-```swift
-let color = Color(hex: "#FF5733")
-print(color.hexValue()) // "#FF5733FF"
-```
+A contrast pass is not whole-app accessibility certification. When generating adjusted colors, inspect the result before using the candidate.
 
-### **2️⃣ HSL Conversion**  
-<!-- swift-example: hsl -->
-```swift
-let hsl = Color.red.hslComponents()
-let customColor = Color(hue: 0.5, saturation: 1.0, lightness: 0.5)
-```
+## Guides and examples
 
-`hslComponents()` resolves named and dynamic colors for the current appearance.
-It converts to sRGB and clamps wider-gamut channels to `0...1` before conversion;
-opacity is not part of HSL. It returns `nil` when resolution fails, such as for a
-pattern color. Unlike HSL, CMYK and LAB require fixed colors and do not choose an
-appearance. See [HSL migration guidance](MIGRATION.md#hsl-resolution).
+- [Usage guide](docs/Usage.md): conversion, blending, themes, palettes, export, and inspection examples.
+- [Color spaces](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md): component results and conversion contracts.
+- [Accessibility](Sources/ColorKit/Documentation.docc/Accessibility-article.md): contrast targets, enhancement budgets, and simulation.
+- [Theming](Sources/ColorKit/Documentation.docc/Theming-article.md): adaptive and semantic colors.
+- [Comparisons and utilities](Sources/ColorKit/Documentation.docc/Utilities-article.md): perceptual differences and inspection.
+- [Performance](PERFORMANCE_IMPROVEMENTS.md): caching and measurement guidance.
 
-### **3️⃣ CMYK Conversion**  
-<!-- swift-example: cmyk -->
-```swift
-// Convert from RGB to CMYK
-let red = Color(.sRGB, red: 1, green: 0, blue: 0)
-let cmyk = red.cmykComponents()
-// (cyan: 0.0, magenta: 1.0, yellow: 1.0, key: 0.0)
-
-// Create color from CMYK values
-let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
-```
-
-### **4️⃣ LAB Conversion**  
-<!-- swift-example: lab -->
-```swift
-// Resolve a fixed color and convert it to LAB
-let red = Color(.sRGB, red: 1, green: 0, blue: 0)
-let lab = red.labComponents()
-if let lab {
-    print(lab) // (L: 53.24, a: 80.09, b: 67.20)
-}
-
-// Create color from LAB values
-let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
-```
-
-`labComponents()` resolves fixed RGB and grayscale colors—including linear RGB and
-Display P3—to nonlinear sRGB before conversion. Finite out-of-gamut channels are
-preserved without clipping. The method returns `nil` for colors it cannot resolve,
-such as unresolved dynamic colors; alpha does not affect the LAB coordinates.
-
-### **5️⃣ Adaptive Colors (Light/Dark Mode)**  
-```swift
-Text("Adaptive Text")
-    .adaptiveColor(light: .blue, dark: .orange)
-```
-
-### **6️⃣ Ensuring High Contrast**  
-```swift
-Text("Accessible Text")
-    .highContrastColor(base: .gray, background: .white)
-```
-
-### **7️⃣ Detecting Theme Changes**  
-```swift
-Text("Theme Change")
-    .onAdaptiveColorChange { newScheme in
-        print("Color scheme changed to: \(newScheme)")
-    }
-```
-
-### **8️⃣ Gradient Generation Utilities**  
-```swift
-let gradient = Gradient(colors: [.red, .blue])
-let linearGradient = LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom)
-```
-
-### **9️⃣ Color Blending Modes**  
-```swift
-let baseColor = Color.red
-let blendColor = Color.blue
-let blendedColor = baseColor.blended(with: blendColor, mode: .overlay)
-```
-
-### **🔟 Comprehensive Theming System**  
-```swift
-// Define a custom theme
-let oceanTheme = ColorTheme(
-    name: "Ocean",
-    primary: Color(hex: "#1E88E5"),
-    secondary: Color(hex: "#00ACC1"),
-    accent: Color(hex: "#7E57C2"),
-    background: Color(hex: "#ECEFF1"),
-    text: Color(hex: "#263238")
-)
-
-// Register the theme
-ThemeManager.shared.register(theme: oceanTheme)
-
-// Apply theme to a view hierarchy
-ContentView()
-    .withThemeManager()
-
-// Use themed colors in views
-Text("Themed Text")
-    .themedText(.primary)
-
-Button("Primary Button") {}
-    .themedButton(.primary)
-
-// Use semantic colors
-Rectangle()
-    .fill(Color.themed(.accent))
-```
-
-### **1️⃣1️⃣ Auto-Generate Accessible Color Palettes**  
-<!-- swift-example: accessible-palette -->
-```swift
-let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let generator = AccessiblePaletteGenerator(configuration: .init(targetLevel: .AA))
-let results = generator.generateAssessedPalette(from: seedColor, against: backgroundColor)
-for result in results {
-    if result.meetsTarget {
-        Text("WCAG AA").foregroundColor(result.color).background(backgroundColor)
-    } else {
-        print(result.status)
-    }
-}
-
-let textResult = backgroundColor.accessibleContrastingColorResult(for: .AA)
-let textColor = textResult.color
-
-switch textResult.status {
-case .meetsTarget:
-    if let ratio = textResult.contrastRatio {
-        print("Contrast: \(ratio):1")
-    }
-case .bestEffort:
-    print("Best available endpoint is below the requested target")
-case .unavailable:
-    print("Resolve the colors in an explicit appearance before assessment")
-case .invalidConfiguration:
-    print("Supply a finite perceptual-distance budget from 0 through 100")
-}
-
-// Use the demo view to experiment with palette generation
-struct ContentView: View {
-    var body: some View {
-        ColorKit.ColorInspector.accessiblePaletteDemoView()
-    }
-}
-```
-
-For new callers, check `meetsTarget` or `status` before using a candidate.
-Assessed palettes retain every outcome; they impose no enhancement budget and do
-not certify contrast between entries. Legacy palettes return candidates; themes
-only establish a black-and-white text/background pair.
-`accessibleContrastingColor(for:)` and `suggestedColor(for:)` ignore the requested
-level, use different heuristics, and do not guarantee that level.
-
-Run the standalone macOS [contrast pair report](Examples/ContrastPairReport/README.md)
-to assess foreground/background pairs against explicit per-pair WCAG targets.
-
-### **1️⃣2️⃣ Export & Share Color Palettes**  
-```swift
-// Create a palette from colors
-let colors: [Color] = [.red, .green, .blue]
-let palette = PaletteExporter.createPalette(from: colors)
-
-// Create a palette from a theme
-let theme = ThemeManager.shared.currentTheme
-let themePalette = PaletteExporter.createPalette(from: theme)
-
-// Export to various formats
-if let jsonData = PaletteExporter.export(
-    palette: palette,
-    to: .json,
-    paletteName: "My Palette"
-) {
-    // Use the data (save to file, share, etc.)
-}
-
-// Copy to clipboard
-PaletteExporter.copyToClipboard(
-    palette: palette,
-    format: .css,
-    paletteName: "My Palette"
-)
-
-// Export accessible palette
-let accessiblePaletteData = seedColor.exportAccessiblePalette(
-    targetLevel: .AA,
-    to: .svg,
-    paletteName: "Accessible Palette"
-)
-
-// Add export functionality to any view
-myView.paletteExport(colors: colors, paletteName: "RGB Palette")
-myView.paletteExport(theme: theme)
-
-// Use the export UI directly
-PaletteExportView(palette: palette, paletteName: "My Palette")
-```
-
-### **1️⃣3️⃣ Performance Optimizations (v1.4.0+)**  
-```swift
-// ColorKit automatically caches expensive color operations
-// No code changes required to benefit from performance improvements
-
-// First call calculates and caches
-let lab1 = color1.labComponents()
-
-// Second call retrieves from cache (much faster)
-let lab1Again = color1.labComponents()
-
-// Blending with caching
-let blended = color1.blended(with: color2, mode: .overlay, amount: 0.5)
-
-// Gradient interpolation with caching
-let interpolated = color1.interpolated(with: color2, amount: 0.5, in: .lab)
-
-// Get cached contrast ratio
-if let ratio = ColorCache.shared.getCachedContrastRatio(for: color1, with: color2) {
-    print("Cached contrast ratio: \(ratio)")
-}
-
-// Cache a contrast ratio
-ColorCache.shared.cacheContrastRatio(for: color1, with: color2, ratio: 4.5)
-
-// If needed, manually clear caches
-ColorCache.shared.clearCache()
-```
-
-For more details on performance improvements, see [PERFORMANCE_IMPROVEMENTS.md](PERFORMANCE_IMPROVEMENTS.md).
-
-### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
-<!-- swift-example: enhancement -->
-```swift
-// Generate a candidate within a distance budget, then inspect its outcome
-let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let targetLevel = WCAGContrastLevel.AA
-
-let result = originalColor.enhancementResult(
-    with: backgroundColor,
-    targetLevel: targetLevel
-)
-let enhancedColor = result.color
-
-if result.meetsTarget {
-    if let ratio = result.contrastRatio {
-        print("Measured contrast: \(ratio):1")
-    }
-}
-```
-
-### **1️⃣5️⃣ Preview Catalog**
-The Preview Catalog provides interactive demonstrations of ColorKit's features:
+Run the standalone macOS [contrast pair report](Examples/ContrastPairReport/README.md) to assess your own pairs, or explore the interactive catalog in a SwiftUI view:
 
 <!-- swift-example: catalog -->
 ```swift
+import SwiftUI
 import ColorKit
 
-struct ContentView: View {
+struct CatalogExample: View {
     var body: some View {
         MainCatalogView()
     }
 }
 ```
 
-Available previews:
+The standalone report has its own platform requirements; see its run instructions.
 
-1. **BlendingPreview**
-   - Interactive color blending with all blend modes
-   - Real-time blend amount control
-   - Performance metrics
+## Project
 
-2. **GradientPreview**
-   - Linear, radial, and angular gradient creation
-   - Color stop management
-   - Code generation
-
-3. **ThemePreview**
-   - Light/dark mode testing
-   - UI component showcase
-   - Theme code generation
-
-4. **PerformanceBenchmark**
-   - Operation benchmarking
-   - Caching metrics
-   - Iteration control
-
-5. **ColorDebuggerPreview**
-   - Color space visualization
-   - Component analysis
-   - Visual comparison tools
-   - Performance monitoring
-
-6. **PaletteStudioPreview**
-   - Palette generation
-   - Export functionality
-   - Harmony rules
-   - Theme generation
-
-7. **ColorAnimationPreview**
-   - Color transition testing
-   - Interpolation modes
-   - Timing curves
-   - Performance metrics
-
-8. **AccessibilityLabPreview**
-   - WCAG contrast checking
-   - Color enhancement strategies
-   - Accessible color suggestions
-   - Educational guidelines
-
-Each preview is designed to help developers understand and utilize ColorKit's features effectively. Access them through the `MainCatalogView` or individually:
-
-<!-- swift-example: previews -->
-```swift
-// Use individual previews
-ColorSpacePreview()
-BlendingPreview()
-GradientPreview()
-ThemePreview()
-PerformanceBenchmark()
-ColorDebuggerPreview()
-PaletteStudioPreview()
-ColorAnimationPreview()
-AccessibilityLabPreview()
-```
-
-## **🎨 Debugging Tools**  
-
-ColorKit now includes advanced debugging tools to help developers inspect colors, validate accessibility compliance, and ensure correct implementation. These tools include:
-
-### **Color Inspection**  
-
-Inspect colors in multiple color spaces (RGB, HSL, HSB, CMYK, LAB, XYZ):
-
-```swift
-// Get color components in all color spaces
-let components = myColor.colorSpaceComponents()
-print(components.description)
-
-// Display visual color inspector in SwiftUI
-ColorSpaceInspectorView(color: myColor)
-```
-
-`rgbaComponents()` resolves the current appearance: UIKit preserves extended sRGB;
-AppKit converts to bounded sRGB. Failure returns `(0, 0, 0, 0)`, indistinguishable
-from transparent black. Aggregate components inherit that policy, substitute zeros
-for failed HSL/CMYK, extract HSB without a success flag, and derive LAB/XYZ from RGB
-even on failure. Use optional conversions when availability matters.
-
-### **Color Comparison**  
-
-Compare fixed, opaque, in-gamut sRGB colors using component differences, WCAG metrics, and CIEDE2000:
-
-<!-- swift-example: comparison -->
-```swift
-let color1 = Color(.sRGB, red: 0.15, green: 0.35, blue: 0.75, opacity: 1)
-let color2 = Color(.sRGB, red: 0.55, green: 0.25, blue: 0.65, opacity: 1)
-
-switch color1.comparisonResult(with: color2) {
-case .available(let difference):
-    print("CIEDE2000 difference: \(difference.perceptualDifference)")
-case .unavailable(let issues):
-    print("Comparison unavailable: \(issues)")
-}
-
-// Visual comparison view
-ColorComparisonView(color1: color1, color2: color2)
-```
-
-Dynamic, translucent, nonfinite, and out-of-sRGB inputs return explicit issues instead of fabricated measurements.
-
-`isPerceptuallySimilar(to:threshold:)` uses CIE76 in D65 LAB and `distance < threshold`
-without validating the threshold. Equality or unavailable LAB returns `false`.
-It ignores alpha without compositing and accepts extended sRGB when LAB is available.
-CIEDE2000 requires opaque, in-gamut inputs; thresholds are not interchangeable.
-
-### **WCAG Accessibility Debugging**  
-
-Validate and improve color accessibility:
-
-In `foreground.contrastResult(with: background)`, the receiver is the foreground.
-A translucent foreground composites over the opaque background; a translucent
-background is unavailable. Reversing the arguments can change the result.
-
-<!-- swift-example: budget -->
-```swift
-// Check WCAG compliance
-let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
-print(assessment.status)
-
-// Get budgeted candidates with explicit outcomes and measurement evidence
-let suggestions = textColor.suggestAccessibleVariantResults(
-    with: backgroundColor,
-    targetLevel: .AA,
-    maxPerceptualDistance: 30
-)
-```
-
-Result-bearing enhancement enforces an inclusive CIEDE2000 Delta E 00 budget
-from the original foreground (finite `0...100`, default `30`). It returns in-budget
-best effort when no examined candidate passes, or an explicit `invalidConfiguration`
-or `unavailable` outcome. Legacy color-returning enhancement ignores the budget and does not guarantee the target.
-See [enhancement migration guidance](MIGRATION.md#enhancement-distance-budgets).
-
-See [Color Debugging Documentation](Sources/ColorKit/Utilities/DOCUMENTATION.md) for more details.
-
----
-
-## **🛠 Contributing**  
-We welcome contributions! Feel free to submit issues or open pull requests.  
-
-## **📜 License**  
-MIT License. See `LICENSE` for details.  
-
----
+[Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md) · [Migration](MIGRATION.md) · [MIT license](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ColorKit 🎨
 
+![Swift Package Manager](https://img.shields.io/badge/SPM-Supported-green)
+![Swift Version](https://img.shields.io/badge/Swift-6.0%2B-blue)
+
 Color conversion, contrast assessment, and adaptive themes for SwiftUI.
 
 **Swift 6+ · iOS 14+ · macOS 12+**

--- a/Sources/ColorKit/Utilities/README.md
+++ b/Sources/ColorKit/Utilities/README.md
@@ -36,7 +36,7 @@ The cache is automatically used by ColorKit methods. No changes to your code are
 // Example: First call calculates and caches
 let lab1 = color.labComponents()
 
-// Second call retrieves from cache (much faster)
+// Repeated calls can reuse cached results for eligible fixed inputs
 let lab2 = color.labComponents()
 ```
 
@@ -71,19 +71,8 @@ Consider clearing the cache in memory-sensitive situations:
 - Before performing memory-intensive operations
 - When transitioning between major sections of your app
 
-### Performance Impact
+### Performance measurement
 
-The caching system provides significant performance improvements:
+Cache benefits depend on the operation, input identity, cache state, and environment. Unsupported identities bypass caching. Historical speedup ratios are not supported by reproducible measurements and should not be used as expectations.
 
-- LAB color conversion: Up to 10x faster for repeated operations
-- HSL color conversion: Up to 8x faster for repeated operations
-- WCAG calculations: Up to 12x faster for repeated operations
-- Color blending: Up to 5x faster for repeated operations
-- Gradient generation: Up to 7x faster for repeated operations
-
-These improvements are most noticeable in scenarios with repeated color operations, such as:
-
-- Complex UIs with many color calculations
-- Animations that repeatedly use the same colors
-- Accessibility checks on the same set of colors
-- Dynamic theming with color transformations
+See [performance guidance](../../../PERFORMANCE_IMPROVEMENTS.md) and the [Release benchmark runner](../../../Benchmarks/README.md) for workloads, cache preparation, and reproduction commands.

--- a/docs/Usage.es-ES.md
+++ b/docs/Usage.es-ES.md
@@ -104,7 +104,7 @@ if result.meetsTarget {
 }
 ```
 
-Comprueba el resultado antes de usar el candidato. El límite de distancia puede impedir alcanzar el objetivo. La mejora heredada que devuelve un color ignora ese límite. Consulta [accesibilidad](../Sources/ColorKit/Documentation.docc/Accessibility-article.md).
+Comprueba el resultado antes de usar el candidato. El límite de distancia puede impedir alcanzar el objetivo. La mejora heredada que devuelve un color ignora ese límite. Consulta [contratos de mejora](../Sources/ColorKit/Documentation.docc/Accessibility-article.md#verifiable-results).
 
 ### Evaluar una paleta generada
 

--- a/docs/Usage.es-ES.md
+++ b/docs/Usage.es-ES.md
@@ -1,0 +1,453 @@
+# Uso de ColorKit
+
+[Volver al README](../README.es-ES.md) · [English](Usage.md)
+
+## **🎨 Uso**  
+
+### Resultados de conversión de componentes
+
+Usa `componentConversionResults()` cuando importe la disponibilidad. Cada campo
+devuelve su valor o un problema, de modo que un fallo de Hex no descarta LAB disponible.
+
+<!-- swift-example: component-results -->
+```swift
+let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
+if case .success(let lab) = conversions.lab {
+    print(lab.lightness, lab.a, lab.b)
+}
+switch conversions.hex {
+case .success(let hex): print(hex)
+case .failure(let issue): print("Hex no disponible:", issue)
+}
+```
+
+Los siete campos describen un único color fijo, sin composición con un fondo:
+`srgba`, `hsl`, `hsb`, `cmyk`, `xyz`, `lab` y `hex`. El llamador debe resolver
+explícitamente los colores con nombre o dinámicos que no tengan componentes fijos.
+Se conservan sRGBA extendido y XYZ/LAB D65 finitos; HSL, HSB, CMYK y Hex rechazan
+RGB fuera de `0...1`, sin recorte ni tolerancia en los extremos. Alfa se conserva
+en sRGBA y en Hex de ocho dígitos `#RRGGBBAA`; las demás coordenadas lo omiten.
+El tono se expresa en vueltas, las fracciones HSL/HSB/CMYK están en `0...1` y XYZ
+usa Y = 100 para el blanco de referencia. CMYK es una aproximación algebraica,
+no un perfil de impresión. Las API existentes no cambian ni se marcan como obsoletas.
+Consulta el [contrato de conversión](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
+y las [notas de adopción](../MIGRATION.md#component-conversion-results).
+
+### **1️⃣ Conversión HEX <-> RGB**  
+```swift
+let color = Color(hex: "#FF5733")
+print(color.hexValue()) // "#FF5733FF"
+```
+
+### **2️⃣ Conversión HSL**  
+<!-- swift-example: hsl -->
+```swift
+let hsl = Color.red.hslComponents()
+let customColor = Color(hue: 0.5, saturation: 1.0, lightness: 0.5)
+```
+
+`hslComponents()` resuelve colores con nombre y dinámicos para la apariencia actual.
+Convierte a sRGB y recorta los canales de gama más amplia a `0...1` antes de la
+conversión; la opacidad no forma parte de HSL. Devuelve `nil` si la resolución falla,
+por ejemplo, con un color de patrón. A diferencia de HSL, CMYK y LAB requieren
+colores fijos y no eligen una apariencia. Consulta la
+[guía de migración de HSL](../MIGRATION.md#hsl-resolution).
+
+### **3️⃣ Conversión CMYK**  
+<!-- swift-example: cmyk -->
+```swift
+// Convertir de RGB a CMYK
+let red = Color(.sRGB, red: 1, green: 0, blue: 0)
+let cmyk = red.cmykComponents()
+// (cyan: 0.0, magenta: 1.0, yellow: 1.0, key: 0.0)
+
+// Crear color a partir de valores CMYK
+let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
+```
+
+### **4️⃣ Conversión LAB**  
+<!-- swift-example: lab -->
+```swift
+// Resolver un color fijo y convertirlo a LAB
+let red = Color(.sRGB, red: 1, green: 0, blue: 0)
+let lab = red.labComponents()
+if let lab {
+    print(lab) // (L: 53.24, a: 80.09, b: 67.20)
+}
+
+// Crear color a partir de valores LAB
+let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
+```
+
+`labComponents()` resuelve colores RGB y de escala de grises fijos —incluidos RGB
+lineal y Display P3— a sRGB no lineal antes de la conversión. Los canales finitos
+fuera de gama se conservan sin recorte. El método devuelve `nil` para los colores
+que no puede resolver, como los colores dinámicos sin resolver; el canal alfa no
+afecta a las coordenadas LAB.
+
+### **5️⃣ Colores adaptables (Modo Claro/Oscuro)**  
+```swift
+Text("Adaptive Text")
+    .adaptiveColor(light: .blue, dark: .orange)
+```
+
+### **6️⃣ Garantizar alto contraste**  
+```swift
+Text("Accessible Text")
+    .highContrastColor(base: .gray, background: .white)
+```
+
+### **7️⃣ Detección de cambios de tema**  
+```swift
+Text("Theme Change")
+    .onAdaptiveColorChange { newScheme in
+        print("El esquema de color cambió a: \(newScheme)")
+    }
+```
+
+### **8️⃣ Utilidades de generación de gradientes**  
+```swift
+let gradient = Gradient(colors: [.red, .blue])
+let linearGradient = LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom)
+```
+
+### **9️⃣ Modos de fusión de colores**  
+```swift
+let baseColor = Color.red
+let blendColor = Color.blue
+let blendedColor = baseColor.blended(with: blendColor, mode: .overlay)
+```
+
+### **🔟 Sistema de temas integral**  
+```swift
+// Definir un tema personalizado
+let oceanTheme = ColorTheme(
+    name: "Ocean",
+    primary: Color(hex: "#1E88E5"),
+    secondary: Color(hex: "#00ACC1"),
+    accent: Color(hex: "#7E57C2"),
+    background: Color(hex: "#ECEFF1"),
+    text: Color(hex: "#263238")
+)
+
+// Registrar el tema
+ThemeManager.shared.register(theme: oceanTheme)
+
+// Aplicar tema a una jerarquía de vistas
+ContentView()
+    .withThemeManager()
+
+// Usar colores con tema en las vistas
+Text("Themed Text")
+    .themedText(.primary)
+
+Button("Primary Button") {}
+    .themedButton(.primary)
+
+// Usar colores semánticos
+Rectangle()
+    .fill(Color.themed(.accent))
+```
+
+### **1️⃣1️⃣ Generación automática de paletas de colores accesibles**  
+<!-- swift-example: accessible-palette -->
+```swift
+let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let generator = AccessiblePaletteGenerator(configuration: .init(targetLevel: .AA))
+let results = generator.generateAssessedPalette(from: seedColor, against: backgroundColor)
+for result in results {
+    if result.meetsTarget {
+        Text("WCAG AA").foregroundColor(result.color).background(backgroundColor)
+    } else {
+        print(result.status)
+    }
+}
+
+let textResult = backgroundColor.accessibleContrastingColorResult(for: .AA)
+let textColor = textResult.color
+
+switch textResult.status {
+case .meetsTarget:
+    if let ratio = textResult.contrastRatio {
+        print("Contraste: \(ratio):1")
+    }
+case .bestEffort:
+    print("El mejor extremo disponible no alcanza el objetivo")
+case .unavailable:
+    print("Resuelve los colores con una apariencia explícita antes de evaluarlos")
+case .invalidConfiguration:
+    print("Proporciona un límite de distancia perceptual finito entre 0 y 100")
+}
+
+// Usar la vista de demostración para experimentar con la generación de paletas
+struct ContentView: View {
+    var body: some View {
+        ColorKit.ColorInspector.accessiblePaletteDemoView()
+    }
+}
+```
+
+Para código nuevo, comprueba `meetsTarget` o `status` antes de usar un candidato.
+La paleta evaluada conserva todos los resultados; no aplica un límite de mejora ni
+certifica el contraste entre entradas. Las paletas heredadas devuelven candidatos;
+los temas solo establecen una pareja de texto/fondo blanco y negro.
+`accessibleContrastingColor(for:)` y `suggestedColor(for:)` ignoran el nivel solicitado,
+usan heurísticas distintas y no garantizan ese nivel.
+
+Ejecuta el [informe de pares de contraste](../Examples/ContrastPairReport/README.md)
+independiente para macOS para evaluar pares de primer plano/fondo con objetivos WCAG explícitos por par.
+
+### **1️⃣2️⃣ Exportar y compartir paletas de colores**  
+```swift
+// Crear una paleta a partir de colores
+let colors: [Color] = [.red, .green, .blue]
+let palette = PaletteExporter.createPalette(from: colors)
+
+// Crear una paleta a partir de un tema
+let theme = ThemeManager.shared.currentTheme
+let themePalette = PaletteExporter.createPalette(from: theme)
+
+// Exportar a varios formatos
+if let jsonData = PaletteExporter.export(
+    palette: palette,
+    to: .json,
+    paletteName: "My Palette"
+) {
+    // Usar los datos (guardar en archivo, compartir, etc.)
+}
+
+// Copiar al portapapeles
+PaletteExporter.copyToClipboard(
+    palette: palette,
+    format: .css,
+    paletteName: "My Palette"
+)
+
+// Exportar paleta accesible
+let accessiblePaletteData = seedColor.exportAccessiblePalette(
+    targetLevel: .AA,
+    to: .svg,
+    paletteName: "Accessible Palette"
+)
+
+// Agregar funcionalidad de exportación a cualquier vista
+myView.paletteExport(colors: colors, paletteName: "RGB Palette")
+myView.paletteExport(theme: theme)
+
+// Usar la interfaz de exportación directamente
+PaletteExportView(palette: palette, paletteName: "My Palette")
+```
+
+### **1️⃣3️⃣ Optimizaciones de rendimiento (v1.4.0+)**  
+```swift
+// ColorKit almacena automáticamente en caché las operaciones de color costosas
+// No se requieren cambios de código para beneficiarse de las mejoras de rendimiento
+
+// La primera llamada calcula y almacena en caché
+let lab1 = color1.labComponents()
+
+// La segunda llamada recupera desde la caché (mucho más rápido)
+let lab1Again = color1.labComponents()
+
+// Fusión con caché
+let blended = color1.blended(with: color2, mode: .overlay, amount: 0.5)
+
+// Interpolación de gradiente con caché
+let interpolated = color1.interpolated(with: color2, amount: 0.5, in: .lab)
+
+// Obtener relación de contraste en caché
+if let ratio = ColorCache.shared.getCachedContrastRatio(for: color1, with: color2) {
+    print("Cached contrast ratio: \(ratio)")
+}
+
+// Almacenar una relación de contraste en caché
+ColorCache.shared.cacheContrastRatio(for: color1, with: color2, ratio: 4.5)
+
+// Si es necesario, borrar manualmente las cachés
+ColorCache.shared.clearCache()
+```
+
+Para más detalles sobre las mejoras de rendimiento, consulta [PERFORMANCE_IMPROVEMENTS.md](../PERFORMANCE_IMPROVEMENTS.md).
+
+### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
+<!-- swift-example: enhancement -->
+```swift
+// Generar un candidato dentro de un límite de distancia e inspeccionar su resultado
+let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let targetLevel = WCAGContrastLevel.AA
+
+let result = originalColor.enhancementResult(
+    with: backgroundColor,
+    targetLevel: targetLevel
+)
+let enhancedColor = result.color
+
+if result.meetsTarget {
+    if let ratio = result.contrastRatio {
+        print("Contraste medido: \(ratio):1")
+    }
+}
+```
+
+### **1️⃣5️⃣ Catálogo de vista previa**
+El Catálogo de vista previa ofrece demostraciones interactivas de las características de ColorKit:
+
+<!-- swift-example: catalog -->
+```swift
+import ColorKit
+
+struct ContentView: View {
+    var body: some View {
+        MainCatalogView()
+    }
+}
+```
+
+Vistas previas disponibles:
+
+1. **BlendingPreview**
+   - Fusión de color interactiva con todos los modos de fusión
+   - Control en tiempo real de la cantidad de fusión
+   - Métricas de rendimiento
+
+2. **GradientPreview**
+   - Creación de gradientes lineales, radiales y angulares
+   - Gestión de paradas de color
+   - Generación de código
+
+3. **ThemePreview**
+   - Pruebas de modo claro/oscuro
+   - Muestra de componentes de interfaz
+   - Generación de código de tema
+
+4. **PerformanceBenchmark**
+   - Análisis comparativo de operaciones
+   - Métricas de caché
+   - Control de iteraciones
+
+5. **ColorDebuggerPreview**
+   - Visualización del espacio de color
+   - Análisis de componentes
+   - Herramientas de comparación visual
+   - Monitoreo de rendimiento
+
+6. **PaletteStudioPreview**
+   - Generación de paletas
+   - Funcionalidad de exportación
+   - Reglas de armonía
+   - Generación de temas
+
+7. **ColorAnimationPreview**
+   - Pruebas de transición de color
+   - Modos de interpolación
+   - Curvas de temporización
+   - Métricas de rendimiento
+
+8. **AccessibilityLabPreview**
+   - Verificación de contraste WCAG
+   - Estrategias de mejora de color
+   - Sugerencias de colores accesibles
+   - Directrices educativas
+
+Cada vista previa está diseñada para ayudar a los desarrolladores a comprender y utilizar eficazmente las características de ColorKit. Accede a ellas a través de `MainCatalogView` o de forma individual:
+
+<!-- swift-example: previews -->
+```swift
+// Usar vistas previas individuales
+ColorSpacePreview()
+BlendingPreview()
+GradientPreview()
+ThemePreview()
+PerformanceBenchmark()
+ColorDebuggerPreview()
+PaletteStudioPreview()
+ColorAnimationPreview()
+AccessibilityLabPreview()
+```
+
+## **🎨 Herramientas de depuración**  
+
+ColorKit ahora incluye herramientas avanzadas de depuración para ayudar a los desarrolladores a inspeccionar colores, validar el cumplimiento de accesibilidad y garantizar una implementación correcta. Estas herramientas incluyen:
+
+### **Inspección de colores**  
+
+Inspecciona colores en múltiples espacios de color (RGB, HSL, HSB, CMYK, LAB, XYZ):
+
+```swift
+// Obtener componentes de color en todos los espacios de color
+let components = myColor.colorSpaceComponents()
+print(components.description)
+
+// Mostrar inspeccionador visual de color en SwiftUI
+ColorSpaceInspectorView(color: myColor)
+```
+
+`rgbaComponents()` resuelve la apariencia actual: UIKit conserva sRGB extendido;
+AppKit convierte a sRGB acotado. Un fallo devuelve `(0, 0, 0, 0)`, indistinguible del
+negro transparente. Los componentes agregados heredan esa política, sustituyen fallos
+HSL/CMYK por ceros, extraen HSB sin indicar éxito y derivan LAB/XYZ de RGB incluso
+si es una sustitución. Usa conversiones opcionales cuando importe la disponibilidad.
+
+### **Comparación de colores**  
+
+Compara colores sRGB fijos, opacos y dentro de gama mediante diferencias de componentes, métricas WCAG y CIEDE2000:
+
+<!-- swift-example: comparison -->
+```swift
+let color1 = Color(.sRGB, red: 0.15, green: 0.35, blue: 0.75, opacity: 1)
+let color2 = Color(.sRGB, red: 0.55, green: 0.25, blue: 0.65, opacity: 1)
+
+switch color1.comparisonResult(with: color2) {
+case .available(let difference):
+    print("Diferencia CIEDE2000: \(difference.perceptualDifference)")
+case .unavailable(let issues):
+    print("Comparación no disponible: \(issues)")
+}
+
+// Vista de comparación visual
+ColorComparisonView(color1: color1, color2: color2)
+```
+
+Los colores dinámicos, translúcidos, no finitos o fuera de la gama sRGB devuelven problemas explícitos en vez de mediciones inventadas.
+
+`isPerceptuallySimilar(to:threshold:)` usa CIE76 en LAB D65 y `distancia < umbral`
+sin validar el umbral. La igualdad o una conversión LAB no disponible devuelven `false`.
+Ignora alfa sin componer sobre un fondo y admite sRGB extendido si LAB está disponible.
+CIEDE2000 requiere colores opacos dentro de gama; los umbrales no son intercambiables.
+
+### **Depuración de accesibilidad WCAG**  
+
+Valida y mejora la accesibilidad de los colores:
+
+En `foreground.contrastResult(with: background)`, el receptor es el primer plano.
+Un primer plano translúcido se compone sobre el fondo opaco; un fondo translúcido
+no está disponible. Invertir los argumentos puede cambiar el resultado.
+
+<!-- swift-example: budget -->
+```swift
+// Verificar cumplimiento WCAG
+let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
+print(assessment.status)
+
+// Obtener candidatos dentro del límite con resultados explícitos y evidencia de medición
+let suggestions = textColor.suggestAccessibleVariantResults(
+    with: backgroundColor,
+    targetLevel: .AA,
+    maxPerceptualDistance: 30
+)
+```
+
+Las APIs de mejora que devuelven resultados aplican un límite inclusivo CIEDE2000
+Delta E 00 respecto al primer plano original (finito, en `0...100`, predeterminado: `30`).
+Si ningún candidato examinado alcanza el objetivo, devuelven el mejor esfuerzo dentro
+del límite, o un resultado explícito `invalidConfiguration` o `unavailable`.
+Las mejoras heredadas que devuelven solo colores ignoran el límite y no garantizan el objetivo.
+Consulta la [guía de migración de mejoras](../MIGRATION.md#enhancement-distance-budgets).
+
+Consulta la [Documentación de depuración de colores](../Sources/ColorKit/Utilities/DOCUMENTATION.md) para más detalles.
+
+---

--- a/docs/Usage.es-ES.md
+++ b/docs/Usage.es-ES.md
@@ -1,13 +1,12 @@
-# Uso de ColorKit
+# Recetas de ColorKit
 
 [Volver al README](../README.es-ES.md) · [English](Usage.md)
 
-## **🎨 Uso**  
+Ejemplos concretos con las API públicas existentes. Importa `SwiftUI` y `ColorKit` en tu proyecto. Los contratos detallados están en las guías enlazadas, en inglés.
 
-### Resultados de conversión de componentes
+## Convertir colores
 
-Usa `componentConversionResults()` cuando importe la disponibilidad. Cada campo
-devuelve su valor o un problema, de modo que un fallo de Hex no descarta LAB disponible.
+Usa resultados por representación cuando importe la disponibilidad. Proporciona un color fijo; captura explícitamente la apariencia deseada para colores dinámicos. Una representación no disponible no descarta las conversiones válidas.
 
 <!-- swift-example: component-results -->
 ```swift
@@ -21,39 +20,20 @@ case .failure(let issue): print("Hex no disponible:", issue)
 }
 ```
 
-Los siete campos describen un único color fijo, sin composición con un fondo:
-`srgba`, `hsl`, `hsb`, `cmyk`, `xyz`, `lab` y `hex`. El llamador debe resolver
-explícitamente los colores con nombre o dinámicos que no tengan componentes fijos.
-Se conservan sRGBA extendido y XYZ/LAB D65 finitos; HSL, HSB, CMYK y Hex rechazan
-RGB fuera de `0...1`, sin recorte ni tolerancia en los extremos. Alfa se conserva
-en sRGBA y en Hex de ocho dígitos `#RRGGBBAA`; las demás coordenadas lo omiten.
-El tono se expresa en vueltas, las fracciones HSL/HSB/CMYK están en `0...1` y XYZ
-usa Y = 100 para el blanco de referencia. CMYK es una aproximación algebraica,
-no un perfil de impresión. Las API existentes no cambian ni se marcan como obsoletas.
-Consulta el [contrato de conversión](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
-y las [notas de adopción](../MIGRATION.md#component-conversion-results).
+Consulta los [contratos de componentes](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results) para las reglas de gama, alfa, unidades y errores.
 
-### **1️⃣ Conversión HEX <-> RGB**  
-```swift
-let color = Color(hex: "#FF5733")
-print(color.hexValue()) // "#FF5733FF"
-```
+### HSL
 
-### **2️⃣ Conversión HSL**  
+El acceso HSL heredado resuelve la apariencia actual y recorta a sRGB. Devuelve `nil` si la resolución falla.
+
 <!-- swift-example: hsl -->
 ```swift
 let hsl = Color.red.hslComponents()
 let customColor = Color(hue: 0.5, saturation: 1.0, lightness: 0.5)
 ```
 
-`hslComponents()` resuelve colores con nombre y dinámicos para la apariencia actual.
-Convierte a sRGB y recorta los canales de gama más amplia a `0...1` antes de la
-conversión; la opacidad no forma parte de HSL. Devuelve `nil` si la resolución falla,
-por ejemplo, con un color de patrón. A diferencia de HSL, CMYK y LAB requieren
-colores fijos y no eligen una apariencia. Consulta la
-[guía de migración de HSL](../MIGRATION.md#hsl-resolution).
+### CMYK
 
-### **3️⃣ Conversión CMYK**  
 <!-- swift-example: cmyk -->
 ```swift
 // Convertir de RGB a CMYK
@@ -65,7 +45,8 @@ let cmyk = red.cmykComponents()
 let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
 ```
 
-### **4️⃣ Conversión LAB**  
+### LAB
+
 <!-- swift-example: lab -->
 ```swift
 // Resolver un color fijo y convertirlo a LAB
@@ -79,77 +60,54 @@ if let lab {
 let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
 ```
 
-`labComponents()` resuelve colores RGB y de escala de grises fijos —incluidos RGB
-lineal y Display P3— a sRGB no lineal antes de la conversión. Los canales finitos
-fuera de gama se conservan sin recorte. El método devuelve `nil` para los colores
-que no puede resolver, como los colores dinámicos sin resolver; el canal alfa no
-afecta a las coordenadas LAB.
+Los accesos CMYK y LAB requieren colores fijos; no eligen una apariencia. Consulta [espacios de color](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md) para sus distintas políticas de conversión y el soporte Hex.
 
-### **5️⃣ Colores adaptables (Modo Claro/Oscuro)**  
-```swift
-Text("Adaptive Text")
-    .adaptiveColor(light: .blue, dark: .orange)
-```
+## Evaluar y ajustar el contraste
 
-### **6️⃣ Garantizar alto contraste**  
-```swift
-Text("Accessible Text")
-    .highContrastColor(base: .gray, background: .white)
-```
+El receptor es el primer plano. Los primeros planos translúcidos se componen sobre fondos opacos; los fondos translúcidos no permiten la medición. Superar el contraste no certifica toda la aplicación.
 
-### **7️⃣ Detección de cambios de tema**  
+<!-- swift-example: budget -->
 ```swift
-Text("Theme Change")
-    .onAdaptiveColorChange { newScheme in
-        print("El esquema de color cambió a: \(newScheme)")
-    }
-```
+// Verificar cumplimiento WCAG
+let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
+print(assessment.status)
 
-### **8️⃣ Utilidades de generación de gradientes**  
-```swift
-let gradient = Gradient(colors: [.red, .blue])
-let linearGradient = LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom)
-```
-
-### **9️⃣ Modos de fusión de colores**  
-```swift
-let baseColor = Color.red
-let blendColor = Color.blue
-let blendedColor = baseColor.blended(with: blendColor, mode: .overlay)
-```
-
-### **🔟 Sistema de temas integral**  
-```swift
-// Definir un tema personalizado
-let oceanTheme = ColorTheme(
-    name: "Ocean",
-    primary: Color(hex: "#1E88E5"),
-    secondary: Color(hex: "#00ACC1"),
-    accent: Color(hex: "#7E57C2"),
-    background: Color(hex: "#ECEFF1"),
-    text: Color(hex: "#263238")
+// Obtener candidatos dentro del límite con resultados explícitos y evidencia de medición
+let suggestions = textColor.suggestAccessibleVariantResults(
+    with: backgroundColor,
+    targetLevel: .AA,
+    maxPerceptualDistance: 30
 )
-
-// Registrar el tema
-ThemeManager.shared.register(theme: oceanTheme)
-
-// Aplicar tema a una jerarquía de vistas
-ContentView()
-    .withThemeManager()
-
-// Usar colores con tema en las vistas
-Text("Themed Text")
-    .themedText(.primary)
-
-Button("Primary Button") {}
-    .themedButton(.primary)
-
-// Usar colores semánticos
-Rectangle()
-    .fill(Color.themed(.accent))
 ```
 
-### **1️⃣1️⃣ Generación automática de paletas de colores accesibles**  
+### Generar un candidato ajustado
+
+<!-- swift-example: enhancement -->
+```swift
+// Generar un candidato dentro de un límite de distancia e inspeccionar su resultado
+let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let targetLevel = WCAGContrastLevel.AA
+
+let result = originalColor.enhancementResult(
+    with: backgroundColor,
+    targetLevel: targetLevel
+)
+let enhancedColor = result.color
+
+if result.meetsTarget {
+    if let ratio = result.contrastRatio {
+        print("Contraste medido: \(ratio):1")
+    }
+}
+```
+
+Comprueba el resultado antes de usar el candidato. El límite de distancia puede impedir alcanzar el objetivo. La mejora heredada que devuelve un color ignora ese límite. Consulta [accesibilidad](../Sources/ColorKit/Documentation.docc/Accessibility-article.md).
+
+### Evaluar una paleta generada
+
 <!-- swift-example: accessible-palette -->
 ```swift
 let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
@@ -188,211 +146,13 @@ struct ContentView: View {
 }
 ```
 
-Para código nuevo, comprueba `meetsTarget` o `status` antes de usar un candidato.
-La paleta evaluada conserva todos los resultados; no aplica un límite de mejora ni
-certifica el contraste entre entradas. Las paletas heredadas devuelven candidatos;
-los temas solo establecen una pareja de texto/fondo blanco y negro.
-`accessibleContrastingColor(for:)` y `suggestedColor(for:)` ignoran el nivel solicitado,
-usan heurísticas distintas y no garantizan ese nivel.
+Las evaluaciones conservan cada resultado y no certifican el contraste entre entradas de la paleta. Consulta [paletas evaluadas](../Sources/ColorKit/Documentation.docc/Accessibility-article.md#assessed-palettes) para las garantías y diferencias heredadas.
 
-Ejecuta el [informe de pares de contraste](../Examples/ContrastPairReport/README.md)
-independiente para macOS para evaluar pares de primer plano/fondo con objetivos WCAG explícitos por par.
+Para evaluar tus propios pares explícitos, ejecuta el [informe de pares de contraste](../Examples/ContrastPairReport/README.md) independiente para macOS.
 
-### **1️⃣2️⃣ Exportar y compartir paletas de colores**  
-```swift
-// Crear una paleta a partir de colores
-let colors: [Color] = [.red, .green, .blue]
-let palette = PaletteExporter.createPalette(from: colors)
+## Comparar colores
 
-// Crear una paleta a partir de un tema
-let theme = ThemeManager.shared.currentTheme
-let themePalette = PaletteExporter.createPalette(from: theme)
-
-// Exportar a varios formatos
-if let jsonData = PaletteExporter.export(
-    palette: palette,
-    to: .json,
-    paletteName: "My Palette"
-) {
-    // Usar los datos (guardar en archivo, compartir, etc.)
-}
-
-// Copiar al portapapeles
-PaletteExporter.copyToClipboard(
-    palette: palette,
-    format: .css,
-    paletteName: "My Palette"
-)
-
-// Exportar paleta accesible
-let accessiblePaletteData = seedColor.exportAccessiblePalette(
-    targetLevel: .AA,
-    to: .svg,
-    paletteName: "Accessible Palette"
-)
-
-// Agregar funcionalidad de exportación a cualquier vista
-myView.paletteExport(colors: colors, paletteName: "RGB Palette")
-myView.paletteExport(theme: theme)
-
-// Usar la interfaz de exportación directamente
-PaletteExportView(palette: palette, paletteName: "My Palette")
-```
-
-### **1️⃣3️⃣ Optimizaciones de rendimiento (v1.4.0+)**  
-```swift
-// ColorKit almacena automáticamente en caché las operaciones de color costosas
-// No se requieren cambios de código para beneficiarse de las mejoras de rendimiento
-
-// La primera llamada calcula y almacena en caché
-let lab1 = color1.labComponents()
-
-// La segunda llamada recupera desde la caché (mucho más rápido)
-let lab1Again = color1.labComponents()
-
-// Fusión con caché
-let blended = color1.blended(with: color2, mode: .overlay, amount: 0.5)
-
-// Interpolación de gradiente con caché
-let interpolated = color1.interpolated(with: color2, amount: 0.5, in: .lab)
-
-// Obtener relación de contraste en caché
-if let ratio = ColorCache.shared.getCachedContrastRatio(for: color1, with: color2) {
-    print("Cached contrast ratio: \(ratio)")
-}
-
-// Almacenar una relación de contraste en caché
-ColorCache.shared.cacheContrastRatio(for: color1, with: color2, ratio: 4.5)
-
-// Si es necesario, borrar manualmente las cachés
-ColorCache.shared.clearCache()
-```
-
-Para más detalles sobre las mejoras de rendimiento, consulta [PERFORMANCE_IMPROVEMENTS.md](../PERFORMANCE_IMPROVEMENTS.md).
-
-### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
-<!-- swift-example: enhancement -->
-```swift
-// Generar un candidato dentro de un límite de distancia e inspeccionar su resultado
-let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let targetLevel = WCAGContrastLevel.AA
-
-let result = originalColor.enhancementResult(
-    with: backgroundColor,
-    targetLevel: targetLevel
-)
-let enhancedColor = result.color
-
-if result.meetsTarget {
-    if let ratio = result.contrastRatio {
-        print("Contraste medido: \(ratio):1")
-    }
-}
-```
-
-### **1️⃣5️⃣ Catálogo de vista previa**
-El Catálogo de vista previa ofrece demostraciones interactivas de las características de ColorKit:
-
-<!-- swift-example: catalog -->
-```swift
-import ColorKit
-
-struct ContentView: View {
-    var body: some View {
-        MainCatalogView()
-    }
-}
-```
-
-Vistas previas disponibles:
-
-1. **BlendingPreview**
-   - Fusión de color interactiva con todos los modos de fusión
-   - Control en tiempo real de la cantidad de fusión
-   - Métricas de rendimiento
-
-2. **GradientPreview**
-   - Creación de gradientes lineales, radiales y angulares
-   - Gestión de paradas de color
-   - Generación de código
-
-3. **ThemePreview**
-   - Pruebas de modo claro/oscuro
-   - Muestra de componentes de interfaz
-   - Generación de código de tema
-
-4. **PerformanceBenchmark**
-   - Análisis comparativo de operaciones
-   - Métricas de caché
-   - Control de iteraciones
-
-5. **ColorDebuggerPreview**
-   - Visualización del espacio de color
-   - Análisis de componentes
-   - Herramientas de comparación visual
-   - Monitoreo de rendimiento
-
-6. **PaletteStudioPreview**
-   - Generación de paletas
-   - Funcionalidad de exportación
-   - Reglas de armonía
-   - Generación de temas
-
-7. **ColorAnimationPreview**
-   - Pruebas de transición de color
-   - Modos de interpolación
-   - Curvas de temporización
-   - Métricas de rendimiento
-
-8. **AccessibilityLabPreview**
-   - Verificación de contraste WCAG
-   - Estrategias de mejora de color
-   - Sugerencias de colores accesibles
-   - Directrices educativas
-
-Cada vista previa está diseñada para ayudar a los desarrolladores a comprender y utilizar eficazmente las características de ColorKit. Accede a ellas a través de `MainCatalogView` o de forma individual:
-
-<!-- swift-example: previews -->
-```swift
-// Usar vistas previas individuales
-ColorSpacePreview()
-BlendingPreview()
-GradientPreview()
-ThemePreview()
-PerformanceBenchmark()
-ColorDebuggerPreview()
-PaletteStudioPreview()
-ColorAnimationPreview()
-AccessibilityLabPreview()
-```
-
-## **🎨 Herramientas de depuración**  
-
-ColorKit ahora incluye herramientas avanzadas de depuración para ayudar a los desarrolladores a inspeccionar colores, validar el cumplimiento de accesibilidad y garantizar una implementación correcta. Estas herramientas incluyen:
-
-### **Inspección de colores**  
-
-Inspecciona colores en múltiples espacios de color (RGB, HSL, HSB, CMYK, LAB, XYZ):
-
-```swift
-// Obtener componentes de color en todos los espacios de color
-let components = myColor.colorSpaceComponents()
-print(components.description)
-
-// Mostrar inspeccionador visual de color en SwiftUI
-ColorSpaceInspectorView(color: myColor)
-```
-
-`rgbaComponents()` resuelve la apariencia actual: UIKit conserva sRGB extendido;
-AppKit convierte a sRGB acotado. Un fallo devuelve `(0, 0, 0, 0)`, indistinguible del
-negro transparente. Los componentes agregados heredan esa política, sustituyen fallos
-HSL/CMYK por ceros, extraen HSB sin indicar éxito y derivan LAB/XYZ de RGB incluso
-si es una sustitución. Usa conversiones opcionales cuando importe la disponibilidad.
-
-### **Comparación de colores**  
-
-Compara colores sRGB fijos, opacos y dentro de gama mediante diferencias de componentes, métricas WCAG y CIEDE2000:
+La comparación CIEDE2000 requiere entradas fijas, opacas y dentro de la gama sRGB. Las mediciones no disponibles se indican explícitamente.
 
 <!-- swift-example: comparison -->
 ```swift
@@ -410,44 +170,44 @@ case .unavailable(let issues):
 ColorComparisonView(color1: color1, color2: color2)
 ```
 
-Los colores dinámicos, translúcidos, no finitos o fuera de la gama sRGB devuelven problemas explícitos en vez de mediciones inventadas.
+El predicado de similitud heredado usa CIE76, no CIEDE2000; los umbrales no son intercambiables. Consulta los [contratos de comparación](../Sources/ColorKit/Documentation.docc/Utilities-article.md).
 
-`isPerceptuallySimilar(to:threshold:)` usa CIE76 en LAB D65 y `distancia < umbral`
-sin validar el umbral. La igualdad o una conversión LAB no disponible devuelven `false`.
-Ignora alfa sin componer sobre un fondo y admite sRGB extendido si LAB está disponible.
-CIEDE2000 requiere colores opacos dentro de gama; los umbrales no son intercambiables.
+## Explorar el catálogo
 
-### **Depuración de accesibilidad WCAG**  
+El catálogo muestra fusión, gradientes, temas, paletas, inspección, animación y accesibilidad. Intégralo en una aplicación SwiftUI:
 
-Valida y mejora la accesibilidad de los colores:
-
-En `foreground.contrastResult(with: background)`, el receptor es el primer plano.
-Un primer plano translúcido se compone sobre el fondo opaco; un fondo translúcido
-no está disponible. Invertir los argumentos puede cambiar el resultado.
-
-<!-- swift-example: budget -->
+<!-- swift-example: catalog -->
 ```swift
-// Verificar cumplimiento WCAG
-let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
-print(assessment.status)
+import ColorKit
 
-// Obtener candidatos dentro del límite con resultados explícitos y evidencia de medición
-let suggestions = textColor.suggestAccessibleVariantResults(
-    with: backgroundColor,
-    targetLevel: .AA,
-    maxPerceptualDistance: 30
-)
+struct ContentView: View {
+    var body: some View {
+        MainCatalogView()
+    }
+}
 ```
 
-Las APIs de mejora que devuelven resultados aplican un límite inclusivo CIEDE2000
-Delta E 00 respecto al primer plano original (finito, en `0...100`, predeterminado: `30`).
-Si ningún candidato examinado alcanza el objetivo, devuelven el mejor esfuerzo dentro
-del límite, o un resultado explícito `invalidConfiguration` o `unavailable`.
-Las mejoras heredadas que devuelven solo colores ignoran el límite y no garantizan el objetivo.
-Consulta la [guía de migración de mejoras](../MIGRATION.md#enhancement-distance-budgets).
+O integra una vista previa individual:
 
-Consulta la [Documentación de depuración de colores](../Sources/ColorKit/Utilities/DOCUMENTATION.md) para más detalles.
+<!-- swift-example: previews -->
+```swift
+// Usar vistas previas individuales
+ColorSpacePreview()
+BlendingPreview()
+GradientPreview()
+ThemePreview()
+PerformanceBenchmark()
+ColorDebuggerPreview()
+PaletteStudioPreview()
+ColorAnimationPreview()
+AccessibilityLabPreview()
+```
 
----
+## Más recetas
+
+- [Temas y colores adaptables](../Sources/ColorKit/Documentation.docc/Theming-article.md)
+- [Exportar y compartir paletas](../Sources/ColorKit/Utilities/PaletteExporter.md)
+- [Fusión y gradientes](../Sources/ColorKit/Documentation.docc/Utilities-article.md#gradient-generation)
+- [Herramientas de inspección](../Sources/ColorKit/Utilities/DOCUMENTATION.md)
+- [Rendimiento y caché](../PERFORMANCE_IMPROVEMENTS.md)
+- [Migración y compatibilidad](../MIGRATION.md)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,0 +1,449 @@
+# ColorKit usage
+
+[Back to README](../README.md) · [Español](Usage.es-ES.md)
+
+## **🎨 Usage**  
+
+### Component conversion results
+
+Use `componentConversionResults()` when availability matters. Each field reports its
+own value or issue, so a failed Hex conversion does not discard available LAB.
+
+<!-- swift-example: component-results -->
+```swift
+let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
+if case .success(let lab) = conversions.lab {
+    print(lab.lightness, lab.a, lab.b)
+}
+switch conversions.hex {
+case .success(let hex): print(hex)
+case .failure(let issue): print("Hex unavailable:", issue)
+}
+```
+
+All seven fields describe one fixed, uncomposited color: `srgba`, `hsl`, `hsb`,
+`cmyk`, `xyz`, `lab`, and `hex`. Named or dynamic colors without fixed components
+must be resolved explicitly by the caller. Extended sRGBA and finite D65 XYZ/LAB
+are preserved; HSL, HSB, CMYK, and Hex reject RGB outside `0...1` without clipping
+or endpoint tolerance. Alpha is retained in sRGBA and eight-digit `#RRGGBBAA` Hex;
+other coordinates omit it. Hues are turns, HSL/HSB/CMYK fractions are `0...1`, and
+XYZ uses reference-white Y = 100. CMYK is an algebraic approximation, not a printer
+profile. Existing APIs remain unchanged and are not deprecated. See the
+[conversion contract](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
+and [adoption notes](../MIGRATION.md#component-conversion-results).
+
+### **1️⃣ HEX <-> RGB Conversion**  
+```swift
+let color = Color(hex: "#FF5733")
+print(color.hexValue()) // "#FF5733FF"
+```
+
+### **2️⃣ HSL Conversion**  
+<!-- swift-example: hsl -->
+```swift
+let hsl = Color.red.hslComponents()
+let customColor = Color(hue: 0.5, saturation: 1.0, lightness: 0.5)
+```
+
+`hslComponents()` resolves named and dynamic colors for the current appearance.
+It converts to sRGB and clamps wider-gamut channels to `0...1` before conversion;
+opacity is not part of HSL. It returns `nil` when resolution fails, such as for a
+pattern color. Unlike HSL, CMYK and LAB require fixed colors and do not choose an
+appearance. See [HSL migration guidance](../MIGRATION.md#hsl-resolution).
+
+### **3️⃣ CMYK Conversion**  
+<!-- swift-example: cmyk -->
+```swift
+// Convert from RGB to CMYK
+let red = Color(.sRGB, red: 1, green: 0, blue: 0)
+let cmyk = red.cmykComponents()
+// (cyan: 0.0, magenta: 1.0, yellow: 1.0, key: 0.0)
+
+// Create color from CMYK values
+let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
+```
+
+### **4️⃣ LAB Conversion**  
+<!-- swift-example: lab -->
+```swift
+// Resolve a fixed color and convert it to LAB
+let red = Color(.sRGB, red: 1, green: 0, blue: 0)
+let lab = red.labComponents()
+if let lab {
+    print(lab) // (L: 53.24, a: 80.09, b: 67.20)
+}
+
+// Create color from LAB values
+let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
+```
+
+`labComponents()` resolves fixed RGB and grayscale colors—including linear RGB and
+Display P3—to nonlinear sRGB before conversion. Finite out-of-gamut channels are
+preserved without clipping. The method returns `nil` for colors it cannot resolve,
+such as unresolved dynamic colors; alpha does not affect the LAB coordinates.
+
+### **5️⃣ Adaptive Colors (Light/Dark Mode)**  
+```swift
+Text("Adaptive Text")
+    .adaptiveColor(light: .blue, dark: .orange)
+```
+
+### **6️⃣ Ensuring High Contrast**  
+```swift
+Text("Accessible Text")
+    .highContrastColor(base: .gray, background: .white)
+```
+
+### **7️⃣ Detecting Theme Changes**  
+```swift
+Text("Theme Change")
+    .onAdaptiveColorChange { newScheme in
+        print("Color scheme changed to: \(newScheme)")
+    }
+```
+
+### **8️⃣ Gradient Generation Utilities**  
+```swift
+let gradient = Gradient(colors: [.red, .blue])
+let linearGradient = LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom)
+```
+
+### **9️⃣ Color Blending Modes**  
+```swift
+let baseColor = Color.red
+let blendColor = Color.blue
+let blendedColor = baseColor.blended(with: blendColor, mode: .overlay)
+```
+
+### **🔟 Comprehensive Theming System**  
+```swift
+// Define a custom theme
+let oceanTheme = ColorTheme(
+    name: "Ocean",
+    primary: Color(hex: "#1E88E5"),
+    secondary: Color(hex: "#00ACC1"),
+    accent: Color(hex: "#7E57C2"),
+    background: Color(hex: "#ECEFF1"),
+    text: Color(hex: "#263238")
+)
+
+// Register the theme
+ThemeManager.shared.register(theme: oceanTheme)
+
+// Apply theme to a view hierarchy
+ContentView()
+    .withThemeManager()
+
+// Use themed colors in views
+Text("Themed Text")
+    .themedText(.primary)
+
+Button("Primary Button") {}
+    .themedButton(.primary)
+
+// Use semantic colors
+Rectangle()
+    .fill(Color.themed(.accent))
+```
+
+### **1️⃣1️⃣ Auto-Generate Accessible Color Palettes**  
+<!-- swift-example: accessible-palette -->
+```swift
+let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let generator = AccessiblePaletteGenerator(configuration: .init(targetLevel: .AA))
+let results = generator.generateAssessedPalette(from: seedColor, against: backgroundColor)
+for result in results {
+    if result.meetsTarget {
+        Text("WCAG AA").foregroundColor(result.color).background(backgroundColor)
+    } else {
+        print(result.status)
+    }
+}
+
+let textResult = backgroundColor.accessibleContrastingColorResult(for: .AA)
+let textColor = textResult.color
+
+switch textResult.status {
+case .meetsTarget:
+    if let ratio = textResult.contrastRatio {
+        print("Contrast: \(ratio):1")
+    }
+case .bestEffort:
+    print("Best available endpoint is below the requested target")
+case .unavailable:
+    print("Resolve the colors in an explicit appearance before assessment")
+case .invalidConfiguration:
+    print("Supply a finite perceptual-distance budget from 0 through 100")
+}
+
+// Use the demo view to experiment with palette generation
+struct ContentView: View {
+    var body: some View {
+        ColorKit.ColorInspector.accessiblePaletteDemoView()
+    }
+}
+```
+
+For new callers, check `meetsTarget` or `status` before using a candidate.
+Assessed palettes retain every outcome; they impose no enhancement budget and do
+not certify contrast between entries. Legacy palettes return candidates; themes
+only establish a black-and-white text/background pair.
+`accessibleContrastingColor(for:)` and `suggestedColor(for:)` ignore the requested
+level, use different heuristics, and do not guarantee that level.
+
+Run the standalone macOS [contrast pair report](../Examples/ContrastPairReport/README.md)
+to assess foreground/background pairs against explicit per-pair WCAG targets.
+
+### **1️⃣2️⃣ Export & Share Color Palettes**  
+```swift
+// Create a palette from colors
+let colors: [Color] = [.red, .green, .blue]
+let palette = PaletteExporter.createPalette(from: colors)
+
+// Create a palette from a theme
+let theme = ThemeManager.shared.currentTheme
+let themePalette = PaletteExporter.createPalette(from: theme)
+
+// Export to various formats
+if let jsonData = PaletteExporter.export(
+    palette: palette,
+    to: .json,
+    paletteName: "My Palette"
+) {
+    // Use the data (save to file, share, etc.)
+}
+
+// Copy to clipboard
+PaletteExporter.copyToClipboard(
+    palette: palette,
+    format: .css,
+    paletteName: "My Palette"
+)
+
+// Export accessible palette
+let accessiblePaletteData = seedColor.exportAccessiblePalette(
+    targetLevel: .AA,
+    to: .svg,
+    paletteName: "Accessible Palette"
+)
+
+// Add export functionality to any view
+myView.paletteExport(colors: colors, paletteName: "RGB Palette")
+myView.paletteExport(theme: theme)
+
+// Use the export UI directly
+PaletteExportView(palette: palette, paletteName: "My Palette")
+```
+
+### **1️⃣3️⃣ Performance Optimizations (v1.4.0+)**  
+```swift
+// ColorKit automatically caches expensive color operations
+// No code changes required to benefit from performance improvements
+
+// First call calculates and caches
+let lab1 = color1.labComponents()
+
+// Second call retrieves from cache (much faster)
+let lab1Again = color1.labComponents()
+
+// Blending with caching
+let blended = color1.blended(with: color2, mode: .overlay, amount: 0.5)
+
+// Gradient interpolation with caching
+let interpolated = color1.interpolated(with: color2, amount: 0.5, in: .lab)
+
+// Get cached contrast ratio
+if let ratio = ColorCache.shared.getCachedContrastRatio(for: color1, with: color2) {
+    print("Cached contrast ratio: \(ratio)")
+}
+
+// Cache a contrast ratio
+ColorCache.shared.cacheContrastRatio(for: color1, with: color2, ratio: 4.5)
+
+// If needed, manually clear caches
+ColorCache.shared.clearCache()
+```
+
+For more details on performance improvements, see [PERFORMANCE_IMPROVEMENTS.md](../PERFORMANCE_IMPROVEMENTS.md).
+
+### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
+<!-- swift-example: enhancement -->
+```swift
+// Generate a candidate within a distance budget, then inspect its outcome
+let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let targetLevel = WCAGContrastLevel.AA
+
+let result = originalColor.enhancementResult(
+    with: backgroundColor,
+    targetLevel: targetLevel
+)
+let enhancedColor = result.color
+
+if result.meetsTarget {
+    if let ratio = result.contrastRatio {
+        print("Measured contrast: \(ratio):1")
+    }
+}
+```
+
+### **1️⃣5️⃣ Preview Catalog**
+The Preview Catalog provides interactive demonstrations of ColorKit's features:
+
+<!-- swift-example: catalog -->
+```swift
+import ColorKit
+
+struct ContentView: View {
+    var body: some View {
+        MainCatalogView()
+    }
+}
+```
+
+Available previews:
+
+1. **BlendingPreview**
+   - Interactive color blending with all blend modes
+   - Real-time blend amount control
+   - Performance metrics
+
+2. **GradientPreview**
+   - Linear, radial, and angular gradient creation
+   - Color stop management
+   - Code generation
+
+3. **ThemePreview**
+   - Light/dark mode testing
+   - UI component showcase
+   - Theme code generation
+
+4. **PerformanceBenchmark**
+   - Operation benchmarking
+   - Caching metrics
+   - Iteration control
+
+5. **ColorDebuggerPreview**
+   - Color space visualization
+   - Component analysis
+   - Visual comparison tools
+   - Performance monitoring
+
+6. **PaletteStudioPreview**
+   - Palette generation
+   - Export functionality
+   - Harmony rules
+   - Theme generation
+
+7. **ColorAnimationPreview**
+   - Color transition testing
+   - Interpolation modes
+   - Timing curves
+   - Performance metrics
+
+8. **AccessibilityLabPreview**
+   - WCAG contrast checking
+   - Color enhancement strategies
+   - Accessible color suggestions
+   - Educational guidelines
+
+Each preview is designed to help developers understand and utilize ColorKit's features effectively. Access them through the `MainCatalogView` or individually:
+
+<!-- swift-example: previews -->
+```swift
+// Use individual previews
+ColorSpacePreview()
+BlendingPreview()
+GradientPreview()
+ThemePreview()
+PerformanceBenchmark()
+ColorDebuggerPreview()
+PaletteStudioPreview()
+ColorAnimationPreview()
+AccessibilityLabPreview()
+```
+
+## **🎨 Debugging Tools**  
+
+ColorKit now includes advanced debugging tools to help developers inspect colors, validate accessibility compliance, and ensure correct implementation. These tools include:
+
+### **Color Inspection**  
+
+Inspect colors in multiple color spaces (RGB, HSL, HSB, CMYK, LAB, XYZ):
+
+```swift
+// Get color components in all color spaces
+let components = myColor.colorSpaceComponents()
+print(components.description)
+
+// Display visual color inspector in SwiftUI
+ColorSpaceInspectorView(color: myColor)
+```
+
+`rgbaComponents()` resolves the current appearance: UIKit preserves extended sRGB;
+AppKit converts to bounded sRGB. Failure returns `(0, 0, 0, 0)`, indistinguishable
+from transparent black. Aggregate components inherit that policy, substitute zeros
+for failed HSL/CMYK, extract HSB without a success flag, and derive LAB/XYZ from RGB
+even on failure. Use optional conversions when availability matters.
+
+### **Color Comparison**  
+
+Compare fixed, opaque, in-gamut sRGB colors using component differences, WCAG metrics, and CIEDE2000:
+
+<!-- swift-example: comparison -->
+```swift
+let color1 = Color(.sRGB, red: 0.15, green: 0.35, blue: 0.75, opacity: 1)
+let color2 = Color(.sRGB, red: 0.55, green: 0.25, blue: 0.65, opacity: 1)
+
+switch color1.comparisonResult(with: color2) {
+case .available(let difference):
+    print("CIEDE2000 difference: \(difference.perceptualDifference)")
+case .unavailable(let issues):
+    print("Comparison unavailable: \(issues)")
+}
+
+// Visual comparison view
+ColorComparisonView(color1: color1, color2: color2)
+```
+
+Dynamic, translucent, nonfinite, and out-of-sRGB inputs return explicit issues instead of fabricated measurements.
+
+`isPerceptuallySimilar(to:threshold:)` uses CIE76 in D65 LAB and `distance < threshold`
+without validating the threshold. Equality or unavailable LAB returns `false`.
+It ignores alpha without compositing and accepts extended sRGB when LAB is available.
+CIEDE2000 requires opaque, in-gamut inputs; thresholds are not interchangeable.
+
+### **WCAG Accessibility Debugging**  
+
+Validate and improve color accessibility:
+
+In `foreground.contrastResult(with: background)`, the receiver is the foreground.
+A translucent foreground composites over the opaque background; a translucent
+background is unavailable. Reversing the arguments can change the result.
+
+<!-- swift-example: budget -->
+```swift
+// Check WCAG compliance
+let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
+print(assessment.status)
+
+// Get budgeted candidates with explicit outcomes and measurement evidence
+let suggestions = textColor.suggestAccessibleVariantResults(
+    with: backgroundColor,
+    targetLevel: .AA,
+    maxPerceptualDistance: 30
+)
+```
+
+Result-bearing enhancement enforces an inclusive CIEDE2000 Delta E 00 budget
+from the original foreground (finite `0...100`, default `30`). It returns in-budget
+best effort when no examined candidate passes, or an explicit `invalidConfiguration`
+or `unavailable` outcome. Legacy color-returning enhancement ignores the budget and does not guarantee the target.
+See [enhancement migration guidance](../MIGRATION.md#enhancement-distance-budgets).
+
+See [Color Debugging Documentation](../Sources/ColorKit/Utilities/DOCUMENTATION.md) for more details.
+
+---

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,13 +1,12 @@
-# ColorKit usage
+# ColorKit recipes
 
 [Back to README](../README.md) · [Español](Usage.es-ES.md)
 
-## **🎨 Usage**  
+Focused examples using existing public APIs. Import `SwiftUI` and `ColorKit` in your client. Detailed contracts live in the linked guides.
 
-### Component conversion results
+## Convert colors
 
-Use `componentConversionResults()` when availability matters. Each field reports its
-own value or issue, so a failed Hex conversion does not discard available LAB.
+Use per-representation results when availability matters. Supply a fixed color; capture the intended appearance explicitly for dynamic colors. One unavailable representation does not discard successful conversions.
 
 <!-- swift-example: component-results -->
 ```swift
@@ -21,37 +20,20 @@ case .failure(let issue): print("Hex unavailable:", issue)
 }
 ```
 
-All seven fields describe one fixed, uncomposited color: `srgba`, `hsl`, `hsb`,
-`cmyk`, `xyz`, `lab`, and `hex`. Named or dynamic colors without fixed components
-must be resolved explicitly by the caller. Extended sRGBA and finite D65 XYZ/LAB
-are preserved; HSL, HSB, CMYK, and Hex reject RGB outside `0...1` without clipping
-or endpoint tolerance. Alpha is retained in sRGBA and eight-digit `#RRGGBBAA` Hex;
-other coordinates omit it. Hues are turns, HSL/HSB/CMYK fractions are `0...1`, and
-XYZ uses reference-white Y = 100. CMYK is an algebraic approximation, not a printer
-profile. Existing APIs remain unchanged and are not deprecated. See the
-[conversion contract](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results)
-and [adoption notes](../MIGRATION.md#component-conversion-results).
+See [component contracts](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results) for gamut, alpha, units, and failure rules.
 
-### **1️⃣ HEX <-> RGB Conversion**  
-```swift
-let color = Color(hex: "#FF5733")
-print(color.hexValue()) // "#FF5733FF"
-```
+### HSL
 
-### **2️⃣ HSL Conversion**  
+The legacy HSL accessor resolves the current appearance and clips to sRGB. It returns `nil` if resolution fails.
+
 <!-- swift-example: hsl -->
 ```swift
 let hsl = Color.red.hslComponents()
 let customColor = Color(hue: 0.5, saturation: 1.0, lightness: 0.5)
 ```
 
-`hslComponents()` resolves named and dynamic colors for the current appearance.
-It converts to sRGB and clamps wider-gamut channels to `0...1` before conversion;
-opacity is not part of HSL. It returns `nil` when resolution fails, such as for a
-pattern color. Unlike HSL, CMYK and LAB require fixed colors and do not choose an
-appearance. See [HSL migration guidance](../MIGRATION.md#hsl-resolution).
+### CMYK
 
-### **3️⃣ CMYK Conversion**  
 <!-- swift-example: cmyk -->
 ```swift
 // Convert from RGB to CMYK
@@ -63,7 +45,8 @@ let cmyk = red.cmykComponents()
 let printColor = Color(cyan: 0.2, magenta: 0.8, yellow: 0.1, key: 0.1)
 ```
 
-### **4️⃣ LAB Conversion**  
+### LAB
+
 <!-- swift-example: lab -->
 ```swift
 // Resolve a fixed color and convert it to LAB
@@ -77,76 +60,54 @@ if let lab {
 let labColor = Color(L: 50.0, a: 25.0, b: -30.0)
 ```
 
-`labComponents()` resolves fixed RGB and grayscale colors—including linear RGB and
-Display P3—to nonlinear sRGB before conversion. Finite out-of-gamut channels are
-preserved without clipping. The method returns `nil` for colors it cannot resolve,
-such as unresolved dynamic colors; alpha does not affect the LAB coordinates.
+CMYK and LAB accessors require fixed colors; they do not choose an appearance. See [color spaces](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md) for their distinct conversion policies and Hex support.
 
-### **5️⃣ Adaptive Colors (Light/Dark Mode)**  
-```swift
-Text("Adaptive Text")
-    .adaptiveColor(light: .blue, dark: .orange)
-```
+## Assess and adjust contrast
 
-### **6️⃣ Ensuring High Contrast**  
-```swift
-Text("Accessible Text")
-    .highContrastColor(base: .gray, background: .white)
-```
+The receiver is the foreground. Translucent foregrounds composite over opaque backgrounds; translucent backgrounds are unavailable. A measured pass does not certify whole-app accessibility.
 
-### **7️⃣ Detecting Theme Changes**  
+<!-- swift-example: budget -->
 ```swift
-Text("Theme Change")
-    .onAdaptiveColorChange { newScheme in
-        print("Color scheme changed to: \(newScheme)")
-    }
-```
+// Check WCAG compliance
+let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
+print(assessment.status)
 
-### **8️⃣ Gradient Generation Utilities**  
-```swift
-let gradient = Gradient(colors: [.red, .blue])
-let linearGradient = LinearGradient(gradient: gradient, startPoint: .top, endPoint: .bottom)
-```
-
-### **9️⃣ Color Blending Modes**  
-```swift
-let baseColor = Color.red
-let blendColor = Color.blue
-let blendedColor = baseColor.blended(with: blendColor, mode: .overlay)
-```
-
-### **🔟 Comprehensive Theming System**  
-```swift
-// Define a custom theme
-let oceanTheme = ColorTheme(
-    name: "Ocean",
-    primary: Color(hex: "#1E88E5"),
-    secondary: Color(hex: "#00ACC1"),
-    accent: Color(hex: "#7E57C2"),
-    background: Color(hex: "#ECEFF1"),
-    text: Color(hex: "#263238")
+// Get budgeted candidates with explicit outcomes and measurement evidence
+let suggestions = textColor.suggestAccessibleVariantResults(
+    with: backgroundColor,
+    targetLevel: .AA,
+    maxPerceptualDistance: 30
 )
-
-// Register the theme
-ThemeManager.shared.register(theme: oceanTheme)
-
-// Apply theme to a view hierarchy
-ContentView()
-    .withThemeManager()
-
-// Use themed colors in views
-Text("Themed Text")
-    .themedText(.primary)
-
-Button("Primary Button") {}
-    .themedButton(.primary)
-
-// Use semantic colors
-Rectangle()
-    .fill(Color.themed(.accent))
 ```
 
-### **1️⃣1️⃣ Auto-Generate Accessible Color Palettes**  
+### Generate an adjusted candidate
+
+<!-- swift-example: enhancement -->
+```swift
+// Generate a candidate within a distance budget, then inspect its outcome
+let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
+let targetLevel = WCAGContrastLevel.AA
+
+let result = originalColor.enhancementResult(
+    with: backgroundColor,
+    targetLevel: targetLevel
+)
+let enhancedColor = result.color
+
+if result.meetsTarget {
+    if let ratio = result.contrastRatio {
+        print("Measured contrast: \(ratio):1")
+    }
+}
+```
+
+Inspect the outcome before using a candidate. The distance budget can prevent reaching the target. Legacy color-returning enhancement ignores that budget. See [enhancement contracts](../Sources/ColorKit/Documentation.docc/Accessibility-article.md#verifiable-results).
+
+### Assess a generated palette
+
 <!-- swift-example: accessible-palette -->
 ```swift
 let seedColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
@@ -185,211 +146,13 @@ struct ContentView: View {
 }
 ```
 
-For new callers, check `meetsTarget` or `status` before using a candidate.
-Assessed palettes retain every outcome; they impose no enhancement budget and do
-not certify contrast between entries. Legacy palettes return candidates; themes
-only establish a black-and-white text/background pair.
-`accessibleContrastingColor(for:)` and `suggestedColor(for:)` ignore the requested
-level, use different heuristics, and do not guarantee that level.
+Assessments retain every outcome and do not certify contrast between palette entries. See [assessed palettes](../Sources/ColorKit/Documentation.docc/Accessibility-article.md#assessed-palettes) for guarantees and legacy differences.
 
-Run the standalone macOS [contrast pair report](../Examples/ContrastPairReport/README.md)
-to assess foreground/background pairs against explicit per-pair WCAG targets.
+To assess your own explicit pairs, run the standalone macOS [contrast pair report](../Examples/ContrastPairReport/README.md).
 
-### **1️⃣2️⃣ Export & Share Color Palettes**  
-```swift
-// Create a palette from colors
-let colors: [Color] = [.red, .green, .blue]
-let palette = PaletteExporter.createPalette(from: colors)
+## Compare colors
 
-// Create a palette from a theme
-let theme = ThemeManager.shared.currentTheme
-let themePalette = PaletteExporter.createPalette(from: theme)
-
-// Export to various formats
-if let jsonData = PaletteExporter.export(
-    palette: palette,
-    to: .json,
-    paletteName: "My Palette"
-) {
-    // Use the data (save to file, share, etc.)
-}
-
-// Copy to clipboard
-PaletteExporter.copyToClipboard(
-    palette: palette,
-    format: .css,
-    paletteName: "My Palette"
-)
-
-// Export accessible palette
-let accessiblePaletteData = seedColor.exportAccessiblePalette(
-    targetLevel: .AA,
-    to: .svg,
-    paletteName: "Accessible Palette"
-)
-
-// Add export functionality to any view
-myView.paletteExport(colors: colors, paletteName: "RGB Palette")
-myView.paletteExport(theme: theme)
-
-// Use the export UI directly
-PaletteExportView(palette: palette, paletteName: "My Palette")
-```
-
-### **1️⃣3️⃣ Performance Optimizations (v1.4.0+)**  
-```swift
-// ColorKit automatically caches expensive color operations
-// No code changes required to benefit from performance improvements
-
-// First call calculates and caches
-let lab1 = color1.labComponents()
-
-// Second call retrieves from cache (much faster)
-let lab1Again = color1.labComponents()
-
-// Blending with caching
-let blended = color1.blended(with: color2, mode: .overlay, amount: 0.5)
-
-// Gradient interpolation with caching
-let interpolated = color1.interpolated(with: color2, amount: 0.5, in: .lab)
-
-// Get cached contrast ratio
-if let ratio = ColorCache.shared.getCachedContrastRatio(for: color1, with: color2) {
-    print("Cached contrast ratio: \(ratio)")
-}
-
-// Cache a contrast ratio
-ColorCache.shared.cacheContrastRatio(for: color1, with: color2, ratio: 4.5)
-
-// If needed, manually clear caches
-ColorCache.shared.clearCache()
-```
-
-For more details on performance improvements, see [PERFORMANCE_IMPROVEMENTS.md](../PERFORMANCE_IMPROVEMENTS.md).
-
-### **1️⃣4️⃣ AccessibilityEnhancer (v1.5.0+)**  
-<!-- swift-example: enhancement -->
-```swift
-// Generate a candidate within a distance budget, then inspect its outcome
-let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let targetLevel = WCAGContrastLevel.AA
-
-let result = originalColor.enhancementResult(
-    with: backgroundColor,
-    targetLevel: targetLevel
-)
-let enhancedColor = result.color
-
-if result.meetsTarget {
-    if let ratio = result.contrastRatio {
-        print("Measured contrast: \(ratio):1")
-    }
-}
-```
-
-### **1️⃣5️⃣ Preview Catalog**
-The Preview Catalog provides interactive demonstrations of ColorKit's features:
-
-<!-- swift-example: catalog -->
-```swift
-import ColorKit
-
-struct ContentView: View {
-    var body: some View {
-        MainCatalogView()
-    }
-}
-```
-
-Available previews:
-
-1. **BlendingPreview**
-   - Interactive color blending with all blend modes
-   - Real-time blend amount control
-   - Performance metrics
-
-2. **GradientPreview**
-   - Linear, radial, and angular gradient creation
-   - Color stop management
-   - Code generation
-
-3. **ThemePreview**
-   - Light/dark mode testing
-   - UI component showcase
-   - Theme code generation
-
-4. **PerformanceBenchmark**
-   - Operation benchmarking
-   - Caching metrics
-   - Iteration control
-
-5. **ColorDebuggerPreview**
-   - Color space visualization
-   - Component analysis
-   - Visual comparison tools
-   - Performance monitoring
-
-6. **PaletteStudioPreview**
-   - Palette generation
-   - Export functionality
-   - Harmony rules
-   - Theme generation
-
-7. **ColorAnimationPreview**
-   - Color transition testing
-   - Interpolation modes
-   - Timing curves
-   - Performance metrics
-
-8. **AccessibilityLabPreview**
-   - WCAG contrast checking
-   - Color enhancement strategies
-   - Accessible color suggestions
-   - Educational guidelines
-
-Each preview is designed to help developers understand and utilize ColorKit's features effectively. Access them through the `MainCatalogView` or individually:
-
-<!-- swift-example: previews -->
-```swift
-// Use individual previews
-ColorSpacePreview()
-BlendingPreview()
-GradientPreview()
-ThemePreview()
-PerformanceBenchmark()
-ColorDebuggerPreview()
-PaletteStudioPreview()
-ColorAnimationPreview()
-AccessibilityLabPreview()
-```
-
-## **🎨 Debugging Tools**  
-
-ColorKit now includes advanced debugging tools to help developers inspect colors, validate accessibility compliance, and ensure correct implementation. These tools include:
-
-### **Color Inspection**  
-
-Inspect colors in multiple color spaces (RGB, HSL, HSB, CMYK, LAB, XYZ):
-
-```swift
-// Get color components in all color spaces
-let components = myColor.colorSpaceComponents()
-print(components.description)
-
-// Display visual color inspector in SwiftUI
-ColorSpaceInspectorView(color: myColor)
-```
-
-`rgbaComponents()` resolves the current appearance: UIKit preserves extended sRGB;
-AppKit converts to bounded sRGB. Failure returns `(0, 0, 0, 0)`, indistinguishable
-from transparent black. Aggregate components inherit that policy, substitute zeros
-for failed HSL/CMYK, extract HSB without a success flag, and derive LAB/XYZ from RGB
-even on failure. Use optional conversions when availability matters.
-
-### **Color Comparison**  
-
-Compare fixed, opaque, in-gamut sRGB colors using component differences, WCAG metrics, and CIEDE2000:
+CIEDE2000 comparison requires fixed, opaque, in-gamut sRGB inputs. Unavailable measurements remain explicit.
 
 <!-- swift-example: comparison -->
 ```swift
@@ -407,43 +170,44 @@ case .unavailable(let issues):
 ColorComparisonView(color1: color1, color2: color2)
 ```
 
-Dynamic, translucent, nonfinite, and out-of-sRGB inputs return explicit issues instead of fabricated measurements.
+The legacy similarity predicate uses CIE76, not CIEDE2000; thresholds are not interchangeable. See [comparison contracts](../Sources/ColorKit/Documentation.docc/Utilities-article.md).
 
-`isPerceptuallySimilar(to:threshold:)` uses CIE76 in D65 LAB and `distance < threshold`
-without validating the threshold. Equality or unavailable LAB returns `false`.
-It ignores alpha without compositing and accepts extended sRGB when LAB is available.
-CIEDE2000 requires opaque, in-gamut inputs; thresholds are not interchangeable.
+## Explore the catalog
 
-### **WCAG Accessibility Debugging**  
+The catalog demonstrates blending, gradients, themes, palettes, inspection, animation, and accessibility. Embed it in a SwiftUI host:
 
-Validate and improve color accessibility:
-
-In `foreground.contrastResult(with: background)`, the receiver is the foreground.
-A translucent foreground composites over the opaque background; a translucent
-background is unavailable. Reversing the arguments can change the result.
-
-<!-- swift-example: budget -->
+<!-- swift-example: catalog -->
 ```swift
-// Check WCAG compliance
-let textColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
-let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
-let assessment = textColor.accessibilityResult(against: backgroundColor, targetLevel: .AA)
-print(assessment.status)
+import ColorKit
 
-// Get budgeted candidates with explicit outcomes and measurement evidence
-let suggestions = textColor.suggestAccessibleVariantResults(
-    with: backgroundColor,
-    targetLevel: .AA,
-    maxPerceptualDistance: 30
-)
+struct ContentView: View {
+    var body: some View {
+        MainCatalogView()
+    }
+}
 ```
 
-Result-bearing enhancement enforces an inclusive CIEDE2000 Delta E 00 budget
-from the original foreground (finite `0...100`, default `30`). It returns in-budget
-best effort when no examined candidate passes, or an explicit `invalidConfiguration`
-or `unavailable` outcome. Legacy color-returning enhancement ignores the budget and does not guarantee the target.
-See [enhancement migration guidance](../MIGRATION.md#enhancement-distance-budgets).
+Or embed an individual preview:
 
-See [Color Debugging Documentation](../Sources/ColorKit/Utilities/DOCUMENTATION.md) for more details.
+<!-- swift-example: previews -->
+```swift
+// Use individual previews
+ColorSpacePreview()
+BlendingPreview()
+GradientPreview()
+ThemePreview()
+PerformanceBenchmark()
+ColorDebuggerPreview()
+PaletteStudioPreview()
+ColorAnimationPreview()
+AccessibilityLabPreview()
+```
 
----
+## More recipes
+
+- [Themes and adaptive colors](../Sources/ColorKit/Documentation.docc/Theming-article.md)
+- [Palette export and sharing](../Sources/ColorKit/Utilities/PaletteExporter.md)
+- [Blending and gradients](../Sources/ColorKit/Documentation.docc/Utilities-article.md#gradient-generation)
+- [Inspection tools](../Sources/ColorKit/Utilities/DOCUMENTATION.md)
+- [Performance and caching](../PERFORMANCE_IMPROVEMENTS.md)
+- [Migration and compatibility](../MIGRATION.md)

--- a/docs/design/contrast-pair-assessment.md
+++ b/docs/design/contrast-pair-assessment.md
@@ -1,0 +1,93 @@
+# Contrast pair assessment — design discussion
+
+Status: delivered in PRs #66, #67, and #68. Existing public APIs were sufficient;
+no library API or version change was needed.
+
+## Agreed scope
+
+- Assess explicitly supplied foreground/background pairs, not every palette combination.
+- Preserve the supplied order and identify each assessed pair.
+- Report measured passes, below-target measurements, and unavailable measurements independently.
+- Do not modify colors automatically or claim whole-app accessibility compliance.
+- Start with a practical example using existing APIs; add a public abstraction only if the example demonstrates a useful need.
+- Preserve shipped 3.x contracts. Protect newly shipped 3.1 clients as part of the first implementation work, without a separate release ceremony.
+
+## Delivery outcome
+
+- PR #66 preserved the released 3.1 client alongside the existing 3.0 baseline.
+- PR #67 added the standalone macOS report and focused tests.
+- PR #68 added English/Spanish discovery links and an example test step in existing CI.
+- All three PRs are merged; the final PR's lint, documentation, and build/test checks passed.
+
+## Agreed: caller-owned appearance resolution
+
+Retain the existing strict contrast measurement contract. Callers explicitly capture
+appearance-dependent colors before supplying them; unresolved inputs remain unavailable.
+Light and dark appearances are separate caller-supplied pairs when both are relevant.
+The example may demonstrate capture, but assessment does not infer ambient appearance,
+automatically assess both appearances, or introduce a new appearance framework.
+
+## Agreed: explicit per-pair targets
+
+Each pair explicitly supplies an existing `WCAGContrastLevel`. Do not infer a target
+from its label, font size, or UI role. The first scope has no collection-wide default
+or custom numeric threshold. A passing result means the requested contrast target
+is met, not that the UI is accessible as a whole.
+
+## Agreed: labels do not establish identity
+
+Labels are display text and need not be unique. Preserve every supplied entry in
+input order, including duplicate labels and identical color pairs; do not merge,
+deduplicate, or reject them. The initial example owns any identity needed for its
+presentation in client code rather than introducing a public ID system.
+
+## Agreed: explicit summary counts
+
+Summarize entries with three separate counts: meets target, below target, and
+unavailable. Keep the individual results visible; do not produce an overall
+accessibility score or conflate unavailability with a measured shortfall.
+Empty input displays “No pairs assessed” rather than a successful assessment.
+
+## Agreed: visible per-pair evidence
+
+Measured rows show the label, foreground/background swatches, requested target,
+measured ratio, required ratio, and explicit outcome without requiring expansion.
+Unavailable rows show the label, target, and independent foreground/background
+explanations without an invented ratio. Classification uses the unrounded measured
+ratio; display rounding must never change the outcome.
+
+## Agreed: focused code-configured example
+
+Begin with a small report configured through client code, using representative
+pairs for passes, shortfalls, unavailable measurements, and duplicate labels,
+plus a separate empty-input case. Developers can replace the samples with their
+own inputs. Color pickers, persistence, export, and automatic fixes are out of
+scope for the initial milestone.
+
+## Agreed: no premature public abstraction
+
+Use existing public methods first. Consider a new public abstraction only if the
+example demonstrates reusable, nontrivial assessment logic—not presentation
+formatting or a simple loop. Any proposed API requires a separate contract review
+grounded in real client usage and preserving shipped 3.x behavior. If the example
+is sufficient, publish it as a recipe without forcing a 3.2 version bump.
+
+## Agreed: standalone example, not shipped library API
+
+Keep the runnable report in the repository but outside the ColorKit library
+target. Its views, sample inputs, and presentation helpers belong to the example;
+they are not new public ColorKit declarations. Developers can run and adapt the
+sample while the library continues to provide its existing measurement APIs.
+
+## Agreed: focused validation using existing tooling
+
+Cover measured passes, below-target measurements, unavailable results, duplicate
+labels, empty input, and threshold rounding with a small set of automated checks.
+Compile the actual runnable example and manually inspect its UI. Reuse existing
+tooling rather than introduce a new testing framework.
+
+## Delivery
+
+The example and compatibility work were delivered independently, followed by
+documentation and CI integration. Future public API additions require a separate
+demonstrated need and contract decision. This milestone does not require a release.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -14,8 +14,10 @@ DOCC = "Sources/ColorKit/Documentation.docc/"
 README_EXAMPLES = {"accessible-palette", "enhancement", "catalog", "previews", "comparison", "budget",
                    "hsl", "cmyk", "lab", "component-results"}
 EXAMPLES = {
-    "README.md": README_EXAMPLES,
-    "README.es-ES.md": README_EXAMPLES,
+    "README.md": {"contrast", "catalog"},
+    "README.es-ES.md": {"contrast", "catalog"},
+    "docs/Usage.md": README_EXAMPLES,
+    "docs/Usage.es-ES.md": README_EXAMPLES,
     DOCC + "Color-Spaces-article.md": {"rgb", "hsl", "lab", "component-results"},
     DOCC + "Theming-article.md": {"dynamic-theme"},
     DOCC + "Accessibility-article.md": {"contrast", "enhancement", "assessed-palette"},
@@ -24,7 +26,7 @@ EXAMPLES = {
     "MIGRATION.md": {"cvd", "enhancement-budget", "enhancement-references", "comparison"},
 }
 MARKER = re.compile(r"<!-- swift-example: ([a-z0-9-]+) -->")
-# Postconditions use the actual README variables, not copied example implementations.
+# Postconditions use the actual usage-guide variables, not copied implementations.
 # Renaming a variable requires updating its check; removing a result cannot pass silently.
 README_CHECKS = {
     "component-results": """
@@ -121,7 +123,7 @@ def check(derived_data):
             source = scratch / f"example_{index}.swift"
             source.write_text(example_source(path, index, line, code))
             files.append(source)
-            if path.name in ("README.md", "README.es-ES.md") and name in README_CHECKS:
+            if path.name in ("Usage.md", "Usage.es-ES.md") and name in README_CHECKS:
                 runtime = scratch / f"runtime_{index}.swift"
                 runtime.write_text(example_source(path, index, line, code, README_CHECKS[name]))
                 runtime_files.append(runtime)
@@ -144,7 +146,7 @@ def check(derived_data):
         run(*compiler, "-profile-generate", "-parse-as-library", "-I", modules, *runtime_files, entry,
             modules / "ColorKit.o", "-o", executable)
         run("env", f"LLVM_PROFILE_FILE={scratch / 'examples.profraw'}", executable)
-        print(f"Verified results of {len(runtime_files)} actual README conversion examples.", flush=True)
+        print(f"Verified results of {len(runtime_files)} actual usage-guide conversion examples.", flush=True)
         emitter = scratch / "emit-theme"
         run(*compiler, "-parse-as-library",
             ROOT / "Sources/ColorKit/PreviewCatalog/ThemeCodeGenerator.swift",

--- a/scripts/check_readme_parity.py
+++ b/scripts/check_readme_parity.py
@@ -27,8 +27,10 @@ def normalize_link(target):
 
 
 def normalize_swift(code):
-    code = re.sub(r"//.*$", "", code, flags=re.MULTILINE)
-    code = re.sub(r'"(?:\\.|[^"\\])*"', '"<translated-text>"', code)
+    # Match ordinary strings and line comments together so URL slashes inside a
+    # string cannot consume executable code following its closing quote.
+    code = re.sub(r'"(?:\\.|[^"\\])*"|//[^\n]*',
+                  lambda match: '"<translated-text>"' if match[0].startswith('"') else "", code)
     return re.sub(r"\s+", "", code)
 
 
@@ -61,8 +63,8 @@ def compare(english, spanish):
 
 
 def git_lines(*arguments):
-    result = subprocess.run(("git", *arguments), cwd=ROOT, text=True, capture_output=True)
-    return result.stdout.splitlines() if result.returncode == 0 else []
+    result = subprocess.run(("git", *arguments), cwd=ROOT, text=True, capture_output=True, check=True)
+    return result.stdout.splitlines()
 
 
 def changed_paths():
@@ -96,7 +98,13 @@ def check():
 
 
 def main():
-    results = check()
+    try:
+        results = check()
+    except (subprocess.CalledProcessError, OSError) as error:
+        detail = error.stderr if isinstance(error, subprocess.CalledProcessError) else str(error)
+        print(f"FAIL Git parity check unavailable: {(detail or str(error)).strip()}")
+        print("Ensure Git is available and origin/main and its merge-base history are fetched.")
+        return 1
     for english, spanish, issues in results:
         print(f"{'PASS' if not issues else 'FAIL'} {english} ↔ {spanish}")
         for issue in issues:

--- a/scripts/check_readme_parity.py
+++ b/scripts/check_readme_parity.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Check structural and changed-file parity for English/Spanish documentation."""
+
+from pathlib import Path
+import re
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAIRS = (
+    ("README.md", "README.es-ES.md"),
+    ("docs/Usage.md", "docs/Usage.es-ES.md"),
+)
+PATHS = tuple(path for pair in PAIRS for path in pair)
+
+
+def captures(text, pattern):
+    return re.findall(pattern, text, re.MULTILINE)
+
+
+def normalize_link(target):
+    if re.fullmatch(r"(?:\.\./)?README(?:\.es-ES)?\.md", target):
+        return "<counterpart-readme>"
+    if re.fullmatch(r"(?:docs/)?Usage(?:\.es-ES)?\.md", target):
+        return "<counterpart-usage>"
+    return target
+
+
+def normalize_swift(code):
+    code = re.sub(r"//.*$", "", code, flags=re.MULTILINE)
+    code = re.sub(r'"(?:\\.|[^"\\])*"', '"<translated-text>"', code)
+    return re.sub(r"\s+", "", code)
+
+
+def examples(text):
+    pattern = r"<!-- swift-example: ([a-z0-9-]+) -->\s*```swift\s*([\s\S]*?)```"
+    return dict(re.findall(pattern, text))
+
+
+def compare(english, spanish):
+    issues = []
+    if [len(value) for value in captures(english, r"^(#{1,6})\s+")] != [
+            len(value) for value in captures(spanish, r"^(#{1,6})\s+")]:
+        issues.append("heading hierarchy differs")
+    if captures(english, r"^```([^\n]*)$") != captures(spanish, r"^```([^\n]*)$"):
+        issues.append("code-fence count or language order differs")
+    link_pattern = r"(?:!?\[[^\]]*\])\(([^)]+)\)"
+    if [normalize_link(link) for link in captures(english, link_pattern)] != [
+            normalize_link(link) for link in captures(spanish, link_pattern)]:
+        issues.append("link/image destinations differ")
+
+    english_examples = examples(english)
+    spanish_examples = examples(spanish)
+    if list(english_examples) != list(spanish_examples):
+        issues.append("swift-example IDs or order differ")
+    else:
+        for name, code in english_examples.items():
+            if normalize_swift(code) != normalize_swift(spanish_examples[name]):
+                issues.append(f"swift-example '{name}' has different executable structure")
+    return issues
+
+
+def git_lines(*arguments):
+    result = subprocess.run(("git", *arguments), cwd=ROOT, text=True, capture_output=True)
+    return result.stdout.splitlines() if result.returncode == 0 else []
+
+
+def changed_paths():
+    changed = set(git_lines("diff", "--name-only", "origin/main...HEAD", "--", *PATHS))
+    for line in git_lines("status", "--porcelain", "--", *PATHS):
+        path = line[3:].strip().split(" -> ")[-1]
+        if path:
+            changed.add(path)
+    return changed
+
+
+def check():
+    changed = changed_paths()
+    results = []
+    for english_path, spanish_path in PAIRS:
+        english = ROOT / english_path
+        spanish = ROOT / spanish_path
+        if not english.exists() and not spanish.exists():
+            continue
+        issues = []
+        if not english.exists() or not spanish.exists():
+            issues.append(f"missing {english_path if not english.exists() else spanish_path}")
+        else:
+            issues.extend(compare(english.read_text(), spanish.read_text()))
+        if (english_path in changed) != (spanish_path in changed):
+            changed_path, stale_path = ((english_path, spanish_path) if english_path in changed
+                                       else (spanish_path, english_path))
+            issues.append(f"changed-file drift: {changed_path} changed without {stale_path}")
+        results.append((english_path, spanish_path, issues))
+    return results
+
+
+def main():
+    results = check()
+    for english, spanish, issues in results:
+        print(f"{'PASS' if not issues else 'FAIL'} {english} ↔ {spanish}")
+        for issue in issues:
+            print(f"  - {issue}")
+    if not results:
+        print("FAIL no English/Spanish documentation pair found")
+        return 1
+    if any(issues for _, _, issues in results):
+        print("Update both documents together and rerun this check.")
+        return 1
+    print("Structural parity passes; semantic translation still requires review.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_documentation.py
+++ b/scripts/tests/test_documentation.py
@@ -32,10 +32,18 @@ class DocumentationContract(unittest.TestCase):
             with self.subTest(text=text), self.assertRaises(ValueError):
                 self.extract(text)
 
-    def test_behavior_checks_are_required_in_both_readme_inventories(self):
+    def test_behavior_checks_are_required_in_both_usage_guide_inventories(self):
         self.assertEqual(set(DOCS.README_CHECKS), {"hsl", "cmyk", "lab", "component-results"})
-        for path in ("README.md", "README.es-ES.md"):
+        for path in ("docs/Usage.md", "docs/Usage.es-ES.md"):
             self.assertLessEqual(DOCS.README_CHECKS.keys(), DOCS.EXAMPLES[path])
+
+    def test_quick_starts_and_relocated_examples_remain_required(self):
+        for path in ("README.md", "README.es-ES.md"):
+            self.assertEqual(DOCS.EXAMPLES[path], {"contrast", "catalog"})
+        for path in ("docs/Usage.md", "docs/Usage.es-ES.md"):
+            self.assertEqual(DOCS.EXAMPLES[path], DOCS.README_EXAMPLES)
+        for path, expected in DOCS.EXAMPLES.items():
+            DOCS.extract_examples(DOCS.ROOT / path, expected)
 
     def test_runtime_checks_follow_the_unmodified_published_code(self):
         code = "let cmyk = Color.red.cmykComponents()"

--- a/scripts/tests/test_readme_parity.py
+++ b/scripts/tests/test_readme_parity.py
@@ -1,8 +1,12 @@
 """Tests for English/Spanish documentation parity."""
 
 import importlib.util
+import contextlib
+import io
 from pathlib import Path
+import subprocess
 import unittest
+from unittest.mock import patch
 
 
 SPEC = importlib.util.spec_from_file_location(
@@ -13,6 +17,45 @@ SPEC.loader.exec_module(PARITY)
 
 
 class ReadmeParityTests(unittest.TestCase):
+    def test_url_strings_do_not_hide_following_code(self):
+        def example(call):
+            return '<!-- swift-example: sample -->\n```swift\nlet url = "https://example.com"; ' + call + '\n```'
+        self.assertIn("swift-example 'sample' has different executable structure",
+                      PARITY.compare(example('oldAPI()'), example('newAPI()')))
+
+    def test_quotes_in_comments_do_not_hide_next_line(self):
+        first = '// "comment\noldAPI() // "\n'
+        second = '// "comentario\nnewAPI() // "\n'
+        self.assertNotEqual(PARITY.normalize_swift(first), PARITY.normalize_swift(second))
+
+    def test_git_failures_fail_the_command(self):
+        for failing_command in ('diff', 'status'):
+            def run(command, **kwargs):
+                if command[1] == failing_command:
+                    raise subprocess.CalledProcessError(128, command, stderr='missing Git history')
+                return subprocess.CompletedProcess(command, 0, stdout='', stderr='')
+            output = io.StringIO()
+            with self.subTest(command=failing_command), patch.object(PARITY.subprocess, 'run', side_effect=run), \
+                    contextlib.redirect_stdout(output):
+                self.assertEqual(PARITY.main(), 1)
+            self.assertIn('FAIL Git parity check unavailable', output.getvalue())
+            self.assertIn('missing Git history', output.getvalue())
+            self.assertNotIn('PASS', output.getvalue())
+
+    def test_git_command_requires_success(self):
+        with patch.object(PARITY.subprocess, 'run', return_value=subprocess.CompletedProcess(
+                ['git'], 0, stdout='README.md\n', stderr='')) as run:
+            self.assertEqual(PARITY.git_lines('diff'), ['README.md'])
+        self.assertTrue(run.call_args.kwargs['check'])
+
+    def test_committed_one_sided_changes_are_reported(self):
+        def run(command, **kwargs):
+            return subprocess.CompletedProcess(command, 0,
+                                               stdout='README.md\n' if command[1] == 'diff' else '', stderr='')
+        with patch.object(PARITY.subprocess, 'run', side_effect=run):
+            results = PARITY.check()
+        self.assertIn('changed-file drift: README.md changed without README.es-ES.md', results[0][2])
+
     def test_accepts_translated_prose_and_strings(self):
         english = '# Usage\n[Español](Usage.es-ES.md)\n<!-- swift-example: sample -->\n```swift\nprint("Hello") // greeting\n```'
         spanish = '# Uso\n[English](Usage.md)\n<!-- swift-example: sample -->\n```swift\nprint("Hola") // saludo\n```'

--- a/scripts/tests/test_readme_parity.py
+++ b/scripts/tests/test_readme_parity.py
@@ -1,0 +1,43 @@
+"""Tests for English/Spanish documentation parity."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "check_readme_parity", Path(__file__).resolve().parents[1] / "check_readme_parity.py"
+)
+PARITY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PARITY)
+
+
+class ReadmeParityTests(unittest.TestCase):
+    def test_accepts_translated_prose_and_strings(self):
+        english = '# Usage\n[Español](Usage.es-ES.md)\n<!-- swift-example: sample -->\n```swift\nprint("Hello") // greeting\n```'
+        spanish = '# Uso\n[English](Usage.md)\n<!-- swift-example: sample -->\n```swift\nprint("Hola") // saludo\n```'
+        self.assertEqual(PARITY.compare(english, spanish), [])
+
+    def test_reports_structural_drift(self):
+        english = "# Usage\n## Example\n```swift\nlet value = 1\n```"
+        spanish = "# Uso\n```text\nlet value = 1\n```"
+        issues = PARITY.compare(english, spanish)
+        self.assertIn("heading hierarchy differs", issues)
+        self.assertIn("code-fence count or language order differs", issues)
+
+    def test_reports_link_drift(self):
+        english = "[Contract](contract.md#result)"
+        spanish = "[Contrato](contract.md)"
+        self.assertEqual(PARITY.compare(english, spanish), ["link/image destinations differ"])
+
+    def test_reports_executable_example_drift(self):
+        english = '<!-- swift-example: sample -->\n```swift\nlet value = oldAPI()\n```'
+        spanish = '<!-- swift-example: sample -->\n```swift\nlet value = newAPI()\n```'
+        self.assertEqual(
+            PARITY.compare(english, spanish),
+            ["swift-example 'sample' has different executable structure"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Simplify bilingual onboarding and usage recipes while preserving checked examples, and align maintainer documentation with current tooling.

## Changes

- Keep feature groups and badges prominent in concise English and Spanish READMEs.
- Retain all 20 relocated marked recipes in focused bilingual usage guides and compile the new README examples.
- Record the delivered contrast-pair design and glossary term.
- Update CONTRIBUTING, remove unsupported utility speedup claims, and add Unreleased notes without a version bump.
- Add an optional structural/changed-file parity checker, its tests, and Pi-local review/parity helpers under `.pi/`.

## Alternatives considered

Deleting recipes would lose guidance and runtime checks; merely relocating tutorials would retain repetition. Existing reference articles hold detailed contracts. Parity remains optional local tooling rather than a new CI gate, and semantic translation still requires review.

## Notes

No production Swift API, behavior, or version change. Specialized reference articles remain in English. The `.pi/` files are intentionally included in the current pushed branch; its extension uses the Pi host runtime.

Pre-merge review fixes are included in `c9a562a`: Git failures now fail visibly, URL strings no longer hide following code, and focused regression tests cover both cases. Parity remains an optional local heuristic.

## Screenshots

Not applicable; no application UI changes.

## Testing

- 35 tooling tests passed locally, including URL/comment handling, Git failure reporting, and one-sided committed-file detection; actual document parity and whitespace checks passed.
- Documentation validation: 39 public examples compiled, eight conversion runtime checks passed, and actual generated theme output compiled.
- Strict SwiftLint passed with zero violations in 123 files; local documentation link targets checked.
- CI must rerun against the latest pushed commit; earlier-head results are not evidence for this head.

The Pi extension was inspected but not executed in a Pi host. The new helper is not a Swift parser and does not prove translation semantics.
