### PR TITLE
doc(onboarding): Add a bilingual API selection map

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -56,7 +56,7 @@ Superar el contraste no certifica la accesibilidad de toda la aplicación. Al ge
 
 ## Guías y ejemplos
 
-- [Guía de uso](docs/Usage.es-ES.md): ejemplos de conversión, fusión, temas, paletas, exportación e inspección.
+- [¿Qué API debo usar?](docs/Usage.es-ES.md): un mapa compacto de las API, seguido de recetas de uso.
 - [Espacios de color](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md): resultados por componente y contratos de conversión.
 - [Accesibilidad](Sources/ColorKit/Documentation.docc/Accessibility-article.md): objetivos de contraste, límites de ajuste y simulación.
 - [Temas](Sources/ColorKit/Documentation.docc/Theming-article.md): colores adaptables y semánticos.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A contrast pass is not whole-app accessibility certification. When generating ad
 
 ## Guides and examples
 
-- [Usage guide](docs/Usage.md): conversion, blending, themes, palettes, export, and inspection examples.
+- [Which API should I use?](docs/Usage.md): a compact API map, followed by usage recipes.
 - [Color spaces](Sources/ColorKit/Documentation.docc/Color-Spaces-article.md): component results and conversion contracts.
 - [Accessibility](Sources/ColorKit/Documentation.docc/Accessibility-article.md): contrast targets, enhancement budgets, and simulation.
 - [Theming](Sources/ColorKit/Documentation.docc/Theming-article.md): adaptive and semantic colors.

--- a/docs/Usage.es-ES.md
+++ b/docs/Usage.es-ES.md
@@ -4,6 +4,25 @@
 
 Ejemplos concretos con las API públicas existentes. Importa `SwiftUI` y `ColorKit` en tu proyecto. Los contratos detallados están en las guías enlazadas, en inglés.
 
+## ¿Qué API debo usar?
+
+«Fijo» significa que los componentes RGB o de escala de grises están disponibles sin elegir una apariencia. Captura primero explícitamente los colores que dependen de la apariencia; consulta los [contratos de resolución y componentes](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results). Los límites de gama siguientes se aplican después de convertir a sRGB, no al nombre del espacio de color de origen.
+
+| Tarea → método preferido de `Color` | Entradas | Retorno / fallo y límites esenciales |
+| --- | --- | --- |
+| Conversión de componentes → `componentConversionResults()` | Fijas | Siete campos `Result` independientes: `.success(value)` / `.failure(ColorConversionIssue)`. Sin recorte ni composición; alfa debe ser finito y estar en `0...1`. sRGBA extendido y XYZ/LAB finitos siguen disponibles fuera de gama; HSL/HSB/CMYK/Hex rechazan esas entradas. Solo sRGBA y Hex incluyen alfa. |
+| Medición de contraste → `contrastResult(with:)` | Primer plano fijo (receptor), fondo fijo | `ColorContrastResult`: `.available(ContrastMeasurement)` / `.unavailable(ContrastIssues)` con problemas por entrada. Ambos deben estar dentro de gama; el primer plano translúcido se compone sobre un fondo opaco. La relación es `1...21`; `passingLevels` vacío indica una medición inferior a los objetivos. |
+| Evaluación de accesibilidad → `accessibilityResult(against:targetLevel:)` | El mismo contrato de primer plano/fondo fijos que para contraste | `ColorAccessibilityResult`: color sin cambios, relación opcional y `.meetsTarget`, `.bestEffort` (medición inferior al objetivo) o `.unavailable`. Sin ajuste ni límite de distancia. |
+| Mejora → `enhancementResult(with:targetLevel:strategy:maxPerceptualDistance:)` | Primer plano y fondo fijos, dentro de gama y opacos | `ColorAccessibilityResult`: candidato, contraste/distancia opcionales y estados de evaluación más `.invalidConfiguration`. Límite inclusivo CIEDE2000 ΔE00: finito en `0...100`, predeterminado `30`; cero conserva el original. El mejor esfuerzo abarca los candidatos examinados dentro del límite, no un óptimo global. |
+| Comparación perceptual → `comparisonResult(with:)` | Dos colores fijos, dentro de gama y opacos | `ColorComparisonResult`: `.available(ColorDifference)` con CIEDE2000 / `.unavailable(ColorComparisonIssues)`. Atómico: sin mediciones parciales, recorte ni composición alfa. |
+| HSL para la apariencia actual → `hslComponents()` | La plataforma resuelve colores con nombre/dinámicos para la apariencia actual | Tupla opcional `(hue, saturation, lightness)` en `0...1`; `nil` si falla la resolución. Recorta los canales de gama amplia a sRGB y omite alfa. Para una entrada fija con fallo de gama explícito, usa `componentConversionResults().hsl`. |
+
+Los componentes cero o ΔE00 cero obtenidos con éxito son valores válidos. No disponible significa ausencia de medición, no cero ni una medición inferior al objetivo. En la mejora, puede conservarse contraste diagnóstico incluso con `.unavailable` o `.invalidConfiguration`; comprueba `status` / `meetsTarget`, no solo la relación. Consulta los [contratos de evaluación y límites](../Sources/ColorKit/Documentation.docc/Accessibility-article.md#verifiable-results).
+
+**Código existente:** `rgbaComponents()` puede sustituir un fallo por `(0, 0, 0, 0)`; `ColorSpaceConverter.getAllColorComponents()` también oculta sustituciones. Ninguno comparte la semántica de resultados por campo. La aritmética XYZ/LAB heredada puede diferir de los resultados por componente. `contrastRatio(with:)` ignora alfa y usa valores de respaldo de luminancia; `wcagContrastRatio(with:)` usa el centinela `1` para entradas translúcidas, indistinguible de una relación medida de 1:1. La mejora heredada que devuelve colores ignora el límite de distancia y no garantiza el objetivo. Consulta los [contratos de conversión](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md) y la [compatibilidad del contraste](../MIGRATION.md).
+
+`isPerceptuallySimilar(to:threshold:)` conserva CIE76, ignora alfa, acepta entradas extendidas cuando LAB está disponible y devuelve `false` si LAB no está disponible o la distancia es igual al umbral. Sus umbrales no son umbrales CIEDE2000. El método obsoleto `compare(with:)` devuelve CIEDE2000 cuando las entradas lo permiten y, en caso contrario, un valor de respaldo identificado como `.legacyRGBDistance`. Consulta los [contratos de comparación](../Sources/ColorKit/Documentation.docc/Utilities-article.md#color-comparison) y la [migración](../MIGRATION.md).
+
 ## Convertir colores
 
 Usa resultados por representación cuando importe la disponibilidad. Proporciona un color fijo; captura explícitamente la apariencia deseada para colores dinámicos. Una representación no disponible no descarta las conversiones válidas.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -4,6 +4,25 @@
 
 Focused examples using existing public APIs. Import `SwiftUI` and `ColorKit` in your client. Detailed contracts live in the linked guides.
 
+## Which API should I use?
+
+“Fixed” means RGB or grayscale components are available without choosing an appearance. Capture appearance-dependent colors explicitly first; see [resolution and component contracts](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md#component-conversion-results). Gamut limits below apply after conversion to sRGB, not to the source color-space label.
+
+| Task → preferred method on `Color` | Inputs | Return / failure and essential limits |
+| --- | --- | --- |
+| Component conversion → `componentConversionResults()` | Fixed | Seven independent `Result` fields: `.success(value)` / `.failure(ColorConversionIssue)`. No clipping or compositing; finite alpha must be in `0...1`. Extended sRGBA and finite XYZ/LAB survive out-of-gamut input; HSL/HSB/CMYK/Hex reject it. Only sRGBA and Hex include alpha. |
+| Contrast measurement → `contrastResult(with:)` | Fixed foreground (receiver), fixed background | `ColorContrastResult`: `.available(ContrastMeasurement)` / `.unavailable(ContrastIssues)` with per-input issues. Both must be in gamut; translucent foreground composites over an opaque background. Ratio is `1...21`; empty `passingLevels` is a measured shortfall. |
+| Accessibility assessment → `accessibilityResult(against:targetLevel:)` | Same fixed foreground/background contract as contrast | `ColorAccessibilityResult`: unchanged color, optional ratio, and `.meetsTarget`, `.bestEffort` (measured below target), or `.unavailable`. No adjustment or distance budget. |
+| Enhancement → `enhancementResult(with:targetLevel:strategy:maxPerceptualDistance:)` | Fixed, in-gamut, opaque foreground and background | `ColorAccessibilityResult`: candidate, optional contrast/distance, assessment statuses plus `.invalidConfiguration`. Inclusive CIEDE2000 ΔE00 budget: finite `0...100`, default `30`; zero preserves the original. Best effort covers examined in-budget candidates, not a global optimum. |
+| Perceptual comparison → `comparisonResult(with:)` | Two fixed, in-gamut, opaque colors | `ColorComparisonResult`: `.available(ColorDifference)` using CIEDE2000 / `.unavailable(ColorComparisonIssues)`. Atomic: no partial measurements, clipping, or alpha compositing. |
+| HSL for the current appearance → `hslComponents()` | Platform resolves named/dynamic colors for the current appearance | Optional `(hue, saturation, lightness)` tuple in `0...1`; `nil` on resolution failure. Clips wider-gamut channels to sRGB and omits alpha. For fixed input with explicit gamut failure, use `componentConversionResults().hsl`. |
+
+Successful zero components or zero ΔE00 are valid values. Unavailable means no measurement, not zero or a measured shortfall. For enhancement, diagnostic contrast can remain available even with `.unavailable` or `.invalidConfiguration`; check `status` / `meetsTarget`, not the ratio alone. See [assessment and budget contracts](../Sources/ColorKit/Documentation.docc/Accessibility-article.md#verifiable-results).
+
+**Existing callers:** `rgbaComponents()` can substitute `(0, 0, 0, 0)` on failure; `ColorSpaceConverter.getAllColorComponents()` also hides substitutions. Neither shares per-field result semantics. Legacy XYZ/LAB arithmetic can differ from component results. `contrastRatio(with:)` ignores alpha and uses luminance fallbacks; `wcagContrastRatio(with:)` uses sentinel `1` for translucent inputs, indistinguishable from a measured 1:1 ratio. Legacy color-returning enhancement ignores the distance budget and does not guarantee the target. See [conversion contracts](../Sources/ColorKit/Documentation.docc/Color-Spaces-article.md) and [contrast compatibility](../MIGRATION.md).
+
+`isPerceptuallySimilar(to:threshold:)` retains CIE76, ignores alpha, accepts extended inputs when LAB is available, and returns `false` for unavailable LAB or distance equal to the threshold. Its thresholds are not CIEDE2000 thresholds. Deprecated `compare(with:)` returns CIEDE2000 when eligible, otherwise a labeled `.legacyRGBDistance` fallback. See [comparison contracts](../Sources/ColorKit/Documentation.docc/Utilities-article.md#color-comparison) and [migration](../MIGRATION.md).
+
 ## Convert colors
 
 Use per-representation results when availability matters. Supply a fixed color; capture the intended appearance explicitly for dynamic colors. One unavailable representation does not discard successful conversions.


### PR DESCRIPTION
## Summary

Help callers choose the right ColorKit API with a compact English/Spanish map covering input resolution, result availability, and compatibility limits. Build on the onboarding flow merged in #70 while keeping both READMEs short.

## Changes

- Add six entries for component conversion, contrast measurement, accessibility assessment, enhancement, perceptual comparison, and appearance-resolved HSL.
- Distinguish valid zeros, unavailable measurements, measured shortfalls, and legacy fallbacks, including alpha, gamut, and enhancement-budget limits.
- Link the map from both READMEs and reuse detailed contract references.

## Alternatives considered

Putting the full map in the READMEs would lengthen the quick start. Repeating detailed contracts would duplicate reference documentation; the usage guides provide a concise selection map alongside existing recipes instead.

## Notes

Claims were checked against public implementations. Only four Markdown files change; existing Swift examples and documentation checks remain unchanged. No API, runtime, package-boundary, or deprecation changes.

## Screenshots

Not applicable; no UI changes.

## Testing

- `python3 scripts/check_readme_parity.py`: passed for both document pairs, including after pushing.
- `python3 -m unittest discover -s scripts/tests`: 35 tests passed.
- `python3 scripts/check_documentation.py`: 39 public examples compiled, eight usage-guide conversion runtime checks passed, and actual generated theme output compiled on macOS.
- `swiftlint lint --strict`: passed.
- Local document links/heading anchors and bilingual map API names/inline contract values checked; `git diff --check` passed. No new TODO/FIXME-style markers.

Existing unused-variable warnings remain in unchanged examples. Structural parity does not prove translation semantics; both map texts were reviewed. No iOS runtime suite or DocC build ran for this documentation-only change. These are local results; PR CI is separate.
