### PR TITLE
doc(first-use): Complete consumer setup and adjustment guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The library requires Swift tools 6.0, iOS 14, and macOS 12. Examples may have hi
 
 The READMEs contain checked quick starts and catalog examples. The bilingual [usage guides](docs/Usage.md) contain the conversion and workflow recipes. Keep snippets self-contained and translations semantically aligned.
 
-The checker executes the guides' HSL, CMYK, LAB, and component-result recipes in both languages. Keep their variables aligned with `README_CHECKS`, the existing postcondition table in the script.
+The checker executes the guides' HSL, CMYK, LAB, component-result, and bounded-enhancement recipes in both languages. Keep their variables aligned with `README_CHECKS`, the existing postcondition table in the script.
 
 Named HSL inputs are checked for availability and normalized finite components, not appearance-specific values. Fixed conversion examples use numeric or availability postconditions. Add checks when examples promise specific results.
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -26,6 +26,8 @@ En Xcode, selecciona **File → Add Packages** e introduce:
 https://github.com/agisilaos/ColorKit.git
 ```
 
+Añade el producto de biblioteca **ColorKit** al target que lo importará.
+
 ¿Actualizas un proyecto existente? Consulta la [guía de migración](MIGRATION.md) antes de cambiar el requisito de versión.
 
 ## Inicio rápido

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In Xcode, choose **File → Add Packages** and enter:
 https://github.com/agisilaos/ColorKit.git
 ```
 
+Add the **ColorKit** library product to the target that will import it.
+
 Upgrading an existing project? Read the [migration guide](MIGRATION.md) before changing your version requirement.
 
 ## Quick start

--- a/Validation/ComponentConsumer/Package.swift
+++ b/Validation/ComponentConsumer/Package.swift
@@ -3,10 +3,13 @@ import PackageDescription
 
 let package = Package(
     name: "ComponentConsumer",
-    platforms: [.macOS(.v12)],
+    platforms: [.iOS(.v14), .macOS(.v12)],
     dependencies: [.package(name: "ColorKit", path: "../..")],
     targets: [.executableTarget(
         name: "ComponentConsumer",
+        dependencies: [.product(name: "ColorKit", package: "ColorKit")]
+    ), .executableTarget(
+        name: "FirstUseConsumer",
         dependencies: [.product(name: "ColorKit", package: "ColorKit")]
     )]
 )

--- a/Validation/ComponentConsumer/README.md
+++ b/Validation/ComponentConsumer/README.md
@@ -1,4 +1,44 @@
-# Component conversion consumer validation
+# Public consumer validation
+
+These separate executable targets depend on the repository's `ColorKit` library
+product through SwiftPM and use ordinary `import ColorKit`, without `@testable`.
+They require Swift 6 and macOS 12 or later to run.
+
+## First-use journey
+
+From the repository root:
+
+```sh
+swift run --package-path Validation/ComponentConsumer -c release FirstUseConsumer
+```
+
+The first-use smoke run checks fixed and partially available conversion, directional
+contrast and a WCAG target, all four bounded-adjustment outcomes, and explicit
+light/dark appearance capture. Failed checks exit unsuccessfully. It remeasures
+candidate contrast and distance through public APIs without fixing a strategy's
+candidate or requiring every valid request to meet its target.
+
+Compile the same consumer, including its UIKit capture path, for iOS 14 or later:
+
+```sh
+cd Validation/ComponentConsumer
+xcodebuild -scheme FirstUseConsumer -destination 'generic/platform=iOS' \
+  -derivedDataPath /tmp/colorkit-first-use-ios CODE_SIGNING_ALLOWED=NO build
+```
+
+This is an unsigned consumer compilation and link check, not an iOS app launch.
+The macOS run does not prove minimum-OS runtime or physical-device behavior.
+Build output and generated Xcode state stay out of version control.
+
+The initial audit used main `0c2986e`: an external temporary package resolved the
+GitHub URL at that revision, ran on macOS 26.6.2, and compiled/linked for iOS with
+Xcode 26.5. No adoption blocker was found. The small guidance gaps were attaching
+the library product to the consuming target and handling every adjustment outcome
+in the usage recipe. The API map, partial-availability contract, and linked
+appearance guidance were sufficient; no new API was needed. This records local
+evidence, not CI or minimum-OS/device validation.
+
+## Hosted component inspection
 
 A separate macOS SwiftPM executable consumes the repository's library product with
 ordinary public imports. It hosts its own SwiftUI inspection view in an AppKit
@@ -7,7 +47,7 @@ window; it does not import or instantiate the catalog implementation.
 From the repository root:
 
 ```sh
-swift run --package-path Validation/ComponentConsumer -c release
+swift run --package-path Validation/ComponentConsumer -c release ComponentConsumer
 ```
 
 The smoke run checks 7/7, 3/7, and 0/7 available representations for fixed black,

--- a/Validation/ComponentConsumer/Sources/FirstUseConsumer/FirstUseConsumer.swift
+++ b/Validation/ComponentConsumer/Sources/FirstUseConsumer/FirstUseConsumer.swift
@@ -1,0 +1,112 @@
+import ColorKit
+import SwiftUI
+#if canImport(AppKit)
+import AppKit
+#else
+import UIKit
+#endif
+
+// An external package target: every check uses the same public API as an adopting app.
+@main
+private enum FirstUseConsumer {
+    @MainActor static func main() throws {
+        let black = Color(.sRGB, red: 0, green: 0, blue: 0)
+        let white = Color(.sRGB, red: 1, green: 1, blue: 1)
+        let gray = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
+        let hex = try black.componentConversionResults().hex.get()
+        precondition(hex == "#000000FF", "Fixed black must retain zero components")
+        let conversions = Color(.displayP3, red: 1, green: 0, blue: 0).componentConversionResults()
+        _ = try conversions.srgba.get()
+        _ = try conversions.xyz.get()
+        _ = try conversions.lab.get()
+        guard case .failure(.outOfSRGBGamut) = conversions.hex else {
+            fatalError("P3 red must retain extended coordinates while declining Hex")
+        }
+        print("PASS fixed conversion and partial availability")
+
+        switch black.contrastResult(with: white) {
+        case .available(let measurement):
+            precondition(abs(measurement.ratio - 21) < 0.000001, "Expected black-on-white contrast")
+            precondition(measurement.passingLevels.contains(.AA), "Expected WCAG AA pass")
+        case .unavailable:
+            fatalError("Fixed black and white must be measurable")
+        }
+        precondition(gray.accessibilityResult(against: white, targetLevel: .AA).status == .bestEffort,
+                     "A measurable shortfall is not unavailable")
+        let translucent = Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 0.9)
+        guard case .available = translucent.contrastResult(with: white),
+              case .unavailable(let issues) = white.contrastResult(with: translucent) else {
+            fatalError("Only a translucent foreground can be composited")
+        }
+        precondition(issues.foreground.isEmpty && !issues.background.isEmpty,
+                     "Issues must identify the translucent background")
+        print("PASS contrast, WCAG target and directional availability")
+
+        let requests: [(Color, Double, ColorAccessibilityResult.Status?)] = [
+            (black, 30, .meetsTarget), (gray, 0, .bestEffort),
+            (.primary, 30, .unavailable), (black, -1, .invalidConfiguration),
+            (translucent, 30, .unavailable),
+            // A search may pass or return best effort; do not freeze its chosen candidate.
+            (gray, 30, nil)
+        ]
+        for (input, budget, expected) in requests {
+            let result = input.enhancementResult(with: white, targetLevel: .AA, maxPerceptualDistance: budget)
+            if let expected {
+                precondition(result.status == expected, "Unexpected enhancement outcome for budget \(budget)")
+            }
+            switch result.status {
+            case .meetsTarget, .bestEffort:
+                guard let ratio = result.contrastRatio,
+                      case .available(let measured) = result.color.contrastResult(with: white),
+                      case .available(let difference) = input.comparisonResult(with: result.color) else {
+                    fatalError("A verifiable candidate must retain contrast and distance evidence")
+                }
+                precondition(abs(ratio - measured.ratio) < 0.000001, "Candidate contrast must match its evidence")
+                precondition(result.meetsTarget == measured.passingLevels.contains(.AA), "Check the requested target")
+                precondition(result.isWithinPerceptualDistanceBudget == true
+                             && difference.perceptualDifference <= budget, "Candidate must respect the hard budget")
+                if budget == 0 {
+                    precondition(result.perceptualDistance == 0 && result.color == input,
+                                 "Zero budget must preserve the original")
+                }
+            case .unavailable:
+                precondition(expected == .unavailable && !result.meetsTarget && result.perceptualDistance == nil,
+                             "Missing distance must not become an apparent success")
+            case .invalidConfiguration:
+                precondition(expected == .invalidConfiguration && !result.meetsTarget && result.contrastRatio == 21,
+                             "Invalid configuration must not succeed even with passing diagnostic contrast")
+            }
+            if input == translucent {
+                precondition((result.contrastRatio ?? 0) >= result.minimumContrastRatio,
+                             "This unavailable adjustment should retain passing diagnostic contrast")
+            }
+            print("PASS enhancement: \(result.status), budget \(budget)")
+        }
+
+        guard case .failure(.unresolvedInput) = Color.primary.componentConversionResults().srgba else {
+            fatalError("Appearance-dependent primary must require caller-side capture")
+        }
+        // Follow the platform capture guidance linked from the API map.
+        #if canImport(AppKit)
+        _ = NSApplication.shared
+        for name in [NSAppearance.Name.aqua, .darkAqua] {
+            var fixed: CGColor?
+            NSAppearance(named: name)?.performAsCurrentDrawingAppearance {
+                fixed = NSColor(Color.primary).usingColorSpace(.extendedSRGB)?.cgColor
+            }
+            guard let fixed else { fatalError("AppKit appearance capture unavailable") }
+            _ = try Color(fixed).componentConversionResults().srgba.get()
+            _ = try Color(fixed).componentConversionResults().lab.get()
+            print("PASS explicit appearance capture: \(name.rawValue)")
+        }
+        #else
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            let traits = UITraitCollection(userInterfaceStyle: style)
+            let fixed = Color(UIColor(Color.primary).resolvedColor(with: traits).cgColor)
+            _ = try fixed.componentConversionResults().srgba.get()
+            _ = try fixed.componentConversionResults().lab.get()
+            print("PASS explicit appearance capture: \(style.rawValue)")
+        }
+        #endif
+    }
+}

--- a/docs/Usage.es-ES.md
+++ b/docs/Usage.es-ES.md
@@ -106,20 +106,28 @@ let suggestions = textColor.suggestAccessibleVariantResults(
 <!-- swift-example: enhancement -->
 ```swift
 // Generar un candidato dentro de un límite de distancia e inspeccionar su resultado
-let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let originalColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
 let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
 let targetLevel = WCAGContrastLevel.AA
 
 let result = originalColor.enhancementResult(
     with: backgroundColor,
-    targetLevel: targetLevel
+    targetLevel: targetLevel,
+    maxPerceptualDistance: 30
 )
-let enhancedColor = result.color
 
-if result.meetsTarget {
+switch result.status {
+case .meetsTarget:
+    print("Candidato:", result.color)
     if let ratio = result.contrastRatio {
-        print("Contraste medido: \(ratio):1")
+        print("Contraste medido:", ratio)
     }
+case .bestEffort:
+    print("El candidato sigue por debajo del objetivo:", result.minimumContrastRatio)
+case .unavailable:
+    print("No se puede verificar el contraste o la distancia requeridos")
+case .invalidConfiguration:
+    print("Usa un límite de distancia finito entre 0 y 100")
 }
 ```
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -106,20 +106,28 @@ let suggestions = textColor.suggestAccessibleVariantResults(
 <!-- swift-example: enhancement -->
 ```swift
 // Generate a candidate within a distance budget, then inspect its outcome
-let originalColor = Color(.sRGB, red: 0.2, green: 0.4, blue: 0.8)
+let originalColor = Color(.sRGB, red: 0.6, green: 0.6, blue: 0.6)
 let backgroundColor = Color(.sRGB, red: 1, green: 1, blue: 1)
 let targetLevel = WCAGContrastLevel.AA
 
 let result = originalColor.enhancementResult(
     with: backgroundColor,
-    targetLevel: targetLevel
+    targetLevel: targetLevel,
+    maxPerceptualDistance: 30
 )
-let enhancedColor = result.color
 
-if result.meetsTarget {
+switch result.status {
+case .meetsTarget:
+    print("Candidate:", result.color)
     if let ratio = result.contrastRatio {
-        print("Measured contrast: \(ratio):1")
+        print("Measured contrast:", ratio)
     }
+case .bestEffort:
+    print("Candidate remains below the target:", result.minimumContrastRatio)
+case .unavailable:
+    print("Required contrast or distance measurement is unavailable")
+case .invalidConfiguration:
+    print("Use a finite distance budget from 0 through 100")
 }
 ```
 

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compile public Markdown examples and verify selected conversion results."""
+"""Compile public Markdown examples and verify selected conversion and enhancement results."""
 
 import argparse
 from pathlib import Path
@@ -31,6 +31,18 @@ MARKER = re.compile(r"<!-- swift-example: ([a-z0-9-]+) -->")
 # Postconditions use the actual usage-guide variables, not copied implementations.
 # Renaming a variable requires updating its check; removing a result cannot pass silently.
 README_CHECKS = {
+    "enhancement": """
+checkExample(result.status == .meetsTarget || result.status == .bestEffort,
+    "Fixed opaque inputs with a valid budget must yield a verifiable candidate")
+checkExample(result.maximumPerceptualDistance == 30 && result.isWithinPerceptualDistanceBudget == true,
+    "The example must request and respect its explicit distance budget")
+guard case .available(let difference) = originalColor.comparisonResult(with: result.color) else {
+    failExample("Expected a comparable enhancement candidate")
+}
+checkExample(difference.perceptualDifference <= 30, "Candidate exceeds the example's distance budget")
+checkExample(result.meetsTarget == result.color.accessibilityResult(
+    against: backgroundColor, targetLevel: targetLevel).meetsTarget, "Candidate must match its reported outcome")
+""",
     "component-results": """
 guard case .success(let coordinates) = conversions.lab else { failExample("P3 red must retain LAB") }
 checkExample(coordinates.lightness.isFinite && coordinates.a.isFinite && coordinates.b.isFinite,
@@ -148,7 +160,7 @@ def check(derived_data):
         run(*compiler, "-profile-generate", "-parse-as-library", "-I", modules, *runtime_files, entry,
             modules / "ColorKit.o", "-o", executable)
         run("env", f"LLVM_PROFILE_FILE={scratch / 'examples.profraw'}", executable)
-        print(f"Verified results of {len(runtime_files)} actual usage-guide conversion examples.", flush=True)
+        print(f"Verified results of {len(runtime_files)} actual usage-guide examples.", flush=True)
         emitter = scratch / "emit-theme"
         run(*compiler, "-parse-as-library",
             ROOT / "Sources/ColorKit/PreviewCatalog/ThemeCodeGenerator.swift",

--- a/scripts/tests/test_documentation.py
+++ b/scripts/tests/test_documentation.py
@@ -33,7 +33,7 @@ class DocumentationContract(unittest.TestCase):
                 self.extract(text)
 
     def test_behavior_checks_are_required_in_both_usage_guide_inventories(self):
-        self.assertEqual(set(DOCS.README_CHECKS), {"hsl", "cmyk", "lab", "component-results"})
+        self.assertEqual(set(DOCS.README_CHECKS), {"hsl", "cmyk", "lab", "component-results", "enhancement"})
         for path in ("docs/Usage.md", "docs/Usage.es-ES.md"):
             self.assertLessEqual(DOCS.README_CHECKS.keys(), DOCS.EXAMPLES[path])
 


### PR DESCRIPTION
## Summary

The first-use audit found no adoption blocker, but installation stopped short of attaching the library product to a target, and the adjustment recipe showed only success. Complete those two steps in English and Spanish and retain an external consumer that exercises the full public journey.

## Changes

- Add one target-product setup sentence to both READMEs.
- Show an explicit distance budget and all four adjustment outcomes in both usage recipes, accessing the candidate only in the successful branch.
- Add `FirstUseConsumer` to the existing validation package with ordinary `import ColorKit`: partial conversion availability, directional contrast/WCAG assessment, complete adjustment outcomes, independently measured candidate evidence, and explicit appearance capture.
- Execute the actual enhancement recipes in both languages through the existing documentation checker. Document consumer commands and bounded audit evidence.

## Alternatives considered

The recently simplified API map and linked appearance guidance were sufficient. Another documentation redesign or new API would not address the observed friction. Reusing the SwiftPM consumer and example checker avoids generated projects and another validation framework. Candidate checks deliberately avoid fixing a strategy's chosen result or promising every request reaches its target.

## Notes

- Audited and reviewed against main `0c2986efb437f67a5c25e00c6d6572ee49a90d84`.
- Independent worktree review and separate committed Standards/Spec reviews found no actionable issues; final local gate passed.
- Production Swift, enhancement internals, and the separately owned diagnostic recipe are unchanged. No release, migration, or runtime performance change is involved.
- Local runtime evidence is macOS 26.6.2 with Xcode 26.5 / Swift 6.3.2. iOS 14 is a compilation target, not minimum-OS runtime proof. No iOS execution, physical-device coverage, or interactive Xcode installation-flow verification is claimed.
- Full library behavioral matrix, compatibility, and benchmark-correctness jobs were not rerun locally for this documentation/consumer-only change; repository CI will report separately.

## Screenshots

Not applicable; no UI changes.

## Testing

All listed checks passed locally:

- `swift run --package-path Validation/ComponentConsumer -c release FirstUseConsumer` — conversion, contrast, every adjustment status, budget verification, and AppKit light/dark capture.
- `swift run --package-path Validation/ComponentConsumer -c release ComponentConsumer` — existing hosted integration still passes.
- From `Validation/ComponentConsumer`: `xcodebuild -scheme FirstUseConsumer -destination 'generic/platform=iOS' -derivedDataPath /tmp/colorkit-first-use-ios CODE_SIGNING_ALLOWED=NO build` — compiled and linked the actual consumer and its UIKit capture path.
- `python3 scripts/check_documentation.py --derived-data .build/documentation` — 47 public examples compiled, 10 actual usage examples executed, generated theme output compiled.
- `python3 -m unittest discover -s scripts/tests` — 35 tests.
- `python3 scripts/check_readme_parity.py` plus manual semantic review.
- `swiftlint lint --strict` — zero violations.
- `xcodebuild docbuild -scheme ColorKit -destination 'generic/platform=macOS' -derivedDataPath .build/documentation -skipMacroValidation 'OTHER_DOCC_FLAGS=--warnings-as-errors'`.
- Eight actual English/Spanish first-use snippets extracted using the existing checker typechecked against the iOS consumer's ColorKit module for `arm64-apple-ios14.0`. Only pre-existing unused `suggestions` warnings remain in those snippets.
- Initial read-only audit: a temporary external SwiftPM package resolved the GitHub dependency URL at the audited revision, ran on macOS, and compiled/linked for iOS. No generated project or raw evidence dump is committed.
